### PR TITLE
Add `--autosave` option to CLI flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ systems/asterinas/asterinas/
 states/
 traces/
 **/output/
+output/autosave/
 generation_summary.json
 specula
 models/

--- a/src/core/autosave.py
+++ b/src/core/autosave.py
@@ -1,0 +1,234 @@
+"""Autosave utilities for Specula CLI runs."""
+
+import json
+import logging
+import os
+import hashlib
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+import yaml
+
+
+class AutosaveManager:
+    """Manage autosave artifacts, prompts, logs, and metadata for generation runs."""
+
+    def __init__(self, base_dir: Path, enabled: bool = False, config_path: Optional[str] = None):
+        self.enabled = enabled
+        self.base_dir = Path(base_dir)
+        self.config_path = Path(config_path) if config_path else None
+        self.session_dir: Optional[Path] = None
+        self.log_handler: Optional[logging.Handler] = None
+        self.metadata: Dict = {}
+        self.prompt_counter = 0
+        self._prompt_entries: Dict[str, Dict] = {}
+        self.log_file: Optional[Path] = None
+        self.versions_dir = self.base_dir / "versions"
+        self.config_versions_dir = self.versions_dir / "configs"
+
+    # -----------------------------
+    # Session lifecycle
+    # -----------------------------
+    def start_session(self, input_path: str, output_dir: str):
+        if not self.enabled:
+            return
+
+        # Reset session-scoped state so runs start fresh even if manager is reused.
+        self.prompt_counter = 0
+        self._prompt_entries.clear()
+        timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+        input_stem = Path(input_path).stem or "input"
+        session_name = f"{timestamp}_{self._sanitize_name(input_stem)}"
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.versions_dir.mkdir(parents=True, exist_ok=True)
+        self.config_versions_dir.mkdir(parents=True, exist_ok=True)
+
+        session_dir = self.base_dir / session_name
+        counter = 1
+        while session_dir.exists():
+            session_dir = self.base_dir / f"{session_name}_{counter}"
+            counter += 1
+
+        session_dir.mkdir(parents=True, exist_ok=True)
+        self.session_dir = session_dir
+
+        logs_dir = self.session_dir / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        self.log_file = logs_dir / "run.log"
+        self.log_handler = logging.FileHandler(self.log_file, encoding='utf-8')
+        self.log_handler.setLevel(logging.NOTSET)
+        self.log_handler.setFormatter(logging.Formatter('[%(levelname)s] %(message)s'))
+        logging.getLogger().addHandler(self.log_handler)
+
+        self.metadata = {
+            "timestamp": timestamp,
+            "input_file": str(input_path),
+            "output_dir": str(output_dir),
+            "session_dir": str(self.session_dir),
+            "log_file": str(self._relative_to_session(self.log_file))
+        }
+        self.metadata.setdefault("prompts", [])
+        self.metadata.setdefault("artifacts", [])
+
+    def finalize(self, summary: Optional[Dict] = None, exit_code: int = 0, error: Optional[str] = None):
+        if not self.enabled or not self.session_dir:
+            return
+
+        try:
+            if summary is not None:
+                self.metadata["summary"] = summary
+            if error:
+                self.metadata.setdefault("errors", []).append(str(error))
+            self.metadata["exit_code"] = exit_code
+            self.metadata["status"] = "success" if exit_code == 0 else "error"
+
+            metadata_path = self.session_dir / "metadata.json"
+            with open(metadata_path, 'w', encoding='utf-8') as f:
+                json.dump(self.metadata, f, indent=2, ensure_ascii=False)
+        finally:
+            if self.log_handler:
+                logging.getLogger().removeHandler(self.log_handler)
+                self.log_handler.close()
+
+    # -----------------------------
+    # Recording helpers
+    # -----------------------------
+    def snapshot_config(self, config_data: Dict, label: str = "base", source_path: Optional[str] = None):
+        if not self.enabled or not self.session_dir:
+            return
+
+        effective_source = source_path if source_path is not None else (str(self.config_path) if self.config_path else None)
+
+        if effective_source and self.config_path and Path(effective_source) == self.config_path and self.config_path.exists():
+            config_bytes = self.config_path.read_bytes()
+            suffix = self.config_path.suffix or ".yaml"
+        else:
+            config_bytes = yaml.dump(config_data, sort_keys=False).encode('utf-8')
+            suffix = ".yaml"
+
+        config_hash, stored_path = self._store_versioned_file(config_bytes, suffix, self.config_versions_dir)
+
+        session_config_dir = self.session_dir / "config"
+        session_config_dir.mkdir(exist_ok=True)
+        session_config_name = f"config_{self._sanitize_name(label)}_{config_hash[:8]}{suffix}"
+        session_config_path = session_config_dir / session_config_name
+        self._link_or_copy(stored_path, session_config_path)
+
+        entry = {
+            "label": label,
+            "hash": config_hash,
+            "path": str(self._relative_to_session(session_config_path))
+        }
+        self.metadata.setdefault("configs", []).append(entry)
+
+    def record_override(self, key: str, value):
+        if not self.enabled or value is None:
+            return
+        overrides = self.metadata.setdefault("overrides", {})
+        overrides[key] = value
+
+    def record_prompt(self, name: str, prompt_content: str) -> Optional[str]:
+        if not self.enabled or not self.session_dir:
+            return None
+
+        self.prompt_counter += 1
+        order = self.prompt_counter
+        entry_id = f"prompt_{order:03d}"
+
+        prompts_dir = self.session_dir / "prompts"
+        prompts_dir.mkdir(exist_ok=True)
+
+        prompt_filename = f"{order:03d}_{self._sanitize_name(name)}.txt"
+        prompt_path = prompts_dir / prompt_filename
+        prompt_path.write_text(prompt_content, encoding='utf-8')
+        prompt_hash = hashlib.sha256(prompt_content.encode('utf-8')).hexdigest()
+
+        entry = {
+            "id": entry_id,
+            "order": order,
+            "name": name,
+            "prompt_hash": prompt_hash,
+            "prompt_path": str(self._relative_to_session(prompt_path))
+        }
+        self.metadata.setdefault("prompts", []).append(entry)
+        self._prompt_entries[entry_id] = entry
+        return entry_id
+
+    def record_response(self, entry_id: Optional[str], response_text: str, suffix: str = "response"):
+        if not self.enabled or not self.session_dir or not entry_id:
+            return
+
+        entry = self._prompt_entries.get(entry_id)
+        if not entry:
+            return
+
+        responses_dir = self.session_dir / "responses"
+        responses_dir.mkdir(exist_ok=True)
+        filename = f"{entry['order']:03d}_{self._sanitize_name(entry['name'])}_{self._sanitize_name(suffix)}.txt"
+        response_path = responses_dir / filename
+        response_path.write_text(response_text, encoding='utf-8')
+        entry.setdefault("responses", [])
+        entry["responses"].append(str(self._relative_to_session(response_path)))
+
+    def record_artifact(self, name: str, source_path: Path):
+        if not self.enabled or not self.session_dir:
+            return
+
+        artifact_source = Path(source_path)
+        if not artifact_source.exists():
+            return
+
+        artifacts_dir = self.session_dir / "artifacts"
+        artifacts_dir.mkdir(exist_ok=True)
+
+        index = len(self.metadata.get("artifacts", [])) + 1
+        artifact_filename = f"{index:03d}_{self._sanitize_name(name)}_{artifact_source.name}"
+        target_path = artifacts_dir / artifact_filename
+        shutil.copy2(artifact_source, target_path)
+
+        self.metadata.setdefault("artifacts", []).append({
+            "name": name,
+            "path": str(self._relative_to_session(target_path))
+        })
+
+    def set_summary(self, summary: Dict):
+        if not self.enabled:
+            return
+        self.metadata["summary"] = summary
+
+    # -----------------------------
+    # Internal helpers
+    # -----------------------------
+    def _store_versioned_file(self, content: bytes, suffix: str, versions_dir: Path) -> Tuple[str, Path]:
+        digest = hashlib.sha256(content).hexdigest()
+        versions_dir.mkdir(parents=True, exist_ok=True)
+        version_path = versions_dir / f"{digest}{suffix}"
+        if not version_path.exists():
+            version_path.write_bytes(content)
+        return digest, version_path
+
+    def _link_or_copy(self, src: Path, dest: Path):
+        if dest.exists():
+            return
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            relative_src = os.path.relpath(src, dest.parent)
+            os.symlink(relative_src, dest)
+        except OSError:
+            shutil.copy2(src, dest)
+
+    def _sanitize_name(self, name: str) -> str:
+        sanitized = ''.join(c if c.isalnum() or c in ('-', '_') else '_' for c in name)
+        sanitized = sanitized.strip('_') or "item"
+        return sanitized[:80]
+
+    def _relative_to_session(self, path: Path) -> str:
+        try:
+            return os.path.relpath(path, self.session_dir)
+        except Exception:
+            return str(path)
+
+
+__all__ = ["AutosaveManager"]

--- a/src/core/iispec_generator.py
+++ b/src/core/iispec_generator.py
@@ -11,13 +11,13 @@ import json
 import yaml
 import argparse
 import subprocess
-import tempfile
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional, Tuple
 import logging
 import traceback
 
 from ..rag.retriever import ErrorRetriever
+from .autosave import AutosaveManager
 
 class Config:
     """Configuration management class"""
@@ -87,6 +87,7 @@ class Config:
                 return default
         return value
 
+
 # Global config instance
 config = Config()
 logger = logging.getLogger(__name__)
@@ -147,15 +148,21 @@ class TLAValidator:
 class Phase1Generator:
     """Main Phase 1 generator class"""
     
-    def __init__(self, use_rag: bool = True):
+    def __init__(self, use_rag: bool = True, autosave: Optional[AutosaveManager] = None):
         self.llm = LLMClientWrapper()
         self.validator = TLAValidator()
         self.prompts_dir = Path(config.get('paths.prompts_dir'))
         self.max_correction_attempts = config.get('generation.max_correction_attempts')
         self.generation_mode = config.get('generation.mode', 'direct')
-        self.step2_prompt = self._load_prompt("step1_error_correction.txt")
+        self.step2_prompt_name = "step1_error_correction.txt"
+        self.step2_prompt = self._load_prompt(self.step2_prompt_name)
         self.use_rag = use_rag
         self.retriever = None
+        self.autosave = autosave if autosave is not None else AutosaveManager(
+            base_dir=Path(config.get('paths.output_dir', 'output')) / 'autosave',
+            enabled=False,
+            config_path=config.config_path
+        )
         if self.use_rag:
             logger.info("RAG-based error correction from knowledge base is enabled.")
         else:
@@ -208,24 +215,38 @@ class Phase1Generator:
     def step0_generate_draft(self, source_code: str) -> str:
         """Step 0: Generate a natural language analysis draft"""
         logger.info("Step 0: Generating natural language analysis draft...")
-        prompt_template = self._load_prompt("step0_draft_generation.txt")
+        prompt_template_name = "step0_draft_generation.txt"
+        prompt_template = self._load_prompt(prompt_template_name)
         prompt = prompt_template.format(source_code=source_code)
-        return self.llm.generate(prompt)
+        prompt_id = self.autosave.record_prompt(
+            name="step0_draft_generation",
+            prompt_content=prompt
+        )
+        response = self.llm.generate(prompt)
+        self.autosave.record_response(prompt_id, response, suffix="draft_analysis")
+        return response
     
     def step1_translate_code(self, source_code: str, draft_analysis: str = "") -> str:
         """Step 1: Translate source code to a TLA+ specification"""
         logger.info("Step 1: Translating source code to TLA+ specification...")
         if self.generation_mode in ["draft-based", "existing-draft"]:
-            prompt_template = self._load_prompt("step1_code_translation_with_draft.txt")
+            prompt_template_name = "step1_code_translation_with_draft.txt"
+            prompt_template = self._load_prompt(prompt_template_name)
             prompt = prompt_template.format(source_code=source_code, draft_analysis=draft_analysis)
         else:
-            prompt_template = self._load_prompt("step1_code_translation.txt")
+            prompt_template_name = "step1_code_translation.txt"
+            prompt_template = self._load_prompt(prompt_template_name)
             prompt = prompt_template.format(source_code=source_code)
+        prompt_id = self.autosave.record_prompt(
+            name="step1_code_translation",
+            prompt_content=prompt
+        )
         response = self.llm.generate(prompt)
+        self.autosave.record_response(prompt_id, response, suffix="tla_translation")
         return self._extract_tla_code(response)
     
-    def step2_correct_errors(self, original_spec: str, error_messages: str, 
-                           knowledge_context: str = "") -> str:
+    def step2_correct_errors(self, original_spec: str, error_messages: str,
+                             knowledge_context: str = "", attempt_label: Optional[str] = None) -> str:
         """Step 2: Correct TLA+ specification based on SANY errors"""
         logger.info("Step 2: Correcting TLA+ specification errors...")
         
@@ -234,9 +255,14 @@ class Phase1Generator:
             error_messages=error_messages,
             knowledge_context=knowledge_context
         )
+        prompt_id = self.autosave.record_prompt(
+            name=f"step2_correction_{attempt_label or 'attempt'}",
+            prompt_content=prompt
+        )
         
         try:
             corrected_response = self.llm.generate(prompt)
+            self.autosave.record_response(prompt_id, corrected_response, suffix=f"correction_{attempt_label or 'attempt'}")
             corrected_spec = self._extract_tla_code(corrected_response)
             
             if not corrected_spec.strip():
@@ -283,7 +309,13 @@ class Phase1Generator:
                 except Exception as e:
                     logger.warning(f"Error retrieval failed: {e}. Proceeding without retrieved context.")
             
-            corrected_spec = self.step2_correct_errors(current_spec, error_output, knowledge_context)
+            attempt_label = f"{correction_attempts}"
+            corrected_spec = self.step2_correct_errors(
+                current_spec,
+                error_output,
+                knowledge_context,
+                attempt_label=attempt_label
+            )
             
             module_name = self._extract_module_name(corrected_spec)
             attempt_dir = output_path / f"attempt_{correction_attempts}"
@@ -291,6 +323,7 @@ class Phase1Generator:
             attempt_file = attempt_dir / f"{module_name}.tla"
             with open(attempt_file, 'w', encoding='utf-8') as f:
                 f.write(corrected_spec)
+            self.autosave.record_artifact(f"correction_attempt_{correction_attempts}", attempt_file)
             
             success, error_output = self.validator.validate(str(attempt_file))
             if success:
@@ -317,6 +350,7 @@ class Phase1Generator:
             with open(draft_file, 'w', encoding='utf-8') as f:
                 f.write(draft_analysis)
             logger.info(f"Draft analysis saved to {draft_file}")
+            self.autosave.record_artifact("draft_analysis", draft_file)
         
         step1_spec = self.step1_translate_code(source_code, draft_analysis)
         module_name = self._extract_module_name(step1_spec)
@@ -325,6 +359,7 @@ class Phase1Generator:
             f.write(step1_spec)
         
         logger.info(f"Step 1 output saved to {step1_file}")
+        self.autosave.record_artifact("step1_translation", step1_file)
         
         success, error_output = self.validator.validate(str(step1_file))
         if success:
@@ -350,6 +385,7 @@ class Phase1Generator:
         if str(step1_file) != str(final_file):
             with open(final_file, 'w', encoding='utf-8') as f:
                 f.write(final_spec)
+        self.autosave.record_artifact("final_spec", final_file)
         
         summary = self._create_summary(
             input_path=input_path, output_path=output_path, generation_mode=self.generation_mode,
@@ -357,6 +393,8 @@ class Phase1Generator:
             correction_attempts=correction_attempts, final_errors=error_output
         )
         self._save_summary(summary, output_path)
+        self.autosave.set_summary(summary)
+        self.autosave.record_artifact("generation_summary", output_path / "generation_summary.json")
         logger.info(f"Generation complete. Final specification: {final_file}")
         return summary
     
@@ -372,6 +410,7 @@ class Phase1Generator:
         with open(draft_file, 'w', encoding='utf-8') as f:
             f.write(draft_analysis)
         logger.info(f"Draft analysis saved to {draft_file}")
+        self.autosave.record_artifact("draft_analysis", draft_file)
         
         summary = {
             "input_file": input_path,
@@ -388,6 +427,8 @@ class Phase1Generator:
             }
         }
         self._save_summary(summary, output_path)
+        self.autosave.set_summary(summary)
+        self.autosave.record_artifact("generation_summary", output_path / "generation_summary.json")
         logger.info(f"Draft generation complete. Draft file: {draft_file}")
         return summary
     
@@ -405,14 +446,16 @@ class Phase1Generator:
         except FileNotFoundError:
             logger.error(f"Draft file not found: {draft_path}")
             raise
+        self.autosave.record_artifact("input_draft", Path(draft_path))
         
         step1_spec = self.step1_translate_code(source_code, draft_analysis)
         module_name = self._extract_module_name(step1_spec)
         step1_file = output_path / f"{module_name}.tla"
         with open(step1_file, 'w', encoding='utf-8') as f:
             f.write(step1_spec)
-        
+
         logger.info(f"Step 1 output saved to {step1_file}")
+        self.autosave.record_artifact("step1_translation", step1_file)
         
         success, error_output = self.validator.validate(str(step1_file))
         if success:
@@ -438,6 +481,7 @@ class Phase1Generator:
         if str(step1_file) != str(final_file):
             with open(final_file, 'w', encoding='utf-8') as f:
                 f.write(final_spec)
+        self.autosave.record_artifact("final_spec", final_file)
         
         summary = self._create_summary(
             input_path=input_path, output_path=output_path, generation_mode="existing-draft",
@@ -446,6 +490,8 @@ class Phase1Generator:
         )
         summary["draft_file"] = draft_path
         self._save_summary(summary, output_path)
+        self.autosave.set_summary(summary)
+        self.autosave.record_artifact("generation_summary", output_path / "generation_summary.json")
         logger.info(f"Generation complete. Final specification: {final_file}")
         return summary
 
@@ -460,6 +506,7 @@ class Phase1Generator:
         except FileNotFoundError:
             logger.error(f"Input specification file not found: {input_spec_path}")
             sys.exit(1)
+        self.autosave.record_artifact("input_spec", Path(input_spec_path))
         
         module_name = self._extract_module_name(initial_spec)
         initial_dir = output_path / "initial"
@@ -467,6 +514,7 @@ class Phase1Generator:
         initial_file = initial_dir / f"{module_name}.tla"
         with open(initial_file, 'w', encoding='utf-8') as f:
             f.write(initial_spec)
+        self.autosave.record_artifact("initial_spec", initial_file)
         
         success, error_output = self.validator.validate(str(initial_file))
         if success:
@@ -491,13 +539,16 @@ class Phase1Generator:
             
         with open(final_file, 'w', encoding='utf-8') as f:
             f.write(final_spec)
-        
+        self.autosave.record_artifact("final_spec", final_file)
+
         summary = self._create_summary(
             input_path=input_spec_path, output_path=output_path, generation_mode="correct-only",
             step1_file=initial_file, final_file=final_file, success=success,
             correction_attempts=correction_attempts, final_errors=error_output
         )
         self._save_summary(summary, output_path)
+        self.autosave.set_summary(summary)
+        self.autosave.record_artifact("generation_summary", output_path / "generation_summary.json")
         logger.info(f"Correction complete. Final specification: {final_file}")
         return summary
     
@@ -564,57 +615,82 @@ def main():
 - existing-draft: Existing Draft + Source code -> TLA+""")
     parser.add_argument("--log-level", choices=["DEBUG", "INFO", "WARNING", "ERROR"],
                         help="Override log level from config")
+    parser.add_argument("--autosave", action="store_true",
+                        help="Enable autosaving of prompts, logs, and outputs under output/autosave/")
     args = parser.parse_args()
+
+    autosave_manager: Optional[AutosaveManager] = None
+    summary: Optional[Dict] = None
+    exit_code = 0
+    error_message: Optional[str] = None
 
     try:
         global config
         if args.config != "config.yaml":
             config = Config(args.config)
-        
+
         if args.log_level:
             logging.getLogger().setLevel(getattr(logging, args.log_level))
 
         use_rag = not args.no_rag
-        generator = Phase1Generator(use_rag=use_rag)
+        mode = args.mode or config.get('generation.mode', 'direct')
+
+        autosave_manager = AutosaveManager(
+            base_dir=Path(config.get('paths.output_dir', 'output')) / 'autosave',
+            enabled=args.autosave,
+            config_path=config.config_path
+        )
+        autosave_manager.start_session(input_path=args.input, output_dir=args.output)
+        autosave_manager.snapshot_config(config.config, label="base", source_path=config.config_path)
+        if autosave_manager.enabled:
+            autosave_manager.metadata["use_rag"] = use_rag
+
+        generator = Phase1Generator(use_rag=use_rag, autosave=autosave_manager)
 
         # Apply command-line overrides
         if args.model:
             generator.llm.model = args.model
             logger.info(f"Using command-line override for model: {args.model}")
-        if args.max_tokens:
+            autosave_manager.record_override("model", args.model)
+        if args.max_tokens is not None:
             generator.llm.max_tokens = args.max_tokens
             logger.info(f"Using command-line override for max_tokens: {args.max_tokens}")
-        if args.temperature:
+            autosave_manager.record_override("max_tokens", args.max_tokens)
+        if args.temperature is not None:
             generator.llm.temperature = args.temperature
             logger.info(f"Using command-line override for temperature: {args.temperature}")
-        
+            autosave_manager.record_override("temperature", args.temperature)
+
         # Determine mode from args or config
-        mode = args.mode or generator.generation_mode
         generator.generation_mode = mode
         logger.info(f"Running in '{mode}' mode.")
-        
+
         # Execute the chosen mode
         if mode == 'correct-only':
             if not args.input.endswith('.tla'):
-                logger.error("Input for 'correct-only' mode must be a .tla file.")
-                sys.exit(1)
-            generator.correct_specification(args.input, args.output)
+                raise ValueError("Input for 'correct-only' mode must be a .tla file.")
+            summary = generator.correct_specification(args.input, args.output)
         elif mode == 'draft-only':
-            generator.generate_draft_only(args.input, args.output)
+            summary = generator.generate_draft_only(args.input, args.output)
         elif mode == 'existing-draft':
             if not args.draft:
-                logger.error("--draft parameter is required for 'existing-draft' mode.")
-                sys.exit(1)
+                raise ValueError("--draft parameter is required for 'existing-draft' mode.")
             if not os.path.exists(args.draft):
-                logger.error(f"Draft file not found: {args.draft}")
-                sys.exit(1)
-            generator.generate_from_existing_draft(args.input, args.draft, args.output)
+                raise FileNotFoundError(f"Draft file not found: {args.draft}")
+            summary = generator.generate_from_existing_draft(args.input, args.draft, args.output)
         else:
-            generator.generate_specification(args.input, args.output)
+            summary = generator.generate_specification(args.input, args.output)
 
     except Exception as e:
-        logger.error(f"An unexpected error occurred: {e}\n{traceback.format_exc()}")
-        sys.exit(1)
+        exit_code = 1
+        error_message = f"An unexpected error occurred: {e}\n{traceback.format_exc()}"
+        logger.error(error_message)
+    finally:
+        if autosave_manager:
+            autosave_manager.finalize(summary=summary, exit_code=exit_code, error=error_message)
+
+    if exit_code != 0:
+        sys.exit(exit_code)
 
 if __name__ == "__main__":
     main() 


### PR DESCRIPTION
This PR adds an `--autosave` option to the CLI, which will save the prompts, config files, and results of a particular stage run to `output/autosave`. This should be helpful for ablation tests and comparing different config options as we begin enabling more tools.

- The config files are hashed when stored, and runs using the same config will refer to the config by the hash to avoid duplicating too much output. The same goes for runs using identical prompts. 
- The logging in `iispec_generator.py` will also be redirected and saved. I don't think this should break any current logging behaviour but let me know if you see a bug (at most might change some formatting, let me know if you depend on the hardcoded log values somewhere).
- N.B.: was mostly implemented by Codex.