### PR TITLE
refactor(etcdraft): Optimize and deduplicate invariants

### DIFF
--- a/data/workloads/etcdraft/scenarios/snapshot/spec/MCetcdraft.cfg
+++ b/data/workloads/etcdraft/scenarios/snapshot/spec/MCetcdraft.cfg
@@ -123,7 +123,6 @@ CONSTRAINT
 INVARIANTS
     LogInv
     MoreThanOneLeaderInv
-    ElectionSafetyInv
     LogMatchingInv
     QuorumLogInv
     MoreUpToDateCorrectInv
@@ -172,7 +171,6 @@ INVARIANTS
     CommittedEntriesTermInv
     PendingConfigBoundInv
     LeaderLogLengthInv
-    LogTermMonotonic
     CurrentTermAtLeastLogTerm
     CandidateVotedForSelfInv
     DurableStateConsistency
@@ -180,7 +178,7 @@ INVARIANTS
     LeaderDurableTermInv
 
 \* ============================================================================
-\* NEW: P0 Log Structure Invariants
+\* P0 Log Structure Invariants
 \* ============================================================================
 INVARIANTS
     LogOffsetMinInv
@@ -191,7 +189,7 @@ INVARIANTS
     SnapshotCommitConsistencyInv
 
 \* ============================================================================
-\* NEW: P1 Configuration Invariants
+\* P1 Configuration Invariants
 \* ============================================================================
 INVARIANTS
     JointConfigNonEmptyInv
@@ -201,18 +199,16 @@ INVARIANTS
     PendingConfIndexValidInv
 
 \* ============================================================================
-\* NEW: P1 Additional Progress Invariants
+\* P1 Additional Progress Invariants
 \* ============================================================================
 INVARIANTS
     NextIndexPositiveInv
     NextIndexBoundInv
     MatchIndexBoundInv
-    LeaderMatchSelfInv
-    LeaderNextSelfInv
     PendingSnapshotBoundInv
 
 \* ============================================================================
-\* NEW: P2 Message Content Invariants
+\* P2 Message Content Invariants
 \* ============================================================================
 INVARIANTS
     SnapshotMsgIndexValidInv
@@ -226,14 +222,14 @@ INVARIANTS
     ResponseTermPositiveInv
 
 \* ============================================================================
-\* NEW: P2 Inflights Refined Invariants
+\* P2 Inflights Refined Invariants
 \* ============================================================================
 INVARIANTS
     InflightsOnlyInReplicateInv
     InflightsBelowNextInv
 
 \* ============================================================================
-\* NEW: P3 Term and Vote Invariants
+\* P3 Term and Vote Invariants
 \* ============================================================================
 INVARIANTS
     TermPositiveInv
@@ -244,104 +240,49 @@ INVARIANTS
 
 \* ============================================================================
 \* BUG DETECTION INVARIANTS
-\* These are designed to detect specific known bugs from etcd/raft git history.
 \* ============================================================================
 INVARIANTS
-    \* Bug 76f1249: MsgApp after log truncation causes panic
-    \* prevLogTerm should never be 0 when prevLogIndex > 0
     AppendEntriesPrevLogTermValidInv
-
-    \* Bug bd3c759: Auto-transitioning out of joint config multiple attempts
-    \* At most one pending leave-joint entry in uncommitted log
     SinglePendingLeaveJointInv
-    \* pendingConfIndex should be updated when auto-leave is proposed
     PendingConfIndexAutoLeaveInv
 
-    \* Bug 8ecce32: CommittedEntries pagination correctness (general safety property)
-    CommittedEntriesConsistentInv
-
 \* ============================================================================
-\* P0: CRITICAL INVARIANTS - Known to cause panics in etcd
-\* Reference: etcd issues #10166, #17081
+\* P0: CRITICAL INVARIANTS
 \* ============================================================================
 INVARIANTS
-    \* applied <= committed (log.go:46)
     AppliedBoundInv
-    \* commitIndex <= lastIndex (log.go:324) - the "tocommit out of range" panic
-    CommitIndexBoundInv
-    \* Message destination must be valid server
     MessageDestinationValidInv
 
 \* ============================================================================
-\* P1: HIGH PRIORITY INVARIANTS - Prevent data corruption
+\* P2: DETAILED INVARIANTS
 \* ============================================================================
 INVARIANTS
-    \* REMOVED: LeaderNextIndexValidInv - too strong
-    \* After compaction, nextIndex can be < offset; leader handles by sending snapshot
-    \* REMOVED: SnapshotAppliedConsistencyInv - too strong
-    \* In async snapshot application model, there's a window where snapshotIndex > applied
-    \* after HandleSnapshotRequest but before ApplyEntries. This is correct behavior.
-    \* Reference: log.go:464-468 restore() only updates committed, not applied
-
-\* ============================================================================
-\* P2: DETAILED INVARIANTS - Catch subtle inconsistencies
-\* ============================================================================
-INVARIANTS
-    \* REMOVED: AppendEntriesSourceValidInv
-    \* This invariant checked if message entries exist in sender's CURRENT log,
-    \* but messages are sent from PAST state. In async systems, sender's log can
-    \* change after sending. The spec structure already guarantees entries exist
-    \* at send time (SubSeq would fail otherwise). Stale messages are safe because
-    \* receivers validate via mterm and prevLogIndex/prevLogTerm checks.
-    \* MsgApp's commitIndex <= leader's commitIndex
-    HeartbeatCommitBoundInv
-    \* appliedConfigIndex <= commitIndex
     AppliedConfigBoundInv
 
 \* ============================================================================
-\* P3: CODE-DERIVED INVARIANTS - Directly from raft source code
-\* ============================================================================
-INVARIANTS
-    \* REMOVED: StateSnapshotNextInv - invariant too strong
-    \* In StateSnapshot, Next can be decreased by stale MsgAppResp rejections.
-    \* This is safe because IsPaused() returns true for StateSnapshot, preventing any MsgApp.
-    \* Reference: progress.go:262-273 IsPaused(), progress.go:226-254 MaybeDecrTo()
-    \* REMOVED: ConfigChangePendingInv - invariant too strong
-    \* pendingConfChangeIndex can equal applied after BecomeLeader when all entries
-    \* have been applied. This is valid (no pending config change).
-    \* Reference: raft.go:1320 "alreadyPending := r.pendingConfIndex > r.raftLog.applied"
-    \* When pendingConfIndex == applied, alreadyPending = FALSE (valid state)
-
-\* ============================================================================
 \* P4: VERDI-RAFT INSPIRED INVARIANTS
-\* Source: https://github.com/uwplse/verdi-raft (Coq proof of Raft)
 \* ============================================================================
 INVARIANTS
-    \* votedFor is valid server when set
     VotedForConsistencyInv
-    \* Entries with leader's current term must exist in leader's log
     LeaderCurrentTermEntriesInv
-    \* RequestVote messages have valid term bounds
     RequestVoteTermBoundInv
-    \* AppendEntries responses have positive terms
     AppendEntriesResponseTermInv
-    \* Leader's log contains all committed entries
-    LeaderLogContainsAllCommittedInv
-    \* Snapshot responses have positive terms
     SnapshotResponseTermValidInv
 
 \* ============================================================================
 \* P5: GIT HISTORY BUG PREVENTION INVARIANTS
-\* Source: etcd/raft git commit history analysis
 \* ============================================================================
 INVARIANTS
-    \* No term=0 entries in log
     TermNeverZeroInLogInv
-    \* snapshotIndex > 0 => snapshotTerm > 0
-    SnapshotTermNeverZeroInv
 
+\* ============================================================================
+\* Temporal Properties
+\* ============================================================================
 PROPERTIES
     MonotonicCommitIndexProp
     MonotonicTermProp
     MonotonicMatchIndexProp
     LeaderCommitCurrentTermLogsProp
+    LeaderAppendOnlyProp
+    CommittedEntriesPersistProp
+    LogTermMonotonicProp

--- a/data/workloads/etcdraft/scenarios/snapshot/spec/MCetcdraft.ini
+++ b/data/workloads/etcdraft/scenarios/snapshot/spec/MCetcdraft.ini
@@ -9,134 +9,46 @@ no summary: true
 [options]
 target: ./MCetcdraft.tla
 model name: MCetcdraft/sim
-workers: auto
+workers: 72
 workers: SHOW_IN_TABLE
 simulation depth: 200
 check deadlock: false
 community modules: true
 memory ratio: 0.8
-stop after: 150
-simulation traces: 100
+coverage minute: 60
+dump trace: true
+stop after: 60
+stop after: 600
+stop after: 3600
+stop after: 10000
+; simulation traces: 100
 ; simulation dump traces: true
 
 [behavior]
-temporal formula: mc_etcdSpec
 temporal formula: mc_etcdSpecWithReady
-temporal formula: SHOW_IN_TABLE
-
-[invariants]
-; Core Raft Safety Invariants
-LogInv: LogInv
-MoreThanOneLeaderInv: MoreThanOneLeaderInv
-ElectionSafetyInv: ElectionSafetyInv
-LogMatchingInv: LogMatchingInv
-QuorumLogInv: QuorumLogInv
-MoreUpToDateCorrectInv: MoreUpToDateCorrectInv
-LeaderCompletenessInv: LeaderCompletenessInv
-CommittedIsDurableInv: CommittedIsDurableInv
-; Flow Control Safety
-ProbeLimitInv: ProbeLimitInv
-ReplicatePauseInv: ReplicatePauseInv
-SnapshotInflightsInv: SnapshotInflightsInv
-; Inflights Data Integrity
-InflightsLogIndexInv: InflightsLogIndexInv
-InflightsMatchIndexInv: InflightsMatchIndexInv
-InflightsMonotonicInv: InflightsMonotonicInv
-; Progress State Consistency
-ProgressStateTypeInv: ProgressStateTypeInv
-InflightsInv: InflightsInv
-SnapshotPendingInv: SnapshotPendingInv
-NoPendingSnapshotInv: NoPendingSnapshotInv
-LeaderSelfReplicateInv: LeaderSelfReplicateInv
-SnapshotStateInv: SnapshotStateInv
-; Fundamental Progress Invariants
-MatchIndexLessThanLogInv: MatchIndexLessThanLogInv
-MatchIndexNonNegativeInv: MatchIndexNonNegativeInv
-InflightsAboveMatchInv: InflightsAboveMatchInv
-MatchIndexLessThanNextInv: MatchIndexLessThanNextInv
-MsgAppFlowPausedConsistencyInv: MsgAppFlowPausedConsistencyInv
-ProbeOneInflightMaxInv: ProbeOneInflightMaxInv
-SnapshotNoInflightsStrictInv: SnapshotNoInflightsStrictInv
-; Additional Safety Invariants
-AllMessageTermsValid: AllMessageTermsValid
-MessageIndexValidInv: MessageIndexValidInv
-StateMachineConsistency: StateMachineConsistency
-CommitIndexBoundInv: CommitIndexBoundInv
-CommittedEntriesTermInv: CommittedEntriesTermInv
-PendingConfigBoundInv: PendingConfigBoundInv
-LeaderLogLengthInv: LeaderLogLengthInv
-LogTermMonotonic: LogTermMonotonic
-CurrentTermAtLeastLogTerm: CurrentTermAtLeastLogTerm
-CandidateVotedForSelfInv: CandidateVotedForSelfInv
-DurableStateConsistency: DurableStateConsistency
-MessageEndpointsValidInv: MessageEndpointsValidInv
-LeaderDurableTermInv: LeaderDurableTermInv
-; P0 Log Structure Invariants
-LogOffsetMinInv: LogOffsetMinInv
-SnapshotOffsetConsistencyInv: SnapshotOffsetConsistencyInv
-SnapshotTermValidInv: SnapshotTermValidInv
-SnapshotTermBoundInv: SnapshotTermBoundInv
-HistoryLogLengthInv: HistoryLogLengthInv
-SnapshotCommitConsistencyInv: SnapshotCommitConsistencyInv
-; P1 Configuration Invariants
-JointConfigNonEmptyInv: JointConfigNonEmptyInv
-SingleConfigOutgoingEmptyInv: SingleConfigOutgoingEmptyInv
-LearnersVotersDisjointInv: LearnersVotersDisjointInv
-ConfigNonEmptyInv: ConfigNonEmptyInv
-PendingConfIndexValidInv: PendingConfIndexValidInv
-; P1 Additional Progress Invariants
-NextIndexPositiveInv: NextIndexPositiveInv
-NextIndexBoundInv: NextIndexBoundInv
-MatchIndexBoundInv: MatchIndexBoundInv
-LeaderMatchSelfInv: LeaderMatchSelfInv
-LeaderNextSelfInv: LeaderNextSelfInv
-PendingSnapshotBoundInv: PendingSnapshotBoundInv
-; P2 Message Content Invariants
-SnapshotMsgIndexValidInv: SnapshotMsgIndexValidInv
-SnapshotMsgTermValidInv: SnapshotMsgTermValidInv
-AppendEntriesPrevIndexNonNegInv: AppendEntriesPrevIndexNonNegInv
-AppendEntriesCommitBoundInv: AppendEntriesCommitBoundInv
-VoteRequestLogIndexNonNegInv: VoteRequestLogIndexNonNegInv
-VoteRequestLogTermNonNegInv: VoteRequestLogTermNonNegInv
-AppendEntriesTermConsistentInv: AppendEntriesTermConsistentInv
-SnapshotMsgIndexPositiveInv: SnapshotMsgIndexPositiveInv
-ResponseTermPositiveInv: ResponseTermPositiveInv
-; P2 Inflights Refined Invariants
-InflightsOnlyInReplicateInv: InflightsOnlyInReplicateInv
-InflightsBelowNextInv: InflightsBelowNextInv
-; P3 Term and Vote Invariants
-TermPositiveInv: TermPositiveInv
-LeaderTermPositiveInv: LeaderTermPositiveInv
-CandidateTermPositiveInv: CandidateTermPositiveInv
-VotesRespondedSubsetInv: VotesRespondedSubsetInv
-VotesGrantedSubsetInv: VotesGrantedSubsetInv
-
-[properties]
-MonotonicCommitIndexProp: MonotonicCommitIndexProp
-MonotonicTermProp: MonotonicTermProp
-MonotonicMatchIndexProp: MonotonicMatchIndexProp
+temporal formula: mc_etcdSpec
 
 [constants]
 ; Server model values
-InitServer: [model value]<symmetrical>{s1, s2}
-Server: [model value]<symmetrical>{s1, s2, s3, s4}
+InitServer: [model value]<symmetrical>{s1, s2, s3}
+Server: [model value]<symmetrical>{s1, s2, s3, s4, s5}
 ; Value model values
 Value: [model value]<symmetrical>{v1, v2}
 ; Constraint limits
 ReconfigurationLimit: 3
 MaxTermLimit: 6
-MaxTimeoutLimit: 8
-RequestLimit: 6
-MaxPendingMsgLimit: 10
-MaxMsgBufferLimit: 16
-; Network partition configuration
-MaxPartitions: 2
-RestartDropsMessages: FALSE
-PartitionLimit: 0
-; MsgNoReorder: FALSE
-MsgNoReorder: TRUE
+MaxTimeoutLimit: 10
+RequestLimit: 8
+MaxPendingMsgLimit: 16
+MaxMsgBufferLimit: 20
 ; Fault injection limits
-RestartLimit: 1
+RestartLimit: 2
+RestartDropsMessages: TRUE
+MaxPartitions: 2
+PartitionLimit: 2
+PartitionLimit: 0
+MsgNoReorder: FALSE
+MsgNoReorder: TRUE
 DropLimit: 6
 DuplicateLimit: 1
 StepDownLimit: 3
@@ -193,3 +105,113 @@ InitServerVars: etcdInitServerVars
 InitLogVars: etcdInitLogVars
 InitConfigVars: etcdInitConfigVars
 InitDurableState: etcdInitDurableState
+
+[invariants]
+; Core Raft Safety Invariants
+LogInv: LogInv
+MoreThanOneLeaderInv: MoreThanOneLeaderInv
+LogMatchingInv: LogMatchingInv
+QuorumLogInv: QuorumLogInv
+MoreUpToDateCorrectInv: MoreUpToDateCorrectInv
+LeaderCompletenessInv: LeaderCompletenessInv
+CommittedIsDurableInv: CommittedIsDurableInv
+; Flow Control Safety
+ProbeLimitInv: ProbeLimitInv
+ReplicatePauseInv: ReplicatePauseInv
+SnapshotInflightsInv: SnapshotInflightsInv
+; Inflights Data Integrity
+InflightsLogIndexInv: InflightsLogIndexInv
+InflightsMatchIndexInv: InflightsMatchIndexInv
+InflightsMonotonicInv: InflightsMonotonicInv
+; Progress State Consistency
+ProgressStateTypeInv: ProgressStateTypeInv
+InflightsInv: InflightsInv
+SnapshotPendingInv: SnapshotPendingInv
+NoPendingSnapshotInv: NoPendingSnapshotInv
+LeaderSelfReplicateInv: LeaderSelfReplicateInv
+SnapshotStateInv: SnapshotStateInv
+; Fundamental Progress Invariants
+MatchIndexLessThanLogInv: MatchIndexLessThanLogInv
+MatchIndexNonNegativeInv: MatchIndexNonNegativeInv
+InflightsAboveMatchInv: InflightsAboveMatchInv
+MatchIndexLessThanNextInv: MatchIndexLessThanNextInv
+MsgAppFlowPausedConsistencyInv: MsgAppFlowPausedConsistencyInv
+ProbeOneInflightMaxInv: ProbeOneInflightMaxInv
+SnapshotNoInflightsStrictInv: SnapshotNoInflightsStrictInv
+; Additional Safety Invariants
+AllMessageTermsValid: AllMessageTermsValid
+MessageIndexValidInv: MessageIndexValidInv
+StateMachineConsistency: StateMachineConsistency
+CommitIndexBoundInv: CommitIndexBoundInv
+CommittedEntriesTermInv: CommittedEntriesTermInv
+PendingConfigBoundInv: PendingConfigBoundInv
+LeaderLogLengthInv: LeaderLogLengthInv
+CurrentTermAtLeastLogTerm: CurrentTermAtLeastLogTerm
+CandidateVotedForSelfInv: CandidateVotedForSelfInv
+DurableStateConsistency: DurableStateConsistency
+MessageEndpointsValidInv: MessageEndpointsValidInv
+LeaderDurableTermInv: LeaderDurableTermInv
+; P0 Log Structure Invariants
+LogOffsetMinInv: LogOffsetMinInv
+SnapshotOffsetConsistencyInv: SnapshotOffsetConsistencyInv
+SnapshotTermValidInv: SnapshotTermValidInv
+SnapshotTermBoundInv: SnapshotTermBoundInv
+HistoryLogLengthInv: HistoryLogLengthInv
+SnapshotCommitConsistencyInv: SnapshotCommitConsistencyInv
+; P1 Configuration Invariants
+JointConfigNonEmptyInv: JointConfigNonEmptyInv
+SingleConfigOutgoingEmptyInv: SingleConfigOutgoingEmptyInv
+LearnersVotersDisjointInv: LearnersVotersDisjointInv
+ConfigNonEmptyInv: ConfigNonEmptyInv
+PendingConfIndexValidInv: PendingConfIndexValidInv
+; P1 Additional Progress Invariants
+NextIndexPositiveInv: NextIndexPositiveInv
+NextIndexBoundInv: NextIndexBoundInv
+MatchIndexBoundInv: MatchIndexBoundInv
+PendingSnapshotBoundInv: PendingSnapshotBoundInv
+; P2 Message Content Invariants
+SnapshotMsgIndexValidInv: SnapshotMsgIndexValidInv
+SnapshotMsgTermValidInv: SnapshotMsgTermValidInv
+AppendEntriesPrevIndexNonNegInv: AppendEntriesPrevIndexNonNegInv
+AppendEntriesCommitBoundInv: AppendEntriesCommitBoundInv
+VoteRequestLogIndexNonNegInv: VoteRequestLogIndexNonNegInv
+VoteRequestLogTermNonNegInv: VoteRequestLogTermNonNegInv
+AppendEntriesTermConsistentInv: AppendEntriesTermConsistentInv
+SnapshotMsgIndexPositiveInv: SnapshotMsgIndexPositiveInv
+ResponseTermPositiveInv: ResponseTermPositiveInv
+; P2 Inflights Refined Invariants
+InflightsOnlyInReplicateInv: InflightsOnlyInReplicateInv
+InflightsBelowNextInv: InflightsBelowNextInv
+; P3 Term and Vote Invariants
+TermPositiveInv: TermPositiveInv
+LeaderTermPositiveInv: LeaderTermPositiveInv
+CandidateTermPositiveInv: CandidateTermPositiveInv
+VotesRespondedSubsetInv: VotesRespondedSubsetInv
+VotesGrantedSubsetInv: VotesGrantedSubsetInv
+; BUG DETECTION INVARIANTS
+AppendEntriesPrevLogTermValidInv: AppendEntriesPrevLogTermValidInv
+SinglePendingLeaveJointInv: SinglePendingLeaveJointInv
+PendingConfIndexAutoLeaveInv: PendingConfIndexAutoLeaveInv
+; P0: CRITICAL INVARIANTS
+AppliedBoundInv: AppliedBoundInv
+MessageDestinationValidInv: MessageDestinationValidInv
+; P2: DETAILED INVARIANTS
+AppliedConfigBoundInv: AppliedConfigBoundInv
+; P4: VERDI-RAFT INSPIRED INVARIANTS
+VotedForConsistencyInv: VotedForConsistencyInv
+LeaderCurrentTermEntriesInv: LeaderCurrentTermEntriesInv
+RequestVoteTermBoundInv: RequestVoteTermBoundInv
+AppendEntriesResponseTermInv: AppendEntriesResponseTermInv
+SnapshotResponseTermValidInv: SnapshotResponseTermValidInv
+; P5: GIT HISTORY BUG PREVENTION INVARIANTS
+TermNeverZeroInLogInv: TermNeverZeroInLogInv
+
+[properties]
+MonotonicCommitIndexProp: MonotonicCommitIndexProp
+MonotonicTermProp: MonotonicTermProp
+MonotonicMatchIndexProp: MonotonicMatchIndexProp
+LeaderCommitCurrentTermLogsProp: LeaderCommitCurrentTermLogsProp
+; Raft Paper Core Properties
+LeaderAppendOnlyProp: LeaderAppendOnlyProp
+CommittedEntriesPersistProp: CommittedEntriesPersistProp
+LogTermMonotonicProp: LogTermMonotonicProp


### PR DESCRIPTION
Invariant Optimizations:
- LeaderCompletenessInv: Rewritten from Leader's perspective using CommittedTermPrefix helper Complexity reduced from O(Server × CommitLen × Leaders) to O(Leaders × Server × CommitLen)
- LogMatchingInv: Only check max matching index instead of all indices Complexity reduced from O(n²) to O(n) per server pair
- Add i /= j restriction to LogInv, LogMatchingInv, MoreUpToDateCorrectInv, StateMachineConsistency to skip trivial self-comparisons

Removed Redundant Invariants:
- ElectionSafetyInv: Corollary of MoreThanOneLeaderInv
- CommittedEntriesConsistentInv: Duplicate of StateMachineConsistency
- LeaderMatchSelfInv, LeaderNextSelfInv: Subsumed by other invariants
- LeaderLogContainsAllCommittedInv: Alias of LeaderLogLengthInv
- SnapshotTermNeverZeroInv: Alias of SnapshotTermValidInv

Removed Invalid Invariants (stale message issues):
- AppendEntriesSourceValidInv: After log compaction, in-flight messages may reference compacted entries
- HeartbeatCommitBoundInv: After Restart, in-flight messages may have higher mcommitIndex

Converted to Temporal Properties:
- LogTermMonotonic → LogTermMonotonicProp: O(1) per transition instead of O(n²) state check

New Temporal Properties:
- LeaderAppendOnlyProp: Leaders only append, never overwrite
- CommittedEntriesPersistProp: Committed entries persist across transitions
- LogTermMonotonicProp: Log terms monotonically increase