### PR TITLE
Add generated Codex plugin setup option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ tools/cfa/tests
 .claude/skills
 .agents/skills
 .github/skills
+.specula-codex/
 src/skills/.system
 
 .venv/

--- a/scripts/infra/setup.sh
+++ b/scripts/infra/setup.sh
@@ -58,6 +58,19 @@ ask_scope() {
   done
 }
 
+ask_codex_install() {
+  local answer
+  while true; do
+    read -rp "$(echo -e "${BLUE}[?]${NC} Install Specula for Codex? (y/n/plugin): ")" answer
+    case "$answer" in
+      [Yy]|[Yy][Ee][Ss]) echo "legacy"; return 0 ;;
+      [Nn]|[Nn][Oo]) echo "skip"; return 0 ;;
+      [Pp]|[Pp][Ll][Uu][Gg][Ii][Nn]) echo "plugin"; return 0 ;;
+      *) echo "  Please answer y, n, or plugin." >&2 ;;
+    esac
+  done
+}
+
 setup_skills_symlink() {
   local target_link="$1"
   local skills_source="$2"
@@ -132,6 +145,18 @@ setup_codex_mcp() {
   fi
 }
 
+setup_codex_plugin() {
+  local project_root="$1"
+  local plugin_root="$2"
+
+  print_status "Generating Specula Codex plugin..."
+  python3 "$SCRIPT_DIR/setup_codex_plugin.py" \
+    --project-root "$project_root" \
+    --plugin-root "$plugin_root"
+  print_success "Codex plugin configured: specula-codex@specula"
+  print_status "Rerun this setup script and choose 'plugin' to update the Codex plugin."
+}
+
 setup_python_tool_env() {
   local tool_name="$1"
   local tool_dir="$2"
@@ -197,6 +222,7 @@ INV_CHECKING_TOOL_VENV="$INV_CHECKING_TOOL_DIR/.venv"
 INV_CHECKING_TOOL_PYTHON="$INV_CHECKING_TOOL_VENV/bin/python"
 INV_CHECKING_TOOL_SERVER="$INV_CHECKING_TOOL_DIR/mcp_server.py"
 SKILLS_SOURCE="$PROJECT_ROOT/skills"
+CODEX_PLUGIN_ROOT="$PROJECT_ROOT/.specula-codex"
 
 print_status "Project root: $PROJECT_ROOT"
 
@@ -333,20 +359,27 @@ echo ""
 
 # --- Codex ---
 echo -e "${BLUE}[2/3] Codex${NC}"
-if ask_yn "Install Specula for Codex?"; then
-  scope="$(ask_scope "Codex")"
-  if [[ "$scope" == "global" ]]; then
-    setup_skills_symlink "$HOME/.codex/skills" "$SKILLS_SOURCE"
-  else
-    setup_skills_symlink "$PROJECT_ROOT/.agents/skills" "$SKILLS_SOURCE"
-  fi
-  for entry in "${MCP_SERVERS[@]}"; do
-    IFS='|' read -r mcp_name mcp_python mcp_server <<< "$entry"
-    setup_codex_mcp "$PROJECT_ROOT" "$mcp_name" "$mcp_python" "$mcp_server"
-  done
-else
-  print_status "Skipped Codex."
-fi
+codex_install="$(ask_codex_install)"
+case "$codex_install" in
+  legacy)
+    scope="$(ask_scope "Codex")"
+    if [[ "$scope" == "global" ]]; then
+      setup_skills_symlink "$HOME/.codex/skills" "$SKILLS_SOURCE"
+    else
+      setup_skills_symlink "$PROJECT_ROOT/.agents/skills" "$SKILLS_SOURCE"
+    fi
+    for entry in "${MCP_SERVERS[@]}"; do
+      IFS='|' read -r mcp_name mcp_python mcp_server <<< "$entry"
+      setup_codex_mcp "$PROJECT_ROOT" "$mcp_name" "$mcp_python" "$mcp_server"
+    done
+    ;;
+  plugin)
+    setup_codex_plugin "$PROJECT_ROOT" "$CODEX_PLUGIN_ROOT"
+    ;;
+  skip)
+    print_status "Skipped Codex."
+    ;;
+esac
 echo ""
 
 # --- Copilot CLI ---

--- a/scripts/infra/setup_codex_plugin.py
+++ b/scripts/infra/setup_codex_plugin.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Generate and install the local Specula Codex plugin."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+
+
+PLUGIN_NAME = "specula-codex"
+MARKETPLACE_NAME = "specula"
+LEGACY_MCP_NAMES = ("tracedebugger", "spec_analyzer", "inv_checking_tool")
+
+
+def build_plugin_manifest() -> dict:
+    return {
+        "name": PLUGIN_NAME,
+        "version": "0.1.0",
+        "description": (
+            "Specula TLA+ workflow skills and MCP tools for code analysis, "
+            "spec generation, trace validation, and bug confirmation."
+        ),
+        "author": {
+            "name": "Specula-org",
+            "url": "https://github.com/specula-org/Specula",
+        },
+        "homepage": "https://github.com/specula-org/Specula",
+        "repository": "https://github.com/specula-org/Specula",
+        "license": "Apache-2.0",
+        "keywords": [
+            "tla",
+            "formal-methods",
+            "model-checking",
+            "trace-validation",
+            "bug-finding",
+        ],
+        "skills": "./skills/",
+        "mcpServers": "./.mcp.json",
+        "interface": {
+            "displayName": "Specula",
+            "shortDescription": "Run Specula's TLA+ bug-finding workflow from Codex.",
+            "longDescription": (
+                "Specula packages workflow skills and MCP tools for analyzing "
+                "system implementations, generating TLA+ specifications, "
+                "validating traces, running model checking, and confirming "
+                "bugs in source code."
+            ),
+            "developerName": "Specula-org",
+            "category": "Developer Tools",
+            "capabilities": ["Interactive", "Read", "Write"],
+            "websiteURL": "https://github.com/specula-org/Specula",
+            "privacyPolicyURL": "https://github.com/specula-org/Specula",
+            "termsOfServiceURL": "https://github.com/specula-org/Specula",
+            "defaultPrompt": [
+                "Run Specula code analysis on this repository.",
+                "Generate TLA+ specs from this modeling brief.",
+                "Validate this trace against the TLA+ spec.",
+            ],
+            "brandColor": "#2563EB",
+            "screenshots": [],
+        },
+    }
+
+
+def build_mcp_config(project_root: pathlib.Path) -> dict:
+    servers = {
+        "tracedebugger": (
+            "tools/trace_debugger/.venv/bin/python",
+            "tools/trace_debugger/mcp_server.py",
+        ),
+        "spec_analyzer": (
+            "tools/spec_analyzer/.venv/bin/python",
+            "tools/spec_analyzer/mcp_server.py",
+        ),
+        "inv_checking_tool": (
+            "tools/inv_checking_tool/.venv/bin/python",
+            "tools/inv_checking_tool/mcp_server.py",
+        ),
+    }
+
+    return {
+        "mcpServers": {
+            name: {
+                "command": str(project_root / python_path),
+                "args": [str(project_root / server_path)],
+                "env": {"SPECULA_ROOT": str(project_root)},
+            }
+            for name, (python_path, server_path) in servers.items()
+        }
+    }
+
+
+def build_marketplace_manifest() -> dict:
+    return {
+        "name": MARKETPLACE_NAME,
+        "interface": {"displayName": "Specula"},
+        "plugins": [
+            {
+                "name": PLUGIN_NAME,
+                "source": {
+                    "source": "local",
+                    "path": f"./plugins/{PLUGIN_NAME}",
+                },
+                "policy": {
+                    "installation": "AVAILABLE",
+                    "authentication": "ON_INSTALL",
+                },
+                "category": "Developer Tools",
+            }
+        ],
+    }
+
+
+def write_json(path: pathlib.Path, value: dict) -> None:
+    path.write_text(json.dumps(value, indent=2) + "\n")
+
+
+def generate_plugin(project_root: pathlib.Path, plugin_root: pathlib.Path) -> None:
+    skills_source = project_root / "skills"
+    if not skills_source.is_dir():
+        raise SystemExit(f"Skills directory not found: {skills_source}")
+
+    if plugin_root.exists():
+        shutil.rmtree(plugin_root)
+
+    plugin_dir = plugin_root / "plugins" / PLUGIN_NAME
+    (plugin_dir / ".codex-plugin").mkdir(parents=True)
+    shutil.copytree(
+        skills_source,
+        plugin_dir / "skills",
+        ignore=shutil.ignore_patterns("__pycache__", ".DS_Store"),
+    )
+
+    write_json(plugin_dir / ".codex-plugin" / "plugin.json", build_plugin_manifest())
+    write_json(plugin_dir / ".mcp.json", build_mcp_config(project_root))
+
+    marketplace_dir = plugin_root / ".agents" / "plugins"
+    marketplace_dir.mkdir(parents=True)
+    write_json(marketplace_dir / "marketplace.json", build_marketplace_manifest())
+
+
+def run(command: list[str], *, check: bool = True, quiet: bool = False) -> subprocess.CompletedProcess:
+    stdout = subprocess.DEVNULL if quiet else None
+    stderr = subprocess.DEVNULL if quiet else None
+    return subprocess.run(command, check=check, stdout=stdout, stderr=stderr)
+
+
+def install_plugin(plugin_root: pathlib.Path) -> None:
+    if shutil.which("codex") is None:
+        raise SystemExit("codex is required to install the Specula Codex plugin")
+
+    run(["codex", "plugin", "marketplace", "remove", MARKETPLACE_NAME], check=False, quiet=True)
+    run(["codex", "plugin", "marketplace", "add", str(plugin_root)])
+
+    for mcp_name in LEGACY_MCP_NAMES:
+        run(["codex", "mcp", "remove", mcp_name], check=False, quiet=True)
+
+    run(["codex", "plugin", "add", f"{PLUGIN_NAME}@{MARKETPLACE_NAME}"])
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-root", required=True, type=pathlib.Path)
+    parser.add_argument("--plugin-root", required=True, type=pathlib.Path)
+    parser.add_argument(
+        "--no-install",
+        action="store_true",
+        help="Generate plugin files without changing Codex configuration.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    project_root = args.project_root.resolve()
+    plugin_root = args.plugin_root.resolve()
+
+    generate_plugin(project_root, plugin_root)
+    if not args.no_install:
+        install_plugin(plugin_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a `plugin` option to the Codex setup flow while preserving the existing symlink/direct-MCP behavior for `y`.

The new path generates a local `specula-codex` plugin from the existing skills and MCP server config, installs it through Codex’s plugin marketplace flow, and ignores the generated `.specula-codex/` output. It also prints a short note that rerunning setup with `plugin` updates the generated plugin.

This is what the plugin looks like in the Codex app:

<img width="600" height="auto" alt="image" src="https://github.com/user-attachments/assets/f0433699-42ed-4785-9fe7-197be8b939ed" />
