### PR TITLE
ruff: add config and apply lint + format across python tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Specula runs as a set of code agent skills and MCP tools. It currently supports 
 
 ### Prerequisites
 
-- Python 3.8+ with pip
+- Python 3.10+ with pip
 - Java 21+ with Maven
 - GitHub CLI `gh`
 - A supported code agent (Claude Code, Codex, or Copilot CLI) — you can contribute an adapter for your favourite agent [here](./scripts/launch/adapters)!

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,42 @@
+# Ruff config for the Specula main repo (code-cleanliness gate; see .github/workflows/ci.yml).
+# Submodules (case-studies, tools/tlaplus*, tools/SysMoBench) and experiment/vendor
+# dirs are excluded so they are linted in their own repos, not here.
+line-length = 120
+target-version = "py310"
+
+extend-exclude = [
+    "case-studies",
+    "tools/tlaplus",
+    "tools/tlaplus-ai-tools",
+    "tools/SysMoBench",
+    "experiments",
+    "data",
+    "traces",
+    "logs",
+    "_build",
+    "lib",
+    ".specula-output",
+]
+
+[lint]
+select = [
+    "E",    # pycodestyle errors
+    "F",    # Pyflakes
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+    "I",    # isort
+]
+ignore = [
+    "E501",   # line too long (handled by formatter)
+    "SIM102", # nested if statements
+    "SIM115", # open() w/o context manager: dual-mode readers accept caller-owned handles
+]
+
+[lint.per-file-ignores]
+# Tests manipulate sys.path before importing project modules.
+"**/tests/**/*.py" = ["E402"]
+
+[format]
+quote-style = "double"
+docstring-code-format = true

--- a/scripts/exp/ablation/eval/check_invariant.py
+++ b/scripts/exp/ablation/eval/check_invariant.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Check a single invariant against a spec using TLC simulation."""
 
+import contextlib
 import json
 import os
 import re
@@ -111,7 +112,5 @@ except subprocess.TimeoutExpired:
 finally:
     # Cleanup
     for f in [check_tla, check_cfg]:
-        try:
+        with contextlib.suppress(BaseException):
             os.remove(f)
-        except:
-            pass

--- a/scripts/exp/ablation/eval/check_invariant.py
+++ b/scripts/exp/ablation/eval/check_invariant.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Check a single invariant against a spec using TLC simulation."""
+
 import json, sys, os, subprocess, tempfile, re
 
 spec_dir = sys.argv[1]
@@ -9,85 +10,104 @@ tla2tools = sys.argv[4]
 community = sys.argv[5]
 
 invariants = json.load(open(inv_file))
-inv_def = invariants.get(inv_name, 'TRUE')
+inv_def = invariants.get(inv_name, "TRUE")
 
-if inv_def == 'TRUE':
-    print('SKIP')
+if inv_def == "TRUE":
+    print("SKIP")
     sys.exit(0)
 
 # Read MC.tla to find what module it extends
-mc_path = os.path.join(spec_dir, 'MC.tla')
+mc_path = os.path.join(spec_dir, "MC.tla")
 mc_content = open(mc_path).read()
-extends_match = re.search(r'EXTENDS\s+(\w+)', mc_content)
-base_module = extends_match.group(1) if extends_match else 'base'
+extends_match = re.search(r"EXTENDS\s+(\w+)", mc_content)
+base_module = extends_match.group(1) if extends_match else "base"
 
 # Write temporary check module
-check_tla = os.path.join(spec_dir, '_InvCheck.tla')
-check_cfg = os.path.join(spec_dir, '_InvCheck.cfg')
+check_tla = os.path.join(spec_dir, "_InvCheck.tla")
+check_cfg = os.path.join(spec_dir, "_InvCheck.cfg")
 
-with open(check_tla, 'w') as f:
-    f.write(f'---- MODULE _InvCheck ----\n')
-    f.write(f'EXTENDS {base_module}\n\n')
+with open(check_tla, "w") as f:
+    f.write(f"---- MODULE _InvCheck ----\n")
+    f.write(f"EXTENDS {base_module}\n\n")
     # MC module may define additional operators needed
-    f.write(f'MCInv_{inv_name} ==\n')
+    f.write(f"MCInv_{inv_name} ==\n")
     # Clean up the invariant definition - extract just the body
     body = inv_def
     # Remove the "Name ==" prefix if present
-    body = re.sub(r'^\w+\s*==\s*', '', body, count=1).strip()
-    f.write(f'  {body}\n')
-    f.write(f'====\n')
+    body = re.sub(r"^\w+\s*==\s*", "", body, count=1).strip()
+    f.write(f"  {body}\n")
+    f.write(f"====\n")
 
 # Copy MC.cfg and replace invariants
-mc_cfg_content = open(os.path.join(spec_dir, 'MC.cfg')).read()
+mc_cfg_content = open(os.path.join(spec_dir, "MC.cfg")).read()
 # Remove existing INVARIANT/INVARIANTS block
-mc_cfg_content = re.sub(r'INVARIANTS?\s*\n(?:\s+\w+\s*\n)*', '', mc_cfg_content)
+mc_cfg_content = re.sub(r"INVARIANTS?\s*\n(?:\s+\w+\s*\n)*", "", mc_cfg_content)
 # Change SPECIFICATION to use MCSpec from MC module (need to extend MC instead)
 # Actually, simpler: extend MC module which already extends base
-with open(check_tla, 'w') as f:
-    mc_module = re.search(r'MODULE\s+(\w+)', mc_content).group(1)
-    f.write(f'---- MODULE _InvCheck ----\n')
-    f.write(f'EXTENDS {mc_module}\n\n')
-    f.write(f'MCInv_{inv_name} ==\n')
-    body = re.sub(r'^\w+\s*==\s*', '', inv_def, count=1).strip()
-    f.write(f'  {body}\n')
-    f.write(f'====\n')
+with open(check_tla, "w") as f:
+    mc_module = re.search(r"MODULE\s+(\w+)", mc_content).group(1)
+    f.write(f"---- MODULE _InvCheck ----\n")
+    f.write(f"EXTENDS {mc_module}\n\n")
+    f.write(f"MCInv_{inv_name} ==\n")
+    body = re.sub(r"^\w+\s*==\s*", "", inv_def, count=1).strip()
+    f.write(f"  {body}\n")
+    f.write(f"====\n")
 
-with open(check_cfg, 'w') as f:
+with open(check_cfg, "w") as f:
     # Use MC.cfg but replace invariants
-    for line in open(os.path.join(spec_dir, 'MC.cfg')):
-        if line.strip().startswith('INVARIANT'):
+    for line in open(os.path.join(spec_dir, "MC.cfg")):
+        if line.strip().startswith("INVARIANT"):
             continue
         # Skip indented invariant names under INVARIANTS block
-        if re.match(r'^\s+MC\w+|^\s+\w+Inv|^\s+\w+Safety|^\s+TypeOK', line):
+        if re.match(r"^\s+MC\w+|^\s+\w+Inv|^\s+\w+Safety|^\s+TypeOK", line):
             continue
         f.write(line)
-    f.write(f'\nINVARIANT\n    MCInv_{inv_name}\n')
+    f.write(f"\nINVARIANT\n    MCInv_{inv_name}\n")
 
 # Run TLC
 try:
     result = subprocess.run(
-        ['java', '-Xss8m', '-Xmx4g', '-XX:+UseParallelGC',
-         '-cp', f'{tla2tools}:{community}',
-         'tlc2.TLC', '_InvCheck.tla', '-config', '_InvCheck.cfg',
-         '-deadlock', '-noTE', '-simulate', 'num=1000', '-workers', '1'],
-        cwd=spec_dir, capture_output=True, text=True, timeout=30
+        [
+            "java",
+            "-Xss8m",
+            "-Xmx4g",
+            "-XX:+UseParallelGC",
+            "-cp",
+            f"{tla2tools}:{community}",
+            "tlc2.TLC",
+            "_InvCheck.tla",
+            "-config",
+            "_InvCheck.cfg",
+            "-deadlock",
+            "-noTE",
+            "-simulate",
+            "num=1000",
+            "-workers",
+            "1",
+        ],
+        cwd=spec_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
     )
     output = result.stdout + result.stderr
 
-    if 'Invariant' in output and 'violated' in output:
-        print('VIOLATED')
-    elif 'Error' in output and 'Semantic' in output:
-        print('ERROR_PARSE')
-    elif 'Error' in output:
-        print('ERROR')
-    elif 'Finished' in output or 'states' in output:
-        print('PASS')
+    if "Invariant" in output and "violated" in output:
+        print("VIOLATED")
+    elif "Error" in output and "Semantic" in output:
+        print("ERROR_PARSE")
+    elif "Error" in output:
+        print("ERROR")
+    elif "Finished" in output or "states" in output:
+        print("PASS")
     else:
-        print('UNKNOWN')
+        print("UNKNOWN")
 except subprocess.TimeoutExpired:
-    print('TIMEOUT')
+    print("TIMEOUT")
 finally:
     # Cleanup
     for f in [check_tla, check_cfg]:
-        try: os.remove(f)
-        except: pass
+        try:
+            os.remove(f)
+        except:
+            pass

--- a/scripts/exp/ablation/eval/check_invariant.py
+++ b/scripts/exp/ablation/eval/check_invariant.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """Check a single invariant against a spec using TLC simulation."""
 
-import json, sys, os, subprocess, tempfile, re
+import json
+import os
+import re
+import subprocess
+import sys
 
 spec_dir = sys.argv[1]
 inv_file = sys.argv[2]  # JSON file with concretized invariants
@@ -27,7 +31,7 @@ check_tla = os.path.join(spec_dir, "_InvCheck.tla")
 check_cfg = os.path.join(spec_dir, "_InvCheck.cfg")
 
 with open(check_tla, "w") as f:
-    f.write(f"---- MODULE _InvCheck ----\n")
+    f.write("---- MODULE _InvCheck ----\n")
     f.write(f"EXTENDS {base_module}\n\n")
     # MC module may define additional operators needed
     f.write(f"MCInv_{inv_name} ==\n")
@@ -36,7 +40,7 @@ with open(check_tla, "w") as f:
     # Remove the "Name ==" prefix if present
     body = re.sub(r"^\w+\s*==\s*", "", body, count=1).strip()
     f.write(f"  {body}\n")
-    f.write(f"====\n")
+    f.write("====\n")
 
 # Copy MC.cfg and replace invariants
 mc_cfg_content = open(os.path.join(spec_dir, "MC.cfg")).read()
@@ -46,12 +50,12 @@ mc_cfg_content = re.sub(r"INVARIANTS?\s*\n(?:\s+\w+\s*\n)*", "", mc_cfg_content)
 # Actually, simpler: extend MC module which already extends base
 with open(check_tla, "w") as f:
     mc_module = re.search(r"MODULE\s+(\w+)", mc_content).group(1)
-    f.write(f"---- MODULE _InvCheck ----\n")
+    f.write("---- MODULE _InvCheck ----\n")
     f.write(f"EXTENDS {mc_module}\n\n")
     f.write(f"MCInv_{inv_name} ==\n")
     body = re.sub(r"^\w+\s*==\s*", "", inv_def, count=1).strip()
     f.write(f"  {body}\n")
-    f.write(f"====\n")
+    f.write("====\n")
 
 with open(check_cfg, "w") as f:
     # Use MC.cfg but replace invariants

--- a/scripts/exp/ablation/eval/concretize.py
+++ b/scripts/exp/ablation/eval/concretize.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Concretize invariant templates to a specific TLA+ spec using claude CLI."""
+
 import json, sys, re, subprocess, os
 
 spec_path = sys.argv[1]
@@ -29,13 +30,16 @@ Rules:
 - Output ALL invariants from the templates"""
 
 result = subprocess.run(
-    ['claude', '--print', '--dangerously-skip-permissions', '--output-format', 'json'],
-    input=prompt, capture_output=True, text=True, timeout=600
+    ["claude", "--print", "--dangerously-skip-permissions", "--output-format", "json"],
+    input=prompt,
+    capture_output=True,
+    text=True,
+    timeout=600,
 )
 
 try:
     d = json.loads(result.stdout)
-    text = d.get('result', '')
+    text = d.get("result", "")
 except:
     text = result.stdout
 
@@ -43,7 +47,7 @@ except:
 invariants = {}
 try:
     # Find JSON block in the text
-    json_match = re.search(r'\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}', text, re.DOTALL)
+    json_match = re.search(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", text, re.DOTALL)
     if json_match:
         invariants = json.loads(json_match.group())
 except:
@@ -51,18 +55,18 @@ except:
 
 # Fallback: extract from code blocks
 if not invariants:
-    for match in re.finditer(r'```(?:tla\+?)?\n(.*?)```', text, re.DOTALL):
+    for match in re.finditer(r"```(?:tla\+?)?\n(.*?)```", text, re.DOTALL):
         content = match.group(1).strip()
-        m = re.match(r'(\w+)\s*==', content)
+        m = re.match(r"(\w+)\s*==", content)
         if m:
             invariants[m.group(1)] = content
 
     # Also try line-by-line
-    for match in re.finditer(r'^(\w+)\s*==\s*\n((?:[ \t].*\n)*)', text, re.MULTILINE):
+    for match in re.finditer(r"^(\w+)\s*==\s*\n((?:[ \t].*\n)*)", text, re.MULTILINE):
         name = match.group(1)
         body = match.group(0).strip()
         if name not in invariants:
             invariants[name] = body
 
-json.dump(invariants, open(output_path, 'w'), indent=2)
-print(f'Concretized {len(invariants)} invariants')
+json.dump(invariants, open(output_path, "w"), indent=2)
+print(f"Concretized {len(invariants)} invariants")

--- a/scripts/exp/ablation/eval/concretize.py
+++ b/scripts/exp/ablation/eval/concretize.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 """Concretize invariant templates to a specific TLA+ spec using claude CLI."""
 
-import json, sys, re, subprocess, os
+import json
+import re
+import subprocess
+import sys
 
 spec_path = sys.argv[1]
 template_path = sys.argv[2]

--- a/scripts/exp/ablation/eval/concretize.py
+++ b/scripts/exp/ablation/eval/concretize.py
@@ -43,7 +43,7 @@ result = subprocess.run(
 try:
     d = json.loads(result.stdout)
     text = d.get("result", "")
-except:
+except BaseException:
     text = result.stdout
 
 # Try to parse as JSON directly
@@ -53,7 +53,7 @@ try:
     json_match = re.search(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", text, re.DOTALL)
     if json_match:
         invariants = json.loads(json_match.group())
-except:
+except BaseException:
     pass
 
 # Fallback: extract from code blocks

--- a/scripts/infra/record_bug.py
+++ b/scripts/infra/record_bug.py
@@ -23,18 +23,31 @@ BORDER_STYLE = {"style": "SOLID", "width": 1, "color": BORDER_COLOR}
 ALL_BORDERS = {"top": BORDER_STYLE, "bottom": BORDER_STYLE, "left": BORDER_STYLE, "right": BORDER_STYLE}
 
 SIMPLE_COLUMNS = ["#", "System", "Protocol / Lang", "Finding", "Reference", "URL", "Status", "Notes"]
-DETAILED_COLUMNS = ["#", "System", "Protocol / Lang", "Finding", "Severity", "Bug Family",
-                    "Discovery Method", "Root Cause", "Affected Code", "Reference", "URL", "Status", "Notes"]
+DETAILED_COLUMNS = [
+    "#",
+    "System",
+    "Protocol / Lang",
+    "Finding",
+    "Severity",
+    "Bug Family",
+    "Discovery Method",
+    "Root Cause",
+    "Affected Code",
+    "Reference",
+    "URL",
+    "Status",
+    "Notes",
+]
 
 # Columns that should be LEFT-aligned (0-indexed)
-SIMPLE_LEFT_COLS = {3, 5, 7}    # Finding, URL, Notes
+SIMPLE_LEFT_COLS = {3, 5, 7}  # Finding, URL, Notes
 DETAILED_LEFT_COLS = {3, 7, 8, 10, 12}  # Finding, Root Cause, Affected Code, URL, Notes
 
 SHEET_MAP = {
-    "new":             ("New bug",              SIMPLE_COLUMNS,   SIMPLE_LEFT_COLS),
-    "new-detailed":    ("New bug (detailed)",   DETAILED_COLUMNS, DETAILED_LEFT_COLS),
-    "known":           ("Known bug",            SIMPLE_COLUMNS,   SIMPLE_LEFT_COLS),
-    "known-detailed":  ("Known bug (detailed)", DETAILED_COLUMNS, DETAILED_LEFT_COLS),
+    "new": ("New bug", SIMPLE_COLUMNS, SIMPLE_LEFT_COLS),
+    "new-detailed": ("New bug (detailed)", DETAILED_COLUMNS, DETAILED_LEFT_COLS),
+    "known": ("Known bug", SIMPLE_COLUMNS, SIMPLE_LEFT_COLS),
+    "known-detailed": ("Known bug (detailed)", DETAILED_COLUMNS, DETAILED_LEFT_COLS),
 }
 
 
@@ -70,16 +83,23 @@ def format_new_row(sh, ws, sheet_key, row_idx):
         # Base: center, Arial 10, borders, wrap, background
         {
             "repeatCell": {
-                "range": {"sheetId": sheet_id, "startRowIndex": row_idx, "endRowIndex": row_idx + 1,
-                          "startColumnIndex": 0, "endColumnIndex": col_count},
-                "cell": {"userEnteredFormat": {
-                    "backgroundColor": bg,
-                    "textFormat": {"fontFamily": "Arial", "fontSize": 10},
-                    "horizontalAlignment": "CENTER",
-                    "verticalAlignment": "MIDDLE",
-                    "wrapStrategy": "WRAP",
-                    "borders": ALL_BORDERS,
-                }},
+                "range": {
+                    "sheetId": sheet_id,
+                    "startRowIndex": row_idx,
+                    "endRowIndex": row_idx + 1,
+                    "startColumnIndex": 0,
+                    "endColumnIndex": col_count,
+                },
+                "cell": {
+                    "userEnteredFormat": {
+                        "backgroundColor": bg,
+                        "textFormat": {"fontFamily": "Arial", "fontSize": 10},
+                        "horizontalAlignment": "CENTER",
+                        "verticalAlignment": "MIDDLE",
+                        "wrapStrategy": "WRAP",
+                        "borders": ALL_BORDERS,
+                    }
+                },
                 "fields": "userEnteredFormat(backgroundColor,textFormat,horizontalAlignment,verticalAlignment,wrapStrategy,borders)",
             }
         },
@@ -87,27 +107,53 @@ def format_new_row(sh, ws, sheet_key, row_idx):
     # Left-aligned columns
     for col_idx in left_cols:
         if col_idx < col_count:
-            requests.append({
-                "repeatCell": {
-                    "range": {"sheetId": sheet_id, "startRowIndex": row_idx, "endRowIndex": row_idx + 1,
-                              "startColumnIndex": col_idx, "endColumnIndex": col_idx + 1},
-                    "cell": {"userEnteredFormat": {"horizontalAlignment": "LEFT"}},
-                    "fields": "userEnteredFormat.horizontalAlignment",
+            requests.append(
+                {
+                    "repeatCell": {
+                        "range": {
+                            "sheetId": sheet_id,
+                            "startRowIndex": row_idx,
+                            "endRowIndex": row_idx + 1,
+                            "startColumnIndex": col_idx,
+                            "endColumnIndex": col_idx + 1,
+                        },
+                        "cell": {"userEnteredFormat": {"horizontalAlignment": "LEFT"}},
+                        "fields": "userEnteredFormat.horizontalAlignment",
+                    }
                 }
-            })
+            )
     sh.batch_update({"requests": requests})
 
 
 def build_simple_row(num, args):
-    return [num, args.system, args.protocol, args.finding,
-            args.reference or "", args.url or "", args.status or "", args.notes or ""]
+    return [
+        num,
+        args.system,
+        args.protocol,
+        args.finding,
+        args.reference or "",
+        args.url or "",
+        args.status or "",
+        args.notes or "",
+    ]
 
 
 def build_detailed_row(num, args):
-    return [num, args.system, args.protocol, args.finding,
-            args.severity or "", args.bug_family or "", args.discovery_method or "",
-            args.root_cause or "", args.affected_code or "",
-            args.reference or "", args.url or "", args.status or "", args.notes or ""]
+    return [
+        num,
+        args.system,
+        args.protocol,
+        args.finding,
+        args.severity or "",
+        args.bug_family or "",
+        args.discovery_method or "",
+        args.root_cause or "",
+        args.affected_code or "",
+        args.reference or "",
+        args.url or "",
+        args.status or "",
+        args.notes or "",
+    ]
 
 
 def resolve_sheets(sheet_key):
@@ -164,9 +210,14 @@ def update_bug(args):
 
         updates = {}
         field_map = {
-            "reference": "Reference", "url": "URL", "status": "Status", "notes": "Notes",
-            "severity": "Severity", "bug_family": "Bug Family",
-            "discovery_method": "Discovery Method", "root_cause": "Root Cause",
+            "reference": "Reference",
+            "url": "URL",
+            "status": "Status",
+            "notes": "Notes",
+            "severity": "Severity",
+            "bug_family": "Bug Family",
+            "discovery_method": "Discovery Method",
+            "root_cause": "Root Cause",
             "affected_code": "Affected Code",
         }
         for attr, col_name in field_map.items():
@@ -262,33 +313,49 @@ def sort_bugs(args):
         for i in range(num_data):
             row_idx = i + 1  # 0-indexed sheet row (row 0 = header, row 1 = first data)
             bg = LIGHT_BLUE if (i + 1) % 2 == 1 else WHITE
-            requests.append({
-                "repeatCell": {
-                    "range": {"sheetId": ws.id, "startRowIndex": row_idx, "endRowIndex": row_idx + 1,
-                              "startColumnIndex": 0, "endColumnIndex": col_count},
-                    "cell": {"userEnteredFormat": {
-                        "backgroundColor": bg,
-                        "textFormat": {"fontFamily": "Arial", "fontSize": 10},
-                        "horizontalAlignment": "CENTER",
-                        "verticalAlignment": "MIDDLE",
-                        "wrapStrategy": "WRAP",
-                        "borders": ALL_BORDERS,
-                    }},
-                    "fields": "userEnteredFormat(backgroundColor,textFormat,horizontalAlignment,verticalAlignment,wrapStrategy,borders)",
+            requests.append(
+                {
+                    "repeatCell": {
+                        "range": {
+                            "sheetId": ws.id,
+                            "startRowIndex": row_idx,
+                            "endRowIndex": row_idx + 1,
+                            "startColumnIndex": 0,
+                            "endColumnIndex": col_count,
+                        },
+                        "cell": {
+                            "userEnteredFormat": {
+                                "backgroundColor": bg,
+                                "textFormat": {"fontFamily": "Arial", "fontSize": 10},
+                                "horizontalAlignment": "CENTER",
+                                "verticalAlignment": "MIDDLE",
+                                "wrapStrategy": "WRAP",
+                                "borders": ALL_BORDERS,
+                            }
+                        },
+                        "fields": "userEnteredFormat(backgroundColor,textFormat,horizontalAlignment,verticalAlignment,wrapStrategy,borders)",
+                    }
                 }
-            })
+            )
             # Left-aligned columns
             _, _, left_cols = SHEET_MAP[sheet_key]
             for col_idx in left_cols:
                 if col_idx < col_count:
-                    requests.append({
-                        "repeatCell": {
-                            "range": {"sheetId": ws.id, "startRowIndex": row_idx, "endRowIndex": row_idx + 1,
-                                      "startColumnIndex": col_idx, "endColumnIndex": col_idx + 1},
-                            "cell": {"userEnteredFormat": {"horizontalAlignment": "LEFT"}},
-                            "fields": "userEnteredFormat.horizontalAlignment",
+                    requests.append(
+                        {
+                            "repeatCell": {
+                                "range": {
+                                    "sheetId": ws.id,
+                                    "startRowIndex": row_idx,
+                                    "endRowIndex": row_idx + 1,
+                                    "startColumnIndex": col_idx,
+                                    "endColumnIndex": col_idx + 1,
+                                },
+                                "cell": {"userEnteredFormat": {"horizontalAlignment": "LEFT"}},
+                                "fields": "userEnteredFormat.horizontalAlignment",
+                            }
                         }
-                    })
+                    )
 
         if requests:
             sh.batch_update({"requests": requests})
@@ -316,8 +383,12 @@ def main():
 
     # --- append ---
     p_add = sub.add_parser("append", help="Add a new bug")
-    p_add.add_argument("--sheet", choices=["new", "known"], default="new",
-                       help="Target: 'new' (writes to New bug + detailed) or 'known' (writes to Known bug + detailed)")
+    p_add.add_argument(
+        "--sheet",
+        choices=["new", "known"],
+        default="new",
+        help="Target: 'new' (writes to New bug + detailed) or 'known' (writes to Known bug + detailed)",
+    )
     p_add.add_argument("--system", required=True, help="System name")
     p_add.add_argument("--protocol", required=True, help="Protocol / Lang")
     p_add.add_argument("--finding", required=True, help="Bug description")
@@ -333,8 +404,12 @@ def main():
 
     # --- update ---
     p_upd = sub.add_parser("update", help="Update an existing bug")
-    p_upd.add_argument("--sheet", choices=["new", "known"], default="new",
-                       help="Target: 'new' or 'known' (updates both simple + detailed)")
+    p_upd.add_argument(
+        "--sheet",
+        choices=["new", "known"],
+        default="new",
+        help="Target: 'new' or 'known' (updates both simple + detailed)",
+    )
     p_upd.add_argument("--number", type=int, required=True, help="Bug number to update")
     p_upd.add_argument("--severity", help="New severity")
     p_upd.add_argument("--bug-family", help="New bug family")
@@ -348,19 +423,26 @@ def main():
 
     # --- delete ---
     p_del = sub.add_parser("delete", help="Delete a bug by number")
-    p_del.add_argument("--sheet", choices=["new", "known"], default="new",
-                       help="Target: 'new' or 'known' (deletes from both simple + detailed)")
+    p_del.add_argument(
+        "--sheet",
+        choices=["new", "known"],
+        default="new",
+        help="Target: 'new' or 'known' (deletes from both simple + detailed)",
+    )
     p_del.add_argument("--number", type=int, required=True, help="Bug number to delete")
 
     # --- sort ---
     p_sort = sub.add_parser("sort", help="Sort bugs by System column")
-    p_sort.add_argument("--sheet", choices=["new", "known"], default="new",
-                        help="Target: 'new' or 'known' (sorts both simple + detailed)")
+    p_sort.add_argument(
+        "--sheet",
+        choices=["new", "known"],
+        default="new",
+        help="Target: 'new' or 'known' (sorts both simple + detailed)",
+    )
 
     # --- list ---
     p_list = sub.add_parser("list", help="List all bugs")
-    p_list.add_argument("--sheet", choices=list(SHEET_MAP.keys()), default="new",
-                        help="Which sheet to list")
+    p_list.add_argument("--sheet", choices=list(SHEET_MAP.keys()), default="new", help="Which sheet to list")
 
     args = parser.parse_args()
     if args.command == "append":

--- a/scripts/infra/record_bug.py
+++ b/scripts/infra/record_bug.py
@@ -9,6 +9,7 @@ Supports 4 sheets:
 """
 
 import argparse
+import contextlib
 import sys
 
 import gspread
@@ -65,10 +66,8 @@ def next_bug_number(ws):
     col_values = ws.col_values(1)
     nums = []
     for v in col_values[1:]:
-        try:
+        with contextlib.suppress(ValueError, TypeError):
             nums.append(int(v))
-        except (ValueError, TypeError):
-            pass
     return max(nums, default=0) + 1
 
 
@@ -176,10 +175,7 @@ def append_bug(args):
         num = num_from_ws if sheet_key == targets[0] else num_from_ws
         _, columns, _ = SHEET_MAP[sheet_key]
 
-        if len(columns) == len(DETAILED_COLUMNS):
-            row = build_detailed_row(num, args)
-        else:
-            row = build_simple_row(num, args)
+        row = build_detailed_row(num, args) if len(columns) == len(DETAILED_COLUMNS) else build_simple_row(num, args)
 
         ws.append_row(row, value_input_option="USER_ENTERED")
         total_rows = len(ws.get_all_values())
@@ -280,7 +276,6 @@ def sort_bugs(args):
         sh, ws = get_worksheet(gc, sheet_key)
         _, columns, _ = SHEET_MAP[sheet_key]
         rows = ws.get_all_values()
-        header = rows[0]
         data_rows = [r for r in rows[1:] if any(r)]
 
         if not data_rows:

--- a/scripts/infra/setup_codex_plugin.py
+++ b/scripts/infra/setup_codex_plugin.py
@@ -8,8 +8,6 @@ import json
 import pathlib
 import shutil
 import subprocess
-import sys
-
 
 PLUGIN_NAME = "specula-codex"
 MARKETPLACE_NAME = "specula"

--- a/scripts/tlc/parse_tlc_log.py
+++ b/scripts/tlc/parse_tlc_log.py
@@ -12,18 +12,16 @@ Given a log path, this prints:
 import argparse
 import re
 from pathlib import Path
-from typing import Dict, List, Tuple
-
 
 STATE_RE = re.compile(r"^State\s+(\d+)")
 ASSIGN_RE = re.compile(r"^\s*/\\\s*([^\s=]+)\s*=\s*(.*)$")
 
 
-def parse_states(lines: List[str]) -> List[Tuple[str, List[str]]]:
+def parse_states(lines: list[str]) -> list[tuple[str, list[str]]]:
     """Group lines by State N sections."""
-    states: List[Tuple[str, List[str]]] = []
+    states: list[tuple[str, list[str]]] = []
     current_id = None
-    current_lines: List[str] = []
+    current_lines: list[str] = []
 
     for raw in lines:
         line = raw.rstrip("\n")
@@ -41,7 +39,7 @@ def parse_states(lines: List[str]) -> List[Tuple[str, List[str]]]:
     return states
 
 
-def print_warnings_errors(lines: List[str]) -> None:
+def print_warnings_errors(lines: list[str]) -> None:
     print("Warnings/Errors:")
     for raw in lines:
         line = raw.rstrip("\n")
@@ -51,15 +49,15 @@ def print_warnings_errors(lines: List[str]) -> None:
     print()
 
 
-def print_state_diffs(states: List[Tuple[str, List[str]]]) -> None:
-    prev_terms: Dict[str, str] = {}
+def print_state_diffs(states: list[tuple[str, list[str]]]) -> None:
+    prev_terms: dict[str, str] = {}
 
     for state_id, lines in states:
-        curr_terms: Dict[str, str] = {}
+        curr_terms: dict[str, str] = {}
         current_var = None
-        buffer: List[str] = []
+        buffer: list[str] = []
 
-        def flush_var(var_name: str, buf: List[str]) -> None:
+        def flush_var(var_name: str, buf: list[str]) -> None:
             if var_name is None:
                 return
             curr_terms[var_name] = "\n".join(buf).strip()
@@ -75,10 +73,10 @@ def print_state_diffs(states: List[Tuple[str, List[str]]]) -> None:
                     buffer.append(line)
         flush_var(current_var, buffer)
 
-        added_keys = [k for k in curr_terms.keys() if k not in prev_terms]
-        removed_keys = [k for k in prev_terms.keys() if k not in curr_terms]
+        added_keys = [k for k in curr_terms if k not in prev_terms]
+        removed_keys = [k for k in prev_terms if k not in curr_terms]
         changed_keys = [
-            k for k in curr_terms.keys() if k in prev_terms and curr_terms[k].strip() != prev_terms[k].strip()
+            k for k in curr_terms if k in prev_terms and curr_terms[k].strip() != prev_terms[k].strip()
         ]
 
         print(f"State {state_id}:")

--- a/scripts/tlc/parse_tlc_log.py
+++ b/scripts/tlc/parse_tlc_log.py
@@ -50,6 +50,11 @@ def print_warnings_errors(lines: list[str]) -> None:
 
 
 def print_state_diffs(states: list[tuple[str, list[str]]]) -> None:
+    def flush_var(var_name: str, buf: list[str], curr_terms: dict[str, str]) -> None:
+        if var_name is None:
+            return
+        curr_terms[var_name] = "\n".join(buf).strip()
+
     prev_terms: dict[str, str] = {}
 
     for state_id, lines in states:
@@ -57,27 +62,20 @@ def print_state_diffs(states: list[tuple[str, list[str]]]) -> None:
         current_var = None
         buffer: list[str] = []
 
-        def flush_var(var_name: str, buf: list[str]) -> None:
-            if var_name is None:
-                return
-            curr_terms[var_name] = "\n".join(buf).strip()
-
         for line in lines:
             m = ASSIGN_RE.match(line)
             if m:
-                flush_var(current_var, buffer)
+                flush_var(current_var, buffer, curr_terms)
                 current_var = m.group(1)
                 buffer = [m.group(2)]
             else:
                 if current_var is not None:
                     buffer.append(line)
-        flush_var(current_var, buffer)
+        flush_var(current_var, buffer, curr_terms)
 
         added_keys = [k for k in curr_terms if k not in prev_terms]
         removed_keys = [k for k in prev_terms if k not in curr_terms]
-        changed_keys = [
-            k for k in curr_terms if k in prev_terms and curr_terms[k].strip() != prev_terms[k].strip()
-        ]
+        changed_keys = [k for k in curr_terms if k in prev_terms and curr_terms[k].strip() != prev_terms[k].strip()]
 
         print(f"State {state_id}:")
         if not added_keys and not removed_keys and not changed_keys:
@@ -118,8 +116,8 @@ def main() -> None:
 
     try:
         lines = args.log_path.read_text(encoding="utf-8").splitlines()
-    except FileNotFoundError:
-        raise SystemExit(f"Log not found: {args.log_path}")
+    except FileNotFoundError as e:
+        raise SystemExit(f"Log not found: {args.log_path}") from e
 
     # Truncate anything after the TLC footer summary (e.g., "<n> states generated").
     for i, ln in enumerate(lines):

--- a/scripts/tlc/parse_tlc_log.py
+++ b/scripts/tlc/parse_tlc_log.py
@@ -78,8 +78,7 @@ def print_state_diffs(states: List[Tuple[str, List[str]]]) -> None:
         added_keys = [k for k in curr_terms.keys() if k not in prev_terms]
         removed_keys = [k for k in prev_terms.keys() if k not in curr_terms]
         changed_keys = [
-            k for k in curr_terms.keys()
-            if k in prev_terms and curr_terms[k].strip() != prev_terms[k].strip()
+            k for k in curr_terms.keys() if k in prev_terms and curr_terms[k].strip() != prev_terms[k].strip()
         ]
 
         print(f"State {state_id}:")

--- a/scripts/tlc/tlc_coverage.py
+++ b/scripts/tlc/tlc_coverage.py
@@ -29,14 +29,12 @@ Examples:
 """
 
 import argparse
-import subprocess
-import re
 import os
-import sys
-from pathlib import Path
+import re
+import subprocess
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Optional, Set, Dict, List, Tuple
+from pathlib import Path
 
 # Default paths (relative to script location)
 SCRIPT_DIR = Path(__file__).parent
@@ -53,7 +51,7 @@ class CoverageResult:
 
     total: int = 0
     covered: int = 0
-    uncovered_lines: Dict[str, Set[int]] = field(default_factory=lambda: defaultdict(set))
+    uncovered_lines: dict[str, set[int]] = field(default_factory=lambda: defaultdict(set))
 
     @property
     def pct(self) -> float:
@@ -64,7 +62,7 @@ class CoverageResult:
         return self.total - self.covered
 
 
-def parse_exclude_range(spec: str) -> Tuple[str, int, int]:
+def parse_exclude_range(spec: str) -> tuple[str, int, int]:
     """Parse 'module:start-end' format."""
     if ":" not in spec:
         raise ValueError(f"Invalid format: {spec}. Expected 'module:start-end'")
@@ -80,9 +78,9 @@ def run_tlc(
     spec_file: str,
     config_file: str,
     tla_jar: Path,
-    trace_file: Optional[Path] = None,
+    trace_file: Path | None = None,
     timeout: int = 300,
-    community_jar: Optional[Path] = None,
+    community_jar: Path | None = None,
 ) -> str:
     """Run TLC with coverage enabled."""
     env = os.environ.copy()
@@ -115,8 +113,8 @@ def run_tlc(
 
 
 def parse_coverage(
-    output: str, modules: Set[str], exclude_ranges: Dict[str, List[Tuple[int, int]]], top_level_only: bool = True
-) -> Dict[Tuple, int]:
+    output: str, modules: set[str], exclude_ranges: dict[str, list[tuple[int, int]]], top_level_only: bool = True
+) -> dict[tuple, int]:
     """Parse TLC coverage output."""
     coverage = {}
 
@@ -159,19 +157,19 @@ def analyze_traces(
     spec_file: str,
     config_file: str,
     tla_jar: Path,
-    modules: Set[str],
-    exclude_ranges: Dict[str, List[Tuple[int, int]]],
+    modules: set[str],
+    exclude_ranges: dict[str, list[tuple[int, int]]],
     top_level_only: bool,
     timeout: int,
     verbose: bool,
-    community_jar: Optional[Path] = None,
+    community_jar: Path | None = None,
 ) -> CoverageResult:
     """Analyze coverage across multiple trace files."""
     trace_files = sorted(trace_dir.glob("*.ndjson"))
     if verbose:
         print(f"Found {len(trace_files)} trace files\n")
 
-    all_stmts: Dict[Tuple, int] = {}
+    all_stmts: dict[tuple, int] = {}
 
     for i, tf in enumerate(trace_files, 1):
         if verbose:
@@ -206,8 +204,8 @@ def analyze_model(
     spec_file: str,
     config_file: str,
     tla_jar: Path,
-    modules: Set[str],
-    exclude_ranges: Dict[str, List[Tuple[int, int]]],
+    modules: set[str],
+    exclude_ranges: dict[str, list[tuple[int, int]]],
     top_level_only: bool,
     timeout: int,
 ) -> CoverageResult:
@@ -217,7 +215,7 @@ def analyze_model(
     return build_result(cov)
 
 
-def build_result(stmts: Dict[Tuple, int]) -> CoverageResult:
+def build_result(stmts: dict[tuple, int]) -> CoverageResult:
     """Build CoverageResult from statements dict."""
     result = CoverageResult()
     result.total = len(stmts)

--- a/scripts/tlc/tlc_coverage.py
+++ b/scripts/tlc/tlc_coverage.py
@@ -44,14 +44,13 @@ DEFAULT_TLA_JAR = SCRIPT_DIR.parent / "lib" / "tla2tools.jar"
 DEFAULT_COMMUNITY_JAR = SCRIPT_DIR.parent / "lib" / "CommunityModules-deps.jar"
 
 # Regex to parse TLC coverage output
-COVERAGE_PATTERN = re.compile(
-    r"line (\d+), col (\d+) to line (\d+), col (\d+) of module (\w+)>?:\s*(\d+)"
-)
+COVERAGE_PATTERN = re.compile(r"line (\d+), col (\d+) to line (\d+), col (\d+) of module (\w+)>?:\s*(\d+)")
 
 
 @dataclass
 class CoverageResult:
     """Results of coverage analysis."""
+
     total: int = 0
     covered: int = 0
     uncovered_lines: Dict[str, Set[int]] = field(default_factory=lambda: defaultdict(set))
@@ -67,18 +66,24 @@ class CoverageResult:
 
 def parse_exclude_range(spec: str) -> Tuple[str, int, int]:
     """Parse 'module:start-end' format."""
-    if ':' not in spec:
+    if ":" not in spec:
         raise ValueError(f"Invalid format: {spec}. Expected 'module:start-end'")
-    module, range_str = spec.split(':', 1)
-    if '-' not in range_str:
+    module, range_str = spec.split(":", 1)
+    if "-" not in range_str:
         raise ValueError(f"Invalid range: {range_str}. Expected 'start-end'")
-    start, end = range_str.split('-', 1)
+    start, end = range_str.split("-", 1)
     return module, int(start), int(end)
 
 
-def run_tlc(spec_dir: Path, spec_file: str, config_file: str,
-            tla_jar: Path, trace_file: Optional[Path] = None,
-            timeout: int = 300, community_jar: Optional[Path] = None) -> str:
+def run_tlc(
+    spec_dir: Path,
+    spec_file: str,
+    config_file: str,
+    tla_jar: Path,
+    trace_file: Optional[Path] = None,
+    timeout: int = 300,
+    community_jar: Optional[Path] = None,
+) -> str:
     """Run TLC with coverage enabled."""
     env = os.environ.copy()
     if trace_file:
@@ -90,9 +95,14 @@ def run_tlc(spec_dir: Path, spec_file: str, config_file: str,
         cp = f"{tla_jar.resolve()}:{community_jar.resolve()}"
 
     cmd = [
-        "java", "-cp", cp, "tlc2.TLC",
-        "-coverage", "0",
-        "-config", config_file,
+        "java",
+        "-cp",
+        cp,
+        "tlc2.TLC",
+        "-coverage",
+        "0",
+        "-config",
+        config_file,
         "-noTE",
     ]
     # For trace validation, suppress deadlock checking (trace terminates naturally)
@@ -100,15 +110,13 @@ def run_tlc(spec_dir: Path, spec_file: str, config_file: str,
         cmd.append("-deadlock")
     cmd.append(spec_file)
 
-    result = subprocess.run(
-        cmd, cwd=spec_dir, env=env,
-        capture_output=True, text=True, timeout=timeout
-    )
+    result = subprocess.run(cmd, cwd=spec_dir, env=env, capture_output=True, text=True, timeout=timeout)
     return result.stdout + result.stderr
 
 
-def parse_coverage(output: str, modules: Set[str], exclude_ranges: Dict[str, List[Tuple[int, int]]],
-                   top_level_only: bool = True) -> Dict[Tuple, int]:
+def parse_coverage(
+    output: str, modules: Set[str], exclude_ranges: Dict[str, List[Tuple[int, int]]], top_level_only: bool = True
+) -> Dict[Tuple, int]:
     """Parse TLC coverage output."""
     coverage = {}
 
@@ -145,10 +153,19 @@ def parse_coverage(output: str, modules: Set[str], exclude_ranges: Dict[str, Lis
     return coverage
 
 
-def analyze_traces(spec_dir: Path, trace_dir: Path, spec_file: str, config_file: str,
-                   tla_jar: Path, modules: Set[str], exclude_ranges: Dict[str, List[Tuple[int, int]]],
-                   top_level_only: bool, timeout: int, verbose: bool,
-                   community_jar: Optional[Path] = None) -> CoverageResult:
+def analyze_traces(
+    spec_dir: Path,
+    trace_dir: Path,
+    spec_file: str,
+    config_file: str,
+    tla_jar: Path,
+    modules: Set[str],
+    exclude_ranges: Dict[str, List[Tuple[int, int]]],
+    top_level_only: bool,
+    timeout: int,
+    verbose: bool,
+    community_jar: Optional[Path] = None,
+) -> CoverageResult:
     """Analyze coverage across multiple trace files."""
     trace_files = sorted(trace_dir.glob("*.ndjson"))
     if verbose:
@@ -160,8 +177,7 @@ def analyze_traces(spec_dir: Path, trace_dir: Path, spec_file: str, config_file:
         if verbose:
             print(f"[{i:2d}/{len(trace_files)}] {tf.name}...", end=" ", flush=True)
         try:
-            output = run_tlc(spec_dir, spec_file, config_file, tla_jar, tf, timeout,
-                             community_jar=community_jar)
+            output = run_tlc(spec_dir, spec_file, config_file, tla_jar, tf, timeout, community_jar=community_jar)
             if "Model checking completed" not in output and "states generated" not in output:
                 if verbose:
                     print("FAILED")
@@ -173,7 +189,7 @@ def analyze_traces(spec_dir: Path, trace_dir: Path, spec_file: str, config_file:
 
             if verbose:
                 c = sum(1 for v in cov.values() if v > 0)
-                print(f"OK ({c}/{len(cov)} = {c/len(cov)*100:.1f}%)" if cov else "OK (empty)")
+                print(f"OK ({c}/{len(cov)} = {c / len(cov) * 100:.1f}%)" if cov else "OK (empty)")
 
         except subprocess.TimeoutExpired:
             if verbose:
@@ -185,9 +201,16 @@ def analyze_traces(spec_dir: Path, trace_dir: Path, spec_file: str, config_file:
     return build_result(all_stmts)
 
 
-def analyze_model(spec_dir: Path, spec_file: str, config_file: str, tla_jar: Path,
-                  modules: Set[str], exclude_ranges: Dict[str, List[Tuple[int, int]]],
-                  top_level_only: bool, timeout: int) -> CoverageResult:
+def analyze_model(
+    spec_dir: Path,
+    spec_file: str,
+    config_file: str,
+    tla_jar: Path,
+    modules: Set[str],
+    exclude_ranges: Dict[str, List[Tuple[int, int]]],
+    top_level_only: bool,
+    timeout: int,
+) -> CoverageResult:
     """Analyze coverage from model checking."""
     output = run_tlc(spec_dir, spec_file, config_file, tla_jar, timeout=timeout)
     cov = parse_coverage(output, modules, exclude_ranges, top_level_only)
@@ -209,7 +232,7 @@ def print_result(result: CoverageResult, title: str):
     """Print coverage result."""
     print(f"\n{'=' * 70}")
     print(title)
-    print('=' * 70)
+    print("=" * 70)
     print(f"Total statements:     {result.total}")
     print(f"Covered statements:   {result.covered}")
     print(f"Uncovered statements: {result.uncovered}")
@@ -218,7 +241,7 @@ def print_result(result: CoverageResult, title: str):
     if result.uncovered_lines:
         print(f"\n{'-' * 70}")
         print("UNCOVERED LINES BY MODULE")
-        print('-' * 70)
+        print("-" * 70)
         for module in sorted(result.uncovered_lines.keys()):
             lines = sorted(result.uncovered_lines[module])
             print(f"\n{module}.tla ({len(lines)} lines):")
@@ -229,24 +252,23 @@ def print_comparison(r1: CoverageResult, r2: CoverageResult, n1: str, n2: str):
     """Print comparison of two results."""
     print(f"\n{'=' * 70}")
     print("COVERAGE COMPARISON")
-    print('=' * 70)
+    print("=" * 70)
     print(f"{'Metric':<25} {n1:>20} {n2:>20}")
-    print('-' * 70)
+    print("-" * 70)
     print(f"{'Total statements':<25} {r1.total:>20} {r2.total:>20}")
     print(f"{'Covered statements':<25} {r1.covered:>20} {r2.covered:>20}")
     print(f"{'Uncovered statements':<25} {r1.uncovered:>20} {r2.uncovered:>20}")
     print(f"{'Coverage %':<25} {r1.pct:>19.2f}% {r2.pct:>19.2f}%")
-    print('-' * 70)
+    print("-" * 70)
     print(f"{'Difference':<25} {'':<20} {r2.pct - r1.pct:>+19.2f}%")
 
 
 def main():
-    parser = argparse.ArgumentParser(description="TLC Coverage Analysis Tool",
-                                     formatter_class=argparse.RawDescriptionHelpFormatter,
-                                     epilog=__doc__)
+    parser = argparse.ArgumentParser(
+        description="TLC Coverage Analysis Tool", formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__
+    )
     parser.add_argument("--tla-jar", default=str(DEFAULT_TLA_JAR), help="Path to tla2tools.jar")
-    parser.add_argument("--community-jar", default=str(DEFAULT_COMMUNITY_JAR),
-                        help="Path to CommunityModules-deps.jar")
+    parser.add_argument("--community-jar", default=str(DEFAULT_COMMUNITY_JAR), help="Path to CommunityModules-deps.jar")
     parser.add_argument("--timeout", type=int, default=300, help="TLC timeout in seconds")
 
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -258,8 +280,9 @@ def main():
     p_trace.add_argument("--spec-file", default="Traceetcdraft.tla")
     p_trace.add_argument("--config-file", default="Traceetcdraft.cfg")
     p_trace.add_argument("--modules", nargs="+", default=[], help="Modules to include")
-    p_trace.add_argument("--exclude-range", nargs="*", default=[],
-                         help="Exclude ranges: module:start-end (e.g., etcdraft:600-650)")
+    p_trace.add_argument(
+        "--exclude-range", nargs="*", default=[], help="Exclude ranges: module:start-end (e.g., etcdraft:600-650)"
+    )
     p_trace.add_argument("--all", action="store_true", help="Include nested statements")
     p_trace.add_argument("--quiet", action="store_true")
 
@@ -299,11 +322,17 @@ def main():
             exclude[m].append((s, e))
 
         result = analyze_traces(
-            Path(args.spec_dir), Path(args.trace_dir),
-            args.spec_file, args.config_file, tla_jar,
-            set(args.modules), dict(exclude),
-            not args.all, args.timeout, not args.quiet,
-            community_jar=community_jar
+            Path(args.spec_dir),
+            Path(args.trace_dir),
+            args.spec_file,
+            args.config_file,
+            tla_jar,
+            set(args.modules),
+            dict(exclude),
+            not args.all,
+            args.timeout,
+            not args.quiet,
+            community_jar=community_jar,
         )
         print_result(result, "TRACE VALIDATION COVERAGE")
 
@@ -314,8 +343,14 @@ def main():
             exclude[m].append((s, e))
 
         result = analyze_model(
-            Path(args.spec_dir), args.spec_file, args.config_file, tla_jar,
-            set(args.modules), dict(exclude), not args.all, args.timeout
+            Path(args.spec_dir),
+            args.spec_file,
+            args.config_file,
+            tla_jar,
+            set(args.modules),
+            dict(exclude),
+            not args.all,
+            args.timeout,
         )
         print_result(result, "MODEL CHECKING COVERAGE")
 
@@ -333,20 +368,54 @@ def main():
         top_level = not args.all
 
         if args.trace_dir1:
-            r1 = analyze_traces(Path(args.spec_dir1), Path(args.trace_dir1),
-                                args.spec_file1, args.config_file1, tla_jar,
-                                set(args.modules1), dict(exc1), top_level, args.timeout, True)
+            r1 = analyze_traces(
+                Path(args.spec_dir1),
+                Path(args.trace_dir1),
+                args.spec_file1,
+                args.config_file1,
+                tla_jar,
+                set(args.modules1),
+                dict(exc1),
+                top_level,
+                args.timeout,
+                True,
+            )
         else:
-            r1 = analyze_model(Path(args.spec_dir1), args.spec_file1, args.config_file1,
-                               tla_jar, set(args.modules1), dict(exc1), top_level, args.timeout)
+            r1 = analyze_model(
+                Path(args.spec_dir1),
+                args.spec_file1,
+                args.config_file1,
+                tla_jar,
+                set(args.modules1),
+                dict(exc1),
+                top_level,
+                args.timeout,
+            )
 
         if args.trace_dir2:
-            r2 = analyze_traces(Path(args.spec_dir2), Path(args.trace_dir2),
-                                args.spec_file2, args.config_file2, tla_jar,
-                                set(args.modules2), dict(exc2), top_level, args.timeout, True)
+            r2 = analyze_traces(
+                Path(args.spec_dir2),
+                Path(args.trace_dir2),
+                args.spec_file2,
+                args.config_file2,
+                tla_jar,
+                set(args.modules2),
+                dict(exc2),
+                top_level,
+                args.timeout,
+                True,
+            )
         else:
-            r2 = analyze_model(Path(args.spec_dir2), args.spec_file2, args.config_file2,
-                               tla_jar, set(args.modules2), dict(exc2), top_level, args.timeout)
+            r2 = analyze_model(
+                Path(args.spec_dir2),
+                args.spec_file2,
+                args.config_file2,
+                tla_jar,
+                set(args.modules2),
+                dict(exc2),
+                top_level,
+                args.timeout,
+            )
 
         print_comparison(r1, r2, Path(args.spec_dir1).name, Path(args.spec_dir2).name)
 

--- a/skills/harness-generation/examples/cometbft/preprocess_trace.py
+++ b/skills/harness-generation/examples/cometbft/preprocess_trace.py
@@ -4,6 +4,7 @@
 Maps concrete hex addresses to abstract server IDs (s1, s2, s3)
 and concrete block hashes to abstract values (v1, v2, ...).
 """
+
 import json
 import sys
 from collections import OrderedDict

--- a/tools/inv_checking_tool/mcp_server.py
+++ b/tools/inv_checking_tool/mcp_server.py
@@ -25,8 +25,8 @@ Available tools:
 """
 
 import asyncio
-import sys
 import os
+import sys
 
 # Add package to path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/tools/inv_checking_tool/src/cli.py
+++ b/tools/inv_checking_tool/src/cli.py
@@ -210,10 +210,7 @@ def handle_state(reader: TLCOutputReader, args) -> None:
     """Handle --state command."""
     # Parse the index
     try:
-        if args.state.lower() in ("first", "last"):
-            index = args.state.lower()
-        else:
-            index = int(args.state)
+        index = args.state.lower() if args.state.lower() in ("first", "last") else int(args.state)
     except ValueError:
         print(f"Error: Invalid state index: {args.state}", file=sys.stderr)
         sys.exit(1)

--- a/tools/inv_checking_tool/src/cli.py
+++ b/tools/inv_checking_tool/src/cli.py
@@ -40,7 +40,6 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import List, Optional
 
 # Handle both direct execution and module execution
 try:

--- a/tools/inv_checking_tool/src/cli.py
+++ b/tools/inv_checking_tool/src/cli.py
@@ -49,9 +49,10 @@ try:
 except ImportError:
     # Direct execution - add parent directories to path
     import os
+
     current_dir = os.path.dirname(os.path.abspath(__file__))
     parent_dir = os.path.dirname(current_dir)  # inv_checking_tool
-    tools_dir = os.path.dirname(parent_dir)    # tools
+    tools_dir = os.path.dirname(parent_dir)  # tools
     sys.path.insert(0, tools_dir)
     from inv_checking_tool.src.tlc_output_reader import TLCOutputReader
     from inv_checking_tool.src.utils.path_parser import format_value
@@ -87,7 +88,7 @@ Examples:
 
   # Show action sequence
   %(prog)s output.log --actions
-        """
+        """,
     )
 
     parser.add_argument(
@@ -100,7 +101,8 @@ Examples:
     mode_group = parser.add_mutually_exclusive_group()
 
     mode_group.add_argument(
-        "--summary", "-s",
+        "--summary",
+        "-s",
         action="store_true",
         help="Show trace summary (violated invariant, trace length, etc.)",
     )
@@ -147,23 +149,25 @@ Examples:
 
     # Options that modify output
     parser.add_argument(
-        "--var", "-v",
+        "--var",
+        "-v",
         type=str,
         metavar="PATH",
         action="append",
         dest="var_paths",
-        help="Variable path to show (can be used multiple times). "
-             "Supports dot notation: 'log.s1.entries[0]'",
+        help="Variable path to show (can be used multiple times). Supports dot notation: 'log.s1.entries[0]'",
     )
 
     parser.add_argument(
-        "--json", "-j",
+        "--json",
+        "-j",
         action="store_true",
         help="Output in JSON format",
     )
 
     parser.add_argument(
-        "--compact", "-c",
+        "--compact",
+        "-c",
         action="store_true",
         help="Compact output (less whitespace)",
     )
@@ -189,13 +193,16 @@ def handle_summary(reader: TLCOutputReader, args) -> None:
     """Handle --summary command."""
     if args.json:
         summary = reader.get_summary()
-        output_json({
-            "violation_type": summary.violation_type,
-            "violation_name": summary.violation_name,
-            "trace_length": summary.trace_length,
-            "actions": summary.actions,
-            "statistics": summary.statistics,
-        }, args.compact)
+        output_json(
+            {
+                "violation_type": summary.violation_type,
+                "violation_name": summary.violation_name,
+                "trace_length": summary.trace_length,
+                "actions": summary.actions,
+                "statistics": summary.statistics,
+            },
+            args.compact,
+        )
     else:
         print(reader.format_summary())
 
@@ -216,7 +223,7 @@ def handle_state(reader: TLCOutputReader, args) -> None:
     variables = args.var_paths if args.var_paths else None
 
     try:
-        if args.var_paths and len(args.var_paths) == 1 and '.' in args.var_paths[0]:
+        if args.var_paths and len(args.var_paths) == 1 and "." in args.var_paths[0]:
             # Single path query - get just that value
             value = reader.get_variable_at_path(index, args.var_paths[0])
             if args.json:
@@ -227,12 +234,15 @@ def handle_state(reader: TLCOutputReader, args) -> None:
             # Get full state or filtered state
             state = reader.get_state(index, variables)
             if args.json:
-                output_json({
-                    "index": state.index,
-                    "action": state.action,
-                    "action_detail": state.action_detail,
-                    "variables": state.variables,
-                }, args.compact)
+                output_json(
+                    {
+                        "index": state.index,
+                        "action": state.action,
+                        "action_detail": state.action_detail,
+                        "variables": state.variables,
+                    },
+                    args.compact,
+                )
             else:
                 print(reader.format_state(index, variables, max_depth=args.max_depth))
     except (IndexError, ValueError) as e:
@@ -248,11 +258,17 @@ def handle_states(reader: TLCOutputReader, args) -> None:
         states = reader.get_states(args.states, variables)
 
         if args.json:
-            output_json([{
-                "index": s.index,
-                "action": s.action,
-                "variables": s.variables,
-            } for s in states], args.compact)
+            output_json(
+                [
+                    {
+                        "index": s.index,
+                        "action": s.action,
+                        "variables": s.variables,
+                    }
+                    for s in states
+                ],
+                args.compact,
+            )
         else:
             for state in states:
                 print(reader.format_state(state.index, variables, max_depth=args.max_depth))
@@ -265,8 +281,8 @@ def handle_states(reader: TLCOutputReader, args) -> None:
 def handle_diff(reader: TLCOutputReader, args) -> None:
     """Handle --diff command."""
     try:
-        index1 = int(args.diff[0]) if args.diff[0].lstrip('-').isdigit() else args.diff[0]
-        index2 = int(args.diff[1]) if args.diff[1].lstrip('-').isdigit() else args.diff[1]
+        index1 = int(args.diff[0]) if args.diff[0].lstrip("-").isdigit() else args.diff[0]
+        index2 = int(args.diff[1]) if args.diff[1].lstrip("-").isdigit() else args.diff[1]
     except ValueError:
         print(f"Error: Invalid state indices: {args.diff}", file=sys.stderr)
         sys.exit(1)
@@ -281,12 +297,12 @@ def handle_diff(reader: TLCOutputReader, args) -> None:
             print(f"Actions: {diff['state1_action']} -> {diff['state2_action']}")
             print()
 
-            if not diff['changed_variables']:
+            if not diff["changed_variables"]:
                 print("No changes detected.")
             else:
                 print(f"Changed variables ({len(diff['changed_variables'])}):")
-                for var_name in diff['changed_variables']:
-                    change = diff['changes'][var_name]
+                for var_name in diff["changed_variables"]:
+                    change = diff["changes"][var_name]
                     print(f"\n  {var_name}:")
                     print(f"    Before: {format_value(change['before'], max_depth=2)}")
                     print(f"    After:  {format_value(change['after'], max_depth=2)}")
@@ -298,8 +314,8 @@ def handle_diff(reader: TLCOutputReader, args) -> None:
 def handle_track(reader: TLCOutputReader, args) -> None:
     """Handle --track command."""
     # Check if tracking a path
-    if '.' in args.track:
-        parts = args.track.split('.', 1)
+    if "." in args.track:
+        parts = args.track.split(".", 1)
         var_name, path = parts[0], parts[1]
     else:
         var_name, path = args.track, None
@@ -338,7 +354,7 @@ def handle_actions(reader: TLCOutputReader, args) -> None:
                 print(f"{action_info['index']:3d}. {action_info['action']}")
             else:
                 print(f"State {action_info['index']:3d}: {action_info['action']}")
-                if action_info['detail']:
+                if action_info["detail"]:
                     print(f"            {action_info['detail']}")
 
 

--- a/tools/inv_checking_tool/src/mcp/handlers/__init__.py
+++ b/tools/inv_checking_tool/src/mcp/handlers/__init__.py
@@ -1,8 +1,8 @@
 """MCP tool handlers."""
 
-from .summary import SummaryHandler
-from .state import StateHandler
 from .compare import CompareHandler
+from .state import StateHandler
+from .summary import SummaryHandler
 from .trace_replay import TraceReplayHandler
 
 __all__ = ["SummaryHandler", "StateHandler", "CompareHandler", "TraceReplayHandler"]

--- a/tools/inv_checking_tool/src/mcp/handlers/base.py
+++ b/tools/inv_checking_tool/src/mcp/handlers/base.py
@@ -19,11 +19,13 @@ class HandlerError(Exception):
 
 class ValidationError(HandlerError):
     """Error during argument validation."""
+
     pass
 
 
 class ExecutionError(HandlerError):
     """Error during tool execution."""
+
     pass
 
 
@@ -56,12 +58,7 @@ class BaseHandler(ABC):
         """
         pass
 
-    def _format_error(
-        self,
-        error_type: str,
-        error_message: str,
-        details: Dict[str, Any] = None
-    ) -> str:
+    def _format_error(self, error_type: str, error_message: str, details: Dict[str, Any] = None) -> str:
         """Format an error response as JSON."""
         response = {
             "success": False,
@@ -69,7 +66,7 @@ class BaseHandler(ABC):
                 "type": error_type,
                 "message": error_message,
                 "tool": self.tool_name,
-            }
+            },
         }
         if details:
             response["error"]["details"] = details
@@ -106,8 +103,4 @@ class BaseHandler(ABC):
         except Exception as e:
             logger.error(f"[{self.tool_name}] Unexpected error: {e}")
             logger.error(traceback.format_exc())
-            return self._format_error(
-                "UnexpectedError",
-                str(e),
-                {"traceback": traceback.format_exc()}
-            )
+            return self._format_error("UnexpectedError", str(e), {"traceback": traceback.format_exc()})

--- a/tools/inv_checking_tool/src/mcp/handlers/base.py
+++ b/tools/inv_checking_tool/src/mcp/handlers/base.py
@@ -4,7 +4,7 @@ import json
 import logging
 import traceback
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class HandlerError(Exception):
     """Base error for handler operations."""
 
-    def __init__(self, message: str, details: Dict[str, Any] = None):
+    def __init__(self, message: str, details: dict[str, Any] = None):
         super().__init__(message)
         self.details = details or {}
 
@@ -44,7 +44,7 @@ class BaseHandler(ABC):
         pass
 
     @abstractmethod
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Execute the tool logic.
 
         Args:
@@ -58,7 +58,7 @@ class BaseHandler(ABC):
         """
         pass
 
-    def _format_error(self, error_type: str, error_message: str, details: Dict[str, Any] = None) -> str:
+    def _format_error(self, error_type: str, error_message: str, details: dict[str, Any] = None) -> str:
         """Format an error response as JSON."""
         response = {
             "success": False,
@@ -72,7 +72,7 @@ class BaseHandler(ABC):
             response["error"]["details"] = details
         return json.dumps(response, indent=2)
 
-    async def handle(self, arguments: Dict[str, Any]) -> str:
+    async def handle(self, arguments: dict[str, Any]) -> str:
         """Handle tool call with error handling.
 
         Args:

--- a/tools/inv_checking_tool/src/mcp/handlers/compare.py
+++ b/tools/inv_checking_tool/src/mcp/handlers/compare.py
@@ -90,9 +90,9 @@ class CompareHandler(BaseHandler):
         except FileNotFoundError:
             raise
         except (IndexError, ValueError) as e:
-            raise ExecutionError(f"Invalid index: {e}")
+            raise ExecutionError(f"Invalid index: {e}") from e
         except Exception as e:
-            raise ExecutionError(f"Error comparing states: {e}")
+            raise ExecutionError(f"Error comparing states: {e}") from e
 
     async def _track_variable(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Track changes to a variable."""
@@ -116,4 +116,4 @@ class CompareHandler(BaseHandler):
         except FileNotFoundError:
             raise
         except Exception as e:
-            raise ExecutionError(f"Error tracking variable: {e}")
+            raise ExecutionError(f"Error tracking variable: {e}") from e

--- a/tools/inv_checking_tool/src/mcp/handlers/compare.py
+++ b/tools/inv_checking_tool/src/mcp/handlers/compare.py
@@ -1,9 +1,9 @@
 """Handler for compare_tlc_states tool."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
-from .base import BaseHandler, ValidationError, ExecutionError
 from ...tlc_output_reader import TLCOutputReader
+from .base import BaseHandler, ExecutionError, ValidationError
 
 
 class CompareHandler(BaseHandler):
@@ -18,7 +18,7 @@ class CompareHandler(BaseHandler):
     def tool_name(self) -> str:
         return "compare_tlc_states"
 
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Execute the compare_tlc_states tool.
 
         Args:
@@ -66,7 +66,7 @@ class CompareHandler(BaseHandler):
                 "  - 'track_variable' to track variable changes"
             )
 
-    async def _compare_states(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def _compare_states(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Compare two states."""
         file_path = arguments["file_path"]
         index1 = arguments["index1"]
@@ -94,7 +94,7 @@ class CompareHandler(BaseHandler):
         except Exception as e:
             raise ExecutionError(f"Error comparing states: {e}")
 
-    async def _track_variable(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def _track_variable(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Track changes to a variable."""
         file_path = arguments["file_path"]
         variable = arguments["track_variable"]

--- a/tools/inv_checking_tool/src/mcp/handlers/state.py
+++ b/tools/inv_checking_tool/src/mcp/handlers/state.py
@@ -60,9 +60,7 @@ class StateHandler(BaseHandler):
         path = arguments.get("path")
 
         if index is None and indices is None:
-            raise ValidationError(
-                "Must provide either 'index' (single state) or 'indices' (multiple states)"
-            )
+            raise ValidationError("Must provide either 'index' (single state) or 'indices' (multiple states)")
 
         try:
             reader = TLCOutputReader(file_path)
@@ -87,12 +85,7 @@ class StateHandler(BaseHandler):
         except Exception as e:
             raise ExecutionError(f"Error reading state: {e}")
 
-    def _query_path(
-        self,
-        reader: TLCOutputReader,
-        index: Union[int, str],
-        path: str
-    ) -> Dict[str, Any]:
+    def _query_path(self, reader: TLCOutputReader, index: Union[int, str], path: str) -> Dict[str, Any]:
         """Query a nested value at a path."""
         value = reader.get_variable_at_path(index, path)
         state = reader.get_state(index)
@@ -105,10 +98,7 @@ class StateHandler(BaseHandler):
         }
 
     def _get_single_state(
-        self,
-        reader: TLCOutputReader,
-        index: Union[int, str],
-        variables: Optional[List[str]]
+        self, reader: TLCOutputReader, index: Union[int, str], variables: Optional[List[str]]
     ) -> Dict[str, Any]:
         """Get a single state."""
         state = reader.get_state(index, variables)
@@ -121,10 +111,7 @@ class StateHandler(BaseHandler):
         }
 
     def _get_multiple_states(
-        self,
-        reader: TLCOutputReader,
-        indices: Union[str, List],
-        variables: Optional[List[str]]
+        self, reader: TLCOutputReader, indices: Union[str, List], variables: Optional[List[str]]
     ) -> Dict[str, Any]:
         """Get multiple states."""
         states = reader.get_states(indices, variables)

--- a/tools/inv_checking_tool/src/mcp/handlers/state.py
+++ b/tools/inv_checking_tool/src/mcp/handlers/state.py
@@ -1,10 +1,10 @@
 """Handler for get_tlc_state tool."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
-from .base import BaseHandler, ValidationError, ExecutionError
 from ...tlc_output_reader import TLCOutputReader
 from ...utils.path_parser import PathAccessError
+from .base import BaseHandler, ExecutionError, ValidationError
 
 
 class StateHandler(BaseHandler):
@@ -21,7 +21,7 @@ class StateHandler(BaseHandler):
     def tool_name(self) -> str:
         return "get_tlc_state"
 
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Execute the get_tlc_state tool.
 
         Args:
@@ -85,7 +85,7 @@ class StateHandler(BaseHandler):
         except Exception as e:
             raise ExecutionError(f"Error reading state: {e}")
 
-    def _query_path(self, reader: TLCOutputReader, index: Union[int, str], path: str) -> Dict[str, Any]:
+    def _query_path(self, reader: TLCOutputReader, index: int | str, path: str) -> dict[str, Any]:
         """Query a nested value at a path."""
         value = reader.get_variable_at_path(index, path)
         state = reader.get_state(index)
@@ -98,8 +98,8 @@ class StateHandler(BaseHandler):
         }
 
     def _get_single_state(
-        self, reader: TLCOutputReader, index: Union[int, str], variables: Optional[List[str]]
-    ) -> Dict[str, Any]:
+        self, reader: TLCOutputReader, index: int | str, variables: list[str] | None
+    ) -> dict[str, Any]:
         """Get a single state."""
         state = reader.get_state(index, variables)
 
@@ -111,8 +111,8 @@ class StateHandler(BaseHandler):
         }
 
     def _get_multiple_states(
-        self, reader: TLCOutputReader, indices: Union[str, List], variables: Optional[List[str]]
-    ) -> Dict[str, Any]:
+        self, reader: TLCOutputReader, indices: str | list, variables: list[str] | None
+    ) -> dict[str, Any]:
         """Get multiple states."""
         states = reader.get_states(indices, variables)
 

--- a/tools/inv_checking_tool/src/mcp/handlers/state.py
+++ b/tools/inv_checking_tool/src/mcp/handlers/state.py
@@ -79,11 +79,11 @@ class StateHandler(BaseHandler):
         except FileNotFoundError:
             raise
         except PathAccessError as e:
-            raise ExecutionError(f"Path access error: {e}")
+            raise ExecutionError(f"Path access error: {e}") from e
         except (IndexError, ValueError) as e:
-            raise ExecutionError(f"Invalid index: {e}")
+            raise ExecutionError(f"Invalid index: {e}") from e
         except Exception as e:
-            raise ExecutionError(f"Error reading state: {e}")
+            raise ExecutionError(f"Error reading state: {e}") from e
 
     def _query_path(self, reader: TLCOutputReader, index: int | str, path: str) -> dict[str, Any]:
         """Query a nested value at a path."""

--- a/tools/inv_checking_tool/src/mcp/handlers/summary.py
+++ b/tools/inv_checking_tool/src/mcp/handlers/summary.py
@@ -1,9 +1,9 @@
 """Handler for get_tlc_summary tool."""
 
-from typing import Any, Dict
+from typing import Any
 
-from .base import BaseHandler, ValidationError, ExecutionError
 from ...tlc_output_reader import TLCOutputReader
+from .base import BaseHandler, ExecutionError, ValidationError
 
 
 class SummaryHandler(BaseHandler):
@@ -18,7 +18,7 @@ class SummaryHandler(BaseHandler):
     def tool_name(self) -> str:
         return "get_tlc_summary"
 
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Execute the get_tlc_summary tool.
 
         Args:

--- a/tools/inv_checking_tool/src/mcp/handlers/summary.py
+++ b/tools/inv_checking_tool/src/mcp/handlers/summary.py
@@ -61,6 +61,6 @@ class SummaryHandler(BaseHandler):
         except FileNotFoundError:
             raise
         except ValueError as e:
-            raise ExecutionError(f"Failed to parse TLC output: {e}")
+            raise ExecutionError(f"Failed to parse TLC output: {e}") from e
         except Exception as e:
-            raise ExecutionError(f"Error reading TLC output: {e}")
+            raise ExecutionError(f"Error reading TLC output: {e}") from e

--- a/tools/inv_checking_tool/src/mcp/handlers/trace_replay.py
+++ b/tools/inv_checking_tool/src/mcp/handlers/trace_replay.py
@@ -1,10 +1,10 @@
 """Handler for run_trace_replay tool."""
 
 import os
-from typing import Any, Dict
+from typing import Any
 
-from .base import BaseHandler, ValidationError, ExecutionError
-from ...trace_replay_tool import TraceReplayer, TraceFormat
+from ...trace_replay_tool import TraceFormat, TraceReplayer
+from .base import BaseHandler, ExecutionError, ValidationError
 
 
 class TraceReplayHandler(BaseHandler):
@@ -19,7 +19,7 @@ class TraceReplayHandler(BaseHandler):
     def tool_name(self) -> str:
         return "run_trace_replay"
 
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Execute trace replay.
 
         Args:

--- a/tools/inv_checking_tool/src/mcp/handlers/trace_replay.py
+++ b/tools/inv_checking_tool/src/mcp/handlers/trace_replay.py
@@ -58,8 +58,8 @@ class TraceReplayHandler(BaseHandler):
         fmt_str = arguments.get("trace_format", "json")
         try:
             trace_format = TraceFormat(fmt_str)
-        except ValueError:
-            raise ValidationError(f"Invalid trace_format: {fmt_str}. Must be 'json' or 'tlc'.")
+        except ValueError as e:
+            raise ValidationError(f"Invalid trace_format: {fmt_str}. Must be 'json' or 'tlc'.") from e
 
         # Determine output file path
         output_file = arguments.get("output_file")
@@ -90,6 +90,6 @@ class TraceReplayHandler(BaseHandler):
             }
 
         except RuntimeError as e:
-            raise ExecutionError(str(e))
+            raise ExecutionError(str(e)) from e
         except Exception as e:
-            raise ExecutionError(f"Trace replay failed: {e}")
+            raise ExecutionError(f"Trace replay failed: {e}") from e

--- a/tools/inv_checking_tool/src/mcp/handlers/trace_replay.py
+++ b/tools/inv_checking_tool/src/mcp/handlers/trace_replay.py
@@ -85,7 +85,7 @@ class TraceReplayHandler(BaseHandler):
                 "message": (
                     f"Trace replay complete. "
                     f"Use get_tlc_summary/get_tlc_state/compare_tlc_states "
-                    f"with file_path=\"{tlc_output_path}\" to analyze the result."
+                    f'with file_path="{tlc_output_path}" to analyze the result.'
                 ),
             }
 

--- a/tools/inv_checking_tool/src/mcp/server.py
+++ b/tools/inv_checking_tool/src/mcp/server.py
@@ -3,11 +3,11 @@
 import logging
 import sys
 
+from mcp import types
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp import types
 
-from .handlers import SummaryHandler, StateHandler, CompareHandler, TraceReplayHandler
+from .handlers import CompareHandler, StateHandler, SummaryHandler, TraceReplayHandler
 
 # Setup logging
 logging.basicConfig(

--- a/tools/inv_checking_tool/src/mcp/server.py
+++ b/tools/inv_checking_tool/src/mcp/server.py
@@ -68,11 +68,11 @@ class TLCOutputReaderMCPServer:
                         "properties": {
                             "file_path": {
                                 "type": "string",
-                                "description": "Path to TLC output file (e.g., 'nohup.out' or simulation log)"
+                                "description": "Path to TLC output file (e.g., 'nohup.out' or simulation log)",
                             }
                         },
-                        "required": ["file_path"]
-                    }
+                        "required": ["file_path"],
+                    },
                 ),
                 types.Tool(
                     name="get_tlc_state",
@@ -92,30 +92,27 @@ class TLCOutputReaderMCPServer:
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "file_path": {
-                                "type": "string",
-                                "description": "Path to TLC output file"
-                            },
+                            "file_path": {"type": "string", "description": "Path to TLC output file"},
                             "index": {
                                 "type": ["integer", "string"],
-                                "description": "State index: positive (1-indexed), negative (-1=last), or 'first'/'last'"
+                                "description": "State index: positive (1-indexed), negative (-1=last), or 'first'/'last'",
                             },
                             "indices": {
                                 "type": ["string", "array"],
-                                "description": "Multiple states: range '1:5', '-3:', or list [1,5,10]"
+                                "description": "Multiple states: range '1:5', '-3:', or list [1,5,10]",
                             },
                             "variables": {
                                 "type": "array",
                                 "items": {"type": "string"},
-                                "description": "Filter to these variables only"
+                                "description": "Filter to these variables only",
                             },
                             "path": {
                                 "type": "string",
-                                "description": "Dot-separated path for nested access: 'log.s1.entries[0]'"
-                            }
+                                "description": "Dot-separated path for nested access: 'log.s1.entries[0]'",
+                            },
                         },
-                        "required": ["file_path"]
-                    }
+                        "required": ["file_path"],
+                    },
                 ),
                 types.Tool(
                     name="compare_tlc_states",
@@ -134,29 +131,26 @@ class TLCOutputReaderMCPServer:
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "file_path": {
-                                "type": "string",
-                                "description": "Path to TLC output file"
-                            },
+                            "file_path": {"type": "string", "description": "Path to TLC output file"},
                             "index1": {
                                 "type": ["integer", "string"],
-                                "description": "First state index (for compare mode)"
+                                "description": "First state index (for compare mode)",
                             },
                             "index2": {
                                 "type": ["integer", "string"],
-                                "description": "Second state index (for compare mode)"
+                                "description": "Second state index (for compare mode)",
                             },
                             "track_variable": {
                                 "type": "string",
-                                "description": "Variable name to track (for track mode)"
+                                "description": "Variable name to track (for track mode)",
                             },
                             "track_path": {
                                 "type": "string",
-                                "description": "Sub-path within variable: 's1' for 'state.s1'"
-                            }
+                                "description": "Sub-path within variable: 's1' for 'state.s1'",
+                            },
                         },
-                        "required": ["file_path"]
-                    }
+                        "required": ["file_path"],
+                    },
                 ),
                 types.Tool(
                     name="run_trace_replay",
@@ -177,46 +171,34 @@ class TLCOutputReaderMCPServer:
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "spec_file": {
-                                "type": "string",
-                                "description": "TLA+ spec file name (e.g., 'Spec.tla')"
-                            },
+                            "spec_file": {"type": "string", "description": "TLA+ spec file name (e.g., 'Spec.tla')"},
                             "trace_file": {
                                 "type": "string",
-                                "description": "Input trace file path (relative to work_dir or absolute)"
+                                "description": "Input trace file path (relative to work_dir or absolute)",
                             },
-                            "work_dir": {
-                                "type": "string",
-                                "description": "Working directory containing the spec"
-                            },
+                            "work_dir": {"type": "string", "description": "Working directory containing the spec"},
                             "config_file": {
                                 "type": "string",
-                                "description": "Config file name (can contain ALIAS definition)"
+                                "description": "Config file name (can contain ALIAS definition)",
                             },
                             "output_file": {
                                 "type": "string",
-                                "description": "Output JSON file path (auto-generated if omitted)"
+                                "description": "Output JSON file path (auto-generated if omitted)",
                             },
                             "trace_format": {
                                 "type": "string",
                                 "description": "Input trace format: 'json' (default) or 'tlc'",
-                                "enum": ["json", "tlc"]
+                                "enum": ["json", "tlc"],
                             },
-                            "tla_jar": {
-                                "type": "string",
-                                "description": "Path to tla2tools.jar (optional)"
-                            },
+                            "tla_jar": {"type": "string", "description": "Path to tla2tools.jar (optional)"},
                             "community_jar": {
                                 "type": "string",
-                                "description": "Path to CommunityModules-deps.jar (optional)"
+                                "description": "Path to CommunityModules-deps.jar (optional)",
                             },
-                            "timeout": {
-                                "type": "integer",
-                                "description": "Timeout in seconds (default: 300)"
-                            }
+                            "timeout": {"type": "integer", "description": "Timeout in seconds (default: 300)"},
                         },
-                        "required": ["spec_file", "trace_file", "work_dir"]
-                    }
+                        "required": ["spec_file", "trace_file", "work_dir"],
+                    },
                 ),
             ]
 
@@ -229,10 +211,7 @@ class TLCOutputReaderMCPServer:
             if name not in self.handlers:
                 error_msg = f"Unknown tool: {name}"
                 logger.error(error_msg)
-                return [types.TextContent(
-                    type="text",
-                    text=f'{{"success": false, "error": "{error_msg}"}}'
-                )]
+                return [types.TextContent(type="text", text=f'{{"success": false, "error": "{error_msg}"}}')]
 
             handler = self.handlers[name]
             result = await handler.handle(arguments)
@@ -245,8 +224,4 @@ class TLCOutputReaderMCPServer:
         logger.info(f"Registered {len(self.handlers)} tools")
 
         async with stdio_server() as (read_stream, write_stream):
-            await self.server.run(
-                read_stream,
-                write_stream,
-                self.server.create_initialization_options()
-            )
+            await self.server.run(read_stream, write_stream, self.server.create_initialization_options())

--- a/tools/inv_checking_tool/src/tlc_output_reader.py
+++ b/tools/inv_checking_tool/src/tlc_output_reader.py
@@ -46,6 +46,7 @@ from .trace_reader import TraceReader
 @dataclass
 class StateInfo:
     """Information about a single state in the trace."""
+
     index: int  # 1-indexed state number
     action: Optional[str]  # Action name (e.g., "MCInit", "HandleRequestVoteRequest")
     action_detail: Optional[str]  # Full action string with location
@@ -55,6 +56,7 @@ class StateInfo:
 @dataclass
 class TraceSummary:
     """Summary information about the TLC trace."""
+
     violation_type: Optional[str]  # "invariant" or "property"
     violation_name: Optional[str]  # Name of the violated invariant/property
     trace_length: int  # Number of states in the trace
@@ -154,8 +156,7 @@ class TLCOutputReader:
         """Load trace from a JSON counterexample file."""
         if not counterexample_path:
             raise ValueError(
-                "JSON mode requires a counterexample path in TLC output. "
-                "Expected 'CounterExample written: <file>'."
+                "JSON mode requires a counterexample path in TLC output. Expected 'CounterExample written: <file>'."
             )
 
         trace_path = Path(counterexample_path)
@@ -176,8 +177,7 @@ class TLCOutputReader:
         """Load trace by parsing raw TLC text output using TraceReader."""
         if ERROR_BEHAVIOR_MARKER not in content:
             raise ValueError(
-                "Text mode requires an error trace in TLC output. "
-                f"Expected '{ERROR_BEHAVIOR_MARKER}' marker."
+                f"Text mode requires an error trace in TLC output. Expected '{ERROR_BEHAVIOR_MARKER}' marker."
             )
 
         trace_content = convert_to_trace_format(content)
@@ -189,8 +189,8 @@ class TLCOutputReader:
             self._states.append(state)
 
             action_detail = None
-            for line in state_str.split('\n'):
-                if line.startswith('\\*') and '<' in line:
+            for line in state_str.split("\n"):
+                if line.startswith("\\*") and "<" in line:
                     action_detail = line.strip()[2:].strip()
                     break
             self._action_details.append(action_detail)
@@ -281,9 +281,7 @@ class TLCOutputReader:
                 try:
                     index = int(index)
                 except ValueError:
-                    raise ValueError(
-                        f"Invalid index: {index}. Use positive int, negative int, 'first', or 'last'."
-                    )
+                    raise ValueError(f"Invalid index: {index}. Use positive int, negative int, 'first', or 'last'.")
 
         if not self._states:
             raise IndexError("Trace is empty")
@@ -298,8 +296,7 @@ class TLCOutputReader:
 
         if idx < 0 or idx >= len(self._states):
             raise IndexError(
-                f"State index {index} out of range. "
-                f"Valid range: 1 to {len(self._states)} or -1 to -{len(self._states)}"
+                f"State index {index} out of range. Valid range: 1 to {len(self._states)} or -1 to -{len(self._states)}"
             )
 
         return idx
@@ -316,31 +313,31 @@ class TLCOutputReader:
         range_str = range_str.strip()
 
         # Handle comma-separated list
-        if ',' in range_str:
+        if "," in range_str:
             indices = []
-            for part in range_str.split(','):
+            for part in range_str.split(","):
                 idx = self._normalize_index(part.strip())
                 indices.append(idx)
             return indices
 
         # Handle range with colon
-        if ':' not in range_str:
+        if ":" not in range_str:
             return [self._normalize_index(range_str)]
 
-        parts = range_str.split(':')
+        parts = range_str.split(":")
         if len(parts) != 2:
             raise ValueError(f"Invalid range format: {range_str}")
 
         start_str, end_str = parts
 
         # Parse start
-        if start_str.strip() == '':
+        if start_str.strip() == "":
             start = 0
         else:
             start = self._normalize_index(start_str.strip())
 
         # Parse end
-        if end_str.strip() == '':
+        if end_str.strip() == "":
             end = len(self._states)
         else:
             # End is inclusive in our API
@@ -361,15 +358,15 @@ class TLCOutputReader:
         """
         actions = []
         for state in self._states:
-            action = state.get('_action', 'Unknown')
+            action = state.get("_action", "Unknown")
             actions.append(action)
 
         return TraceSummary(
-            violation_type=self._metadata.get('violation_type'),
-            violation_name=self._metadata.get('violation_name'),
+            violation_type=self._metadata.get("violation_type"),
+            violation_name=self._metadata.get("violation_name"),
             trace_length=len(self._states),
             actions=actions,
-            statistics=self._metadata.get('statistics', {}),
+            statistics=self._metadata.get("statistics", {}),
         )
 
     def get_state(
@@ -391,9 +388,9 @@ class TLCOutputReader:
             StateInfo object with state data.
 
         Examples:
-            >>> reader.get_state(1)        # First state
-            >>> reader.get_state(-1)       # Last state
-            >>> reader.get_state("last")   # Also last state
+            >>> reader.get_state(1)  # First state
+            >>> reader.get_state(-1)  # Last state
+            >>> reader.get_state("last")  # Also last state
             >>> reader.get_state(5, variables=["currentTerm", "state"])
         """
         idx = self._normalize_index(index)
@@ -406,7 +403,7 @@ class TLCOutputReader:
             for var in variables:
                 if var in state:
                     filtered[var] = state[var]
-                elif not var.startswith('_'):
+                elif not var.startswith("_"):
                     # Try to find case-insensitive match
                     for k, v in state.items():
                         if k.lower() == var.lower():
@@ -415,11 +412,11 @@ class TLCOutputReader:
             vars_dict = filtered
         else:
             # Exclude internal keys
-            vars_dict = {k: v for k, v in state.items() if not k.startswith('_')}
+            vars_dict = {k: v for k, v in state.items() if not k.startswith("_")}
 
         return StateInfo(
             index=idx + 1,  # Return 1-indexed
-            action=state.get('_action'),
+            action=state.get("_action"),
             action_detail=action_detail,
             variables=vars_dict,
         )
@@ -442,10 +439,10 @@ class TLCOutputReader:
             List of StateInfo objects.
 
         Examples:
-            >>> reader.get_states([1, -1])           # First and last
-            >>> reader.get_states("1:5")             # States 1-5
-            >>> reader.get_states("-3:")             # Last 3 states
-            >>> reader.get_states("1,5,10")          # States 1, 5, 10
+            >>> reader.get_states([1, -1])  # First and last
+            >>> reader.get_states("1:5")  # States 1-5
+            >>> reader.get_states("-3:")  # Last 3 states
+            >>> reader.get_states("1,5,10")  # States 1, 5, 10
         """
         if isinstance(indices, str):
             idx_list = self._parse_range(indices)
@@ -515,7 +512,7 @@ class TLCOutputReader:
         state = self._states[idx]
 
         # Remove internal keys for cleaner access
-        clean_state = {k: v for k, v in state.items() if not k.startswith('_')}
+        clean_state = {k: v for k, v in state.items() if not k.startswith("_")}
 
         return get_value_at_path(clean_state, path)
 
@@ -529,7 +526,7 @@ class TLCOutputReader:
             return []
 
         # Get from first state (all states should have same variables)
-        return sorted([k for k in self._states[0].keys() if not k.startswith('_')])
+        return sorted([k for k in self._states[0].keys() if not k.startswith("_")])
 
     def get_actions_list(self) -> List[Dict[str, Any]]:
         """Get the sequence of actions in the trace.
@@ -546,11 +543,13 @@ class TLCOutputReader:
         """
         result = []
         for i, state in enumerate(self._states):
-            result.append({
-                "index": i + 1,
-                "action": state.get('_action', 'Unknown'),
-                "detail": self._action_details[i] if i < len(self._action_details) else None,
-            })
+            result.append(
+                {
+                    "index": i + 1,
+                    "action": state.get("_action", "Unknown"),
+                    "detail": self._action_details[i] if i < len(self._action_details) else None,
+                }
+            )
         return result
 
     def compare_states(
@@ -586,7 +585,7 @@ class TLCOutputReader:
         state2 = self._states[idx2]
 
         ignore_vars = set(ignore_vars or [])
-        ignore_vars.add('_action')  # Always ignore internal keys
+        ignore_vars.add("_action")  # Always ignore internal keys
 
         changed_variables = []
         changes = {}
@@ -594,7 +593,7 @@ class TLCOutputReader:
         # Compare all variables
         all_keys = set(state1.keys()) | set(state2.keys())
         for key in sorted(all_keys):
-            if key.startswith('_') or key in ignore_vars:
+            if key.startswith("_") or key in ignore_vars:
                 continue
 
             val1 = state1.get(key)
@@ -612,8 +611,8 @@ class TLCOutputReader:
             "changes": changes,
             "state1_index": idx1 + 1,
             "state2_index": idx2 + 1,
-            "state1_action": state1.get('_action'),
-            "state2_action": state2.get('_action'),
+            "state1_action": state1.get("_action"),
+            "state2_action": state2.get("_action"),
         }
 
     def find_variable_changes(
@@ -651,8 +650,7 @@ class TLCOutputReader:
             try:
                 if path:
                     current_value = get_value_at_path(
-                        {k: v for k, v in state.items() if not k.startswith('_')},
-                        full_path
+                        {k: v for k, v in state.items() if not k.startswith("_")}, full_path
                     )
                 else:
                     current_value = state.get(variable_name)
@@ -660,13 +658,15 @@ class TLCOutputReader:
                 current_value = None
 
             if i > 0 and current_value != prev_value:
-                changes.append({
-                    "from_state": i,  # 1-indexed
-                    "to_state": i + 1,
-                    "action": state.get('_action'),
-                    "before": prev_value,
-                    "after": current_value,
-                })
+                changes.append(
+                    {
+                        "from_state": i,  # 1-indexed
+                        "to_state": i + 1,
+                        "action": state.get("_action"),
+                        "before": prev_value,
+                        "after": current_value,
+                    }
+                )
 
             prev_value = current_value
 
@@ -692,7 +692,7 @@ class TLCOutputReader:
         matching = []
         for i, state in enumerate(self._states):
             # Create clean state without internal keys
-            clean_state = {k: v for k, v in state.items() if not k.startswith('_')}
+            clean_state = {k: v for k, v in state.items() if not k.startswith("_")}
             if predicate(clean_state):
                 matching.append(i + 1)
         return matching
@@ -727,11 +727,11 @@ class TLCOutputReader:
         for var_name, var_value in sorted(state_info.variables.items()):
             formatted = format_value(var_value, max_depth=max_depth)
             # Indent multi-line values
-            if '\n' in formatted:
-                formatted = formatted.replace('\n', '\n    ')
+            if "\n" in formatted:
+                formatted = formatted.replace("\n", "\n    ")
             lines.append(f"  {var_name} = {formatted}")
 
-        return '\n'.join(lines)
+        return "\n".join(lines)
 
     def format_summary(self) -> str:
         """Format the trace summary for display.
@@ -782,7 +782,7 @@ class TLCOutputReader:
         lines.append("")
         lines.append("=" * 60)
 
-        return '\n'.join(lines)
+        return "\n".join(lines)
 
     def __repr__(self) -> str:
         """Return string representation."""

--- a/tools/inv_checking_tool/src/tlc_output_reader.py
+++ b/tools/inv_checking_tool/src/tlc_output_reader.py
@@ -279,8 +279,10 @@ class TLCOutputReader:
             else:
                 try:
                     index = int(index)
-                except ValueError:
-                    raise ValueError(f"Invalid index: {index}. Use positive int, negative int, 'first', or 'last'.")
+                except ValueError as e:
+                    raise ValueError(
+                        f"Invalid index: {index}. Use positive int, negative int, 'first', or 'last'."
+                    ) from e
 
         if not self._states:
             raise IndexError("Trace is empty")
@@ -330,17 +332,10 @@ class TLCOutputReader:
         start_str, end_str = parts
 
         # Parse start
-        if start_str.strip() == "":
-            start = 0
-        else:
-            start = self._normalize_index(start_str.strip())
+        start = 0 if start_str.strip() == "" else self._normalize_index(start_str.strip())
 
-        # Parse end
-        if end_str.strip() == "":
-            end = len(self._states)
-        else:
-            # End is inclusive in our API
-            end = self._normalize_index(end_str.strip()) + 1
+        # Parse end (end is inclusive in our API)
+        end = len(self._states) if end_str.strip() == "" else self._normalize_index(end_str.strip()) + 1
 
         return list(range(start, end))
 
@@ -480,7 +475,7 @@ class TLCOutputReader:
 
         raise KeyError(
             f"Variable '{variable_name}' not found in state {state_index}. "
-            f"Available: {[k for k in state.keys() if not k.startswith('_')]}"
+            f"Available: {[k for k in state if not k.startswith('_')]}"
         )
 
     def get_variable_at_path(
@@ -525,7 +520,7 @@ class TLCOutputReader:
             return []
 
         # Get from first state (all states should have same variables)
-        return sorted([k for k in self._states[0].keys() if not k.startswith("_")])
+        return sorted([k for k in self._states[0] if not k.startswith("_")])
 
     def get_actions_list(self) -> list[dict[str, Any]]:
         """Get the sequence of actions in the trace.

--- a/tools/inv_checking_tool/src/tlc_output_reader.py
+++ b/tools/inv_checking_tool/src/tlc_output_reader.py
@@ -26,21 +26,20 @@ Example usage:
 
 import io
 import json
-from typing import Any, Dict, List, Optional, Union
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
+from .trace_reader import TraceReader
+from .utils.path_parser import PathAccessError, format_value, get_value_at_path
 from .utils.preprocessing import (
     ERROR_BEHAVIOR_MARKER,
     convert_to_trace_format,
     extract_counterexample_path,
     extract_statistics,
     extract_violation_info,
-    preprocess_tlc_output,
     strip_ansi_codes,
 )
-from .utils.path_parser import get_value_at_path, format_value, PathAccessError
-from .trace_reader import TraceReader
 
 
 @dataclass
@@ -48,20 +47,20 @@ class StateInfo:
     """Information about a single state in the trace."""
 
     index: int  # 1-indexed state number
-    action: Optional[str]  # Action name (e.g., "MCInit", "HandleRequestVoteRequest")
-    action_detail: Optional[str]  # Full action string with location
-    variables: Dict[str, Any]  # State variables
+    action: str | None  # Action name (e.g., "MCInit", "HandleRequestVoteRequest")
+    action_detail: str | None  # Full action string with location
+    variables: dict[str, Any]  # State variables
 
 
 @dataclass
 class TraceSummary:
     """Summary information about the TLC trace."""
 
-    violation_type: Optional[str]  # "invariant" or "property"
-    violation_name: Optional[str]  # Name of the violated invariant/property
+    violation_type: str | None  # "invariant" or "property"
+    violation_name: str | None  # Name of the violated invariant/property
     trace_length: int  # Number of states in the trace
-    actions: List[str]  # List of action names
-    statistics: Dict[str, Any] = field(default_factory=dict)  # TLC statistics
+    actions: list[str]  # List of action names
+    statistics: dict[str, Any] = field(default_factory=dict)  # TLC statistics
 
 
 class TLCOutputReader:
@@ -100,9 +99,9 @@ class TLCOutputReader:
 
         self.file_path = file_path
         self.mode = mode
-        self._states: List[Dict[str, Any]] = []
-        self._metadata: Dict[str, Any] = {}
-        self._action_details: List[str] = []
+        self._states: list[dict[str, Any]] = []
+        self._metadata: dict[str, Any] = {}
+        self._action_details: list[str] = []
 
         self._load_and_parse(save_action_name)
 
@@ -152,7 +151,7 @@ class TLCOutputReader:
         else:
             self._load_text(content, save_action_name)
 
-    def _load_json(self, counterexample_path: Optional[str], save_action_name: bool) -> None:
+    def _load_json(self, counterexample_path: str | None, save_action_name: bool) -> None:
         """Load trace from a JSON counterexample file."""
         if not counterexample_path:
             raise ValueError(
@@ -200,9 +199,9 @@ class TLCOutputReader:
 
     def _parse_trace(
         self,
-        trace: Dict[str, Any],
+        trace: dict[str, Any],
         save_action_name: bool,
-    ) -> tuple[List[Dict[str, Any]], List[Optional[str]]]:
+    ) -> tuple[list[dict[str, Any]], list[str | None]]:
         action_by_state = {}
         detail_by_state = {}
         for entry in trace.get("action", []):
@@ -236,7 +235,7 @@ class TLCOutputReader:
         return states, details
 
     @staticmethod
-    def _format_action_detail(action: Dict[str, Any]) -> Optional[str]:
+    def _format_action_detail(action: dict[str, Any]) -> str | None:
         name = action.get("name")
         if not name:
             return None
@@ -254,7 +253,7 @@ class TLCOutputReader:
         """Return the number of states in the trace."""
         return len(self._states)
 
-    def _normalize_index(self, index: Union[int, str]) -> int:
+    def _normalize_index(self, index: int | str) -> int:
         """Convert various index formats to a 0-based index.
 
         Args:
@@ -301,7 +300,7 @@ class TLCOutputReader:
 
         return idx
 
-    def _parse_range(self, range_str: str) -> List[int]:
+    def _parse_range(self, range_str: str) -> list[int]:
         """Parse a range string into a list of 0-based indices.
 
         Args:
@@ -371,8 +370,8 @@ class TLCOutputReader:
 
     def get_state(
         self,
-        index: Union[int, str],
-        variables: Optional[List[str]] = None,
+        index: int | str,
+        variables: list[str] | None = None,
     ) -> StateInfo:
         """Get a single state by index.
 
@@ -423,9 +422,9 @@ class TLCOutputReader:
 
     def get_states(
         self,
-        indices: Union[str, List[Union[int, str]]],
-        variables: Optional[List[str]] = None,
-    ) -> List[StateInfo]:
+        indices: str | list[int | str],
+        variables: list[str] | None = None,
+    ) -> list[StateInfo]:
         """Get multiple states.
 
         Args:
@@ -453,7 +452,7 @@ class TLCOutputReader:
 
     def get_variable(
         self,
-        state_index: Union[int, str],
+        state_index: int | str,
         variable_name: str,
     ) -> Any:
         """Get a specific variable from a state.
@@ -486,7 +485,7 @@ class TLCOutputReader:
 
     def get_variable_at_path(
         self,
-        state_index: Union[int, str],
+        state_index: int | str,
         path: str,
     ) -> Any:
         """Get a nested variable value using path syntax.
@@ -516,7 +515,7 @@ class TLCOutputReader:
 
         return get_value_at_path(clean_state, path)
 
-    def get_all_variables(self) -> List[str]:
+    def get_all_variables(self) -> list[str]:
         """Get list of all variable names in the trace.
 
         Returns:
@@ -528,7 +527,7 @@ class TLCOutputReader:
         # Get from first state (all states should have same variables)
         return sorted([k for k in self._states[0].keys() if not k.startswith("_")])
 
-    def get_actions_list(self) -> List[Dict[str, Any]]:
+    def get_actions_list(self) -> list[dict[str, Any]]:
         """Get the sequence of actions in the trace.
 
         Returns:
@@ -554,10 +553,10 @@ class TLCOutputReader:
 
     def compare_states(
         self,
-        index1: Union[int, str],
-        index2: Union[int, str],
-        ignore_vars: Optional[List[str]] = None,
-    ) -> Dict[str, Any]:
+        index1: int | str,
+        index2: int | str,
+        ignore_vars: list[str] | None = None,
+    ) -> dict[str, Any]:
         """Compare two states and find differences.
 
         Args:
@@ -618,8 +617,8 @@ class TLCOutputReader:
     def find_variable_changes(
         self,
         variable_name: str,
-        path: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
+        path: str | None = None,
+    ) -> list[dict[str, Any]]:
         """Find all states where a variable changes.
 
         Args:
@@ -675,7 +674,7 @@ class TLCOutputReader:
     def search_states(
         self,
         predicate: callable,
-    ) -> List[int]:
+    ) -> list[int]:
         """Search for states matching a predicate.
 
         Args:
@@ -699,8 +698,8 @@ class TLCOutputReader:
 
     def format_state(
         self,
-        index: Union[int, str],
-        variables: Optional[List[str]] = None,
+        index: int | str,
+        variables: list[str] | None = None,
         max_depth: int = 4,
     ) -> str:
         """Format a state for display.

--- a/tools/inv_checking_tool/src/trace_reader.py
+++ b/tools/inv_checking_tool/src/trace_reader.py
@@ -66,34 +66,34 @@ class TraceReader:
                 level -= 1
                 if level == 0:
                     return i
-        assert False
+        raise AssertionError("unbalanced delimiters: no matching close found")
 
-    def _post_process_list(self, l, kind):
-        l = self._list_handler(l, kind)
+    def _post_process_list(self, items, kind):
+        items = self._list_handler(items, kind)
         if self.hashable:
             if kind is self.LIST_IS_SET:
-                l = frozenset(l)
+                items = frozenset(items)
             elif kind is self.LIST_IS_SEQ:
-                l = tuple(l)
-        return l
+                items = tuple(items)
+        return items
 
     # return a list
     def _lists(self, string, kind):
-        l = list()
+        items = list()
         if not string:
-            return self._post_process_list(l, kind)
+            return self._post_process_list(items, kind)
         processed, pos, length = 0, 0, len(string)
         while pos < length:
             if string[pos] in self._matching or string[pos] == ",":
                 if string[pos] != ",":
                     pos = pos + self._find_next_match(string[pos:]) + 1
-                l.append(self._variable_converter(string[processed:pos]))
+                items.append(self._variable_converter(string[processed:pos]))
                 processed = pos + 2
                 pos += 1
             pos += 1
         if pos != processed:
-            l.append(self._variable_converter(string[processed:pos]))
-        return self._post_process_list(l, kind)
+            items.append(self._variable_converter(string[processed:pos]))
+        return self._post_process_list(items, kind)
 
     # < string $
     def _chevrons(self, string):
@@ -182,10 +182,7 @@ class TraceReader:
     # convert MC.out to trace file
     @staticmethod
     def get_out_converted_string(file):
-        if not hasattr(file, "read"):
-            f = open(file)
-        else:
-            f = file
+        f = open(file) if not hasattr(file, "read") else file
 
         n_state = 0
         start_msg = "The behavior up to this point is:"
@@ -229,10 +226,7 @@ class TraceReader:
 
     @staticmethod
     def get_dot_converted_string(file):
-        if not hasattr(file, "read"):
-            f = open(file)
-        else:
-            f = file
+        f = open(file) if not hasattr(file, "read") else file
         yield "-" * 16 + " MODULE MC_dot " + "-" * 16 + "\n"
         for line in f:
             if ' [label="' in line:
@@ -244,10 +238,7 @@ class TraceReader:
         f.close()
 
     def get_dot_graph(self, file):
-        if not hasattr(file, "read"):
-            f = open(file)
-        else:
-            f = file
+        f = open(file) if not hasattr(file, "read") else file
         g = defaultdict(lambda: [])
         for line in f:
             if " -> " in line:
@@ -265,10 +256,7 @@ class TraceReader:
 
     # read trace file and yield states as python objects
     def trace_reader_with_state_str(self, file):
-        if not hasattr(file, "read"):
-            f = open(file)
-        else:
-            f = file
+        f = open(file) if not hasattr(file, "read") else file
 
         starting_chars = f.read(2)
         is_dot_file = False
@@ -357,10 +345,7 @@ if __name__ == "__main__":
         save_action_name=args.action, hashable=args.hash_data, sort_dict=args.sort_keys, handler_py=args.handler
     )
 
-    if not args.graph:
-        states = list(tr.trace_reader(args.trace_file))
-    else:
-        states = tr.get_dot_graph(args.trace_file)
+    states = list(tr.trace_reader(args.trace_file)) if not args.graph else tr.get_dot_graph(args.trace_file)
 
     def serialize_sets(obj):
         if isinstance(obj, frozenset):

--- a/tools/inv_checking_tool/src/trace_reader.py
+++ b/tools/inv_checking_tool/src/trace_reader.py
@@ -6,14 +6,18 @@ import os
 import sys
 from collections import OrderedDict, defaultdict
 
+
 class TraceReader:
     LIST_IS_SEQ = "seq"
     LIST_IS_SET = "set"
 
-    def __init__(self, save_action_name=False, hashable=False, sort_dict=False,
-                 handler_py=None):
-        self._matching = {'{': ('}', self._braces), '<': ('$', self._chevrons),
-            '[': (']', self._brackets), '(': (')', self._parentheses)}
+    def __init__(self, save_action_name=False, hashable=False, sort_dict=False, handler_py=None):
+        self._matching = {
+            "{": ("}", self._braces),
+            "<": ("$", self._chevrons),
+            "[": ("]", self._brackets),
+            "(": (")", self._parentheses),
+        }
 
         self._string_dict = {"TRUE": True, "FALSE": False}
         self._user_dict = dict()
@@ -27,21 +31,18 @@ class TraceReader:
         if self.hashable:
             self.sort_dict = True
 
-
     # set callback handlers from ENV 'HANDLER_PY'
     def set_handlers(self, handler_py=None):
         if handler_py is None:
-            handler_py = os.getenv('HANDLER_PY')
+            handler_py = os.getenv("HANDLER_PY")
             if handler_py is None:
                 return
         try:
             sys.path.insert(0, os.path.dirname(handler_py))
-            handler_module = __import__(
-                os.path.basename(handler_py).replace('.py', ''))
+            handler_module = __import__(os.path.basename(handler_py).replace(".py", ""))
             sys.path.pop(0)
         except ModuleNotFoundError:
-            print("Warning: cannot import module '{}'".format(handler_py),
-                  file=sys.stderr)
+            print("Warning: cannot import module '{}'".format(handler_py), file=sys.stderr)
             handler_module = None
 
         if hasattr(handler_module, "user_dict"):
@@ -52,7 +53,6 @@ class TraceReader:
             self.set_kv_handler(handler_module.outside_kv_handler, inside=False)
         if hasattr(handler_module, "inside_kv_handler"):
             self.set_kv_handler(handler_module.inside_kv_handler, inside=True)
-
 
     # find '}$])' for '{<[('
     def _find_next_match(self, string):
@@ -68,7 +68,6 @@ class TraceReader:
                     return i
         assert False
 
-
     def _post_process_list(self, l, kind):
         l = self._list_handler(l, kind)
         if self.hashable:
@@ -78,7 +77,6 @@ class TraceReader:
                 l = tuple(l)
         return l
 
-
     # return a list
     def _lists(self, string, kind):
         l = list()
@@ -86,8 +84,8 @@ class TraceReader:
             return self._post_process_list(l, kind)
         processed, pos, length = 0, 0, len(string)
         while pos < length:
-            if string[pos] in self._matching or string[pos] == ',':
-                if string[pos] != ',':
+            if string[pos] in self._matching or string[pos] == ",":
+                if string[pos] != ",":
                     pos = pos + self._find_next_match(string[pos:]) + 1
                 l.append(self._variable_converter(string[processed:pos]))
                 processed = pos + 2
@@ -97,22 +95,18 @@ class TraceReader:
             l.append(self._variable_converter(string[processed:pos]))
         return self._post_process_list(l, kind)
 
-
     # < string $
     def _chevrons(self, string):
         return self._lists(string, kind=self.LIST_IS_SEQ)
-
 
     # { string } (we treat set as list)
     def _braces(self, string):
         return self._lists(string, kind=self.LIST_IS_SET)
 
-
     # make dicts hashable if hash_data is True
     class HashableDict(OrderedDict):
         def __hash__(self):
             return hash(frozenset(self.items()))
-    
 
     # sort dict or make dict hashable
     def _post_process_dict(self, d):
@@ -123,23 +117,21 @@ class TraceReader:
         else:
             return d
 
-
     # return a dict
     def _dict_common(self, string, arrow, sep, value_seq_len):
         d = dict() if not self.hashable else self.HashableDict()
         processed, pos, length = 0, 0, len(string)
-        key, value = '', ''
+        key, value = "", ""
         while True:
             if string[pos] == arrow[0]:
-                key = string[processed:pos - 1]
+                key = string[processed : pos - 1]
                 pos += len(arrow)
                 processed = pos + 1
             if string[pos] == sep[0]:
-                value = string[processed:pos - value_seq_len]
+                value = string[processed : pos - value_seq_len]
                 pos += len(sep)
                 processed = pos + 1
-                key, value = self._kv_inside_handler(
-                    key, self._variable_converter(value))
+                key, value = self._kv_inside_handler(key, self._variable_converter(value))
                 d[key] = value
             pos += 1
             if pos >= length:
@@ -147,21 +139,17 @@ class TraceReader:
             if string[pos] in self._matching:
                 pos = pos + self._find_next_match(string[pos:])
         value = string[processed:]
-        key, value = self._kv_inside_handler(
-            key, self._variable_converter(value))
+        key, value = self._kv_inside_handler(key, self._variable_converter(value))
         d[key] = value
         return self._post_process_dict(d)
 
-
     # [ string ]
     def _brackets(self, string):
-        return self._dict_common(string, '|->', ',', 0)
-
+        return self._dict_common(string, "|->", ",", 0)
 
     # ( string )
     def _parentheses(self, string):
-        return self._dict_common(string, ':>', '@@', 1)
-
+        return self._dict_common(string, ":>", "@@", 1)
 
     # convert string to python variable
     def _variable_converter(self, string):
@@ -178,11 +166,9 @@ class TraceReader:
         except ValueError:
             return string
 
-
     # callback handlers
     def set_user_dict(self, user_dict):
         self._user_dict = user_dict
-
 
     def set_kv_handler(self, kv_handler, inside=False):
         if inside:
@@ -190,113 +176,106 @@ class TraceReader:
         else:
             self._kv_outside_handler = kv_handler
 
-
     def set_list_handler(self, list_handler):
         self._list_handler = list_handler
-
 
     # convert MC.out to trace file
     @staticmethod
     def get_out_converted_string(file):
-        if not hasattr(file, 'read'):
+        if not hasattr(file, "read"):
             f = open(file)
         else:
             f = file
 
         n_state = 0
-        start_msg = 'The behavior up to this point is:'
-        end_msg = ['Progress', 'The number of states generated', 'Worker: rmi']
+        start_msg = "The behavior up to this point is:"
+        end_msg = ["Progress", "The number of states generated", "Worker: rmi"]
         for line in f:
-            if 'TLC Server' in line:
+            if "TLC Server" in line:
                 continue
-            if line[0] != '@':
-                start_msg = 'Error: ' + start_msg
+            if line[0] != "@":
+                start_msg = "Error: " + start_msg
             break
         for line in f:
             if line.startswith(start_msg):
-                yield '-' * 16 + ' MODULE MC_trace ' + '-' * 16 + '\n'
+                yield "-" * 16 + " MODULE MC_trace " + "-" * 16 + "\n"
                 break
         for line in f:
-            if line[0] in '/ ':
+            if line[0] in "/ ":
                 yield line
-            elif line.startswith('State') or line[0].isdigit():
-                yield r'\*' + line[line.find(':')+1:]
+            elif line.startswith("State") or line[0].isdigit():
+                yield r"\*" + line[line.find(":") + 1 :]
                 n_state = n_state + 1
-                yield 'STATE_{} == \n'.format(n_state)
-            elif line == '\n':
-                yield '\n' * 2
+                yield "STATE_{} == \n".format(n_state)
+            elif line == "\n":
+                yield "\n" * 2
             elif any(line.startswith(x) for x in end_msg):
-                yield '=' * 49 + '\n'
+                yield "=" * 49 + "\n"
                 break
             else:
-                if line[0] != '@':
+                if line[0] != "@":
                     pass
 
         f.close()
 
-
     @staticmethod
     def get_dot_label_string(line):
-        space_idx = line.find(' ')
+        space_idx = line.find(" ")
         state_hash = line[:space_idx]
-        label_end_idx = 1 if line[-2] == ';' else 0
-        label_end_idx += 2 if line[-label_end_idx-3] == '"' else 17
-        label = eval(line[space_idx+8:-label_end_idx]) + '\n'
+        label_end_idx = 1 if line[-2] == ";" else 0
+        label_end_idx += 2 if line[-label_end_idx - 3] == '"' else 17
+        label = eval(line[space_idx + 8 : -label_end_idx]) + "\n"
         return int(state_hash), label
-
 
     @staticmethod
     def get_dot_converted_string(file):
-        if not hasattr(file, 'read'):
+        if not hasattr(file, "read"):
             f = open(file)
         else:
             f = file
-        yield '-' * 16 + ' MODULE MC_dot ' + '-' * 16 + '\n'
+        yield "-" * 16 + " MODULE MC_dot " + "-" * 16 + "\n"
         for line in f:
             if ' [label="' in line:
                 state_hash, label = TraceReader.get_dot_label_string(line)
-                yield 'STATE_{} == \n'.format(state_hash)
+                yield "STATE_{} == \n".format(state_hash)
                 yield from label.splitlines(keepends=True)
-                yield '\n' * 2
-        yield '=' * 49 + '\n'
+                yield "\n" * 2
+        yield "=" * 49 + "\n"
         f.close()
 
-
     def get_dot_graph(self, file):
-        if not hasattr(file, 'read'):
+        if not hasattr(file, "read"):
             f = open(file)
         else:
             f = file
         g = defaultdict(lambda: [])
         for line in f:
-            if ' -> ' in line:
-                a, b = map(int, line.rstrip(';\n').split(' -> '))
+            if " -> " in line:
+                a, b = map(int, line.rstrip(";\n").split(" -> "))
                 g[a].append(b)
         return self._post_process_dict(g)
 
-
     @staticmethod
     def get_action_name(line):
-        start = line.find('<')
-        end = line.find(' ', start)
+        start = line.find("<")
+        end = line.find(" ", start)
         if end > start > 0:
-            return line[start+1:end]
+            return line[start + 1 : end]
         return None
-
 
     # read trace file and yield states as python objects
     def trace_reader_with_state_str(self, file):
-        if not hasattr(file, 'read'):
+        if not hasattr(file, "read"):
             f = open(file)
         else:
             f = file
 
         starting_chars = f.read(2)
         is_dot_file = False
-        if starting_chars != '--':
-            if starting_chars == '@!':
+        if starting_chars != "--":
+            if starting_chars == "@!":
                 f = self.get_out_converted_string(f)
-            elif starting_chars == 'st':
+            elif starting_chars == "st":
                 f = self.get_dot_converted_string(f)
                 is_dot_file = True
             else:
@@ -308,27 +287,28 @@ class TraceReader:
         cur_action = None
         cur_action_line = None
         for line in f:
-            if line.startswith(r'\*'):
+            if line.startswith(r"\*"):
                 cur_action_line = line
                 if self.save_action_name:
                     cur_action = self.get_action_name(line)
             elif line[0] in "-=S":
                 if state:
                     state = self._post_process_dict(state)
-                    yield state, ''.join(lines).strip()
+                    yield state, "".join(lines).strip()
                     state = dict()
                 if cur_action is not None:
-                    state['_action'] = cur_action
-                if is_dot_file and line[0] == 'S':
-                    state['_hash'] = int(line[6:-4])
+                    state["_action"] = cur_action
+                if is_dot_file and line[0] == "S":
+                    state["_hash"] = int(line[6:-4])
                 lines = [] if cur_action_line is None else [cur_action_line]
             elif line[0] in "/\n":
                 if variable:
-                    k, v = variable.split('=')
+                    k, v = variable.split("=")
                     k, v = k.rstrip(), v.lstrip()
                     # replace to 1-char keywords, replace '>' to a uniq key
-                    k, v = self._kv_outside_handler(k, self._variable_converter(
-                        v.replace('<<', '<').replace('>>', '$')))
+                    k, v = self._kv_outside_handler(
+                        k, self._variable_converter(v.replace("<<", "<").replace(">>", "$"))
+                    )
                     state[k] = v
                 variable = line.strip()[3:]
                 lines.append(line)
@@ -337,7 +317,6 @@ class TraceReader:
                 lines.append(line)
 
         f.close()
-
 
     def trace_reader(self, file):
         for state, _ in self.trace_reader_with_state_str(file):
@@ -349,52 +328,48 @@ get_out_converted_string = TraceReader.get_out_converted_string
 get_dot_converted_string = TraceReader.get_dot_converted_string
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import json
     import argparse
 
     # arg parser
-    parser = argparse.ArgumentParser(
-        description="Read TLA traces into Python objects")
+    parser = argparse.ArgumentParser(description="Read TLA traces into Python objects")
 
-    parser.add_argument(dest='trace_file', action='store',
-                        help='TLA trace file')
-    parser.add_argument('-o', dest='json_file', action='store', required=False,
-                        help="output to json file")
-    parser.add_argument('-i', dest='indent', action='store', required=False,
-                        type=int, help="json file indent")
-    parser.add_argument('-p', dest='handler', action='store', required=False,
-                        help="python user_dict and list/kv handers")
-    parser.add_argument('-a', dest='action', action='store_true',
-                        required=False,
-                        help="save action name in '_action' key if available")
-    parser.add_argument('-d', dest='hash_data', action='store_true',
-                        required=False,
-                        help="make data structures hashable")
-    parser.add_argument('-s', dest='sort_keys', action='store_true',
-                        required=False,
-                        help="sort dict by keys, true if -d is defined")
-    parser.add_argument('-g', dest='graph', action='store_true', required=False,
-                        help="get dot file graph")
+    parser.add_argument(dest="trace_file", action="store", help="TLA trace file")
+    parser.add_argument("-o", dest="json_file", action="store", required=False, help="output to json file")
+    parser.add_argument("-i", dest="indent", action="store", required=False, type=int, help="json file indent")
+    parser.add_argument(
+        "-p", dest="handler", action="store", required=False, help="python user_dict and list/kv handers"
+    )
+    parser.add_argument(
+        "-a", dest="action", action="store_true", required=False, help="save action name in '_action' key if available"
+    )
+    parser.add_argument(
+        "-d", dest="hash_data", action="store_true", required=False, help="make data structures hashable"
+    )
+    parser.add_argument(
+        "-s", dest="sort_keys", action="store_true", required=False, help="sort dict by keys, true if -d is defined"
+    )
+    parser.add_argument("-g", dest="graph", action="store_true", required=False, help="get dot file graph")
     args = parser.parse_args()
 
-    tr = TraceReader(save_action_name=args.action, hashable=args.hash_data,
-                     sort_dict=args.sort_keys, handler_py=args.handler)
+    tr = TraceReader(
+        save_action_name=args.action, hashable=args.hash_data, sort_dict=args.sort_keys, handler_py=args.handler
+    )
 
     if not args.graph:
         states = list(tr.trace_reader(args.trace_file))
     else:
         states = tr.get_dot_graph(args.trace_file)
-    
+
     def serialize_sets(obj):
         if isinstance(obj, frozenset):
             return tuple(obj)
         return obj
-    
 
     if args.json_file:
-        with open(args.json_file, 'w') as f:
+        with open(args.json_file, "w") as f:
             json.dump(states, f, indent=args.indent, default=serialize_sets)
-            f.write('\n')
+            f.write("\n")
     else:
         print(json.dumps(states, indent=args.indent, default=serialize_sets))

--- a/tools/inv_checking_tool/src/trace_reader.py
+++ b/tools/inv_checking_tool/src/trace_reader.py
@@ -42,7 +42,7 @@ class TraceReader:
             handler_module = __import__(os.path.basename(handler_py).replace(".py", ""))
             sys.path.pop(0)
         except ModuleNotFoundError:
-            print("Warning: cannot import module '{}'".format(handler_py), file=sys.stderr)
+            print(f"Warning: cannot import module '{handler_py}'", file=sys.stderr)
             handler_module = None
 
         if hasattr(handler_module, "user_dict"):
@@ -206,7 +206,7 @@ class TraceReader:
             elif line.startswith("State") or line[0].isdigit():
                 yield r"\*" + line[line.find(":") + 1 :]
                 n_state = n_state + 1
-                yield "STATE_{} == \n".format(n_state)
+                yield f"STATE_{n_state} == \n"
             elif line == "\n":
                 yield "\n" * 2
             elif any(line.startswith(x) for x in end_msg):
@@ -237,7 +237,7 @@ class TraceReader:
         for line in f:
             if ' [label="' in line:
                 state_hash, label = TraceReader.get_dot_label_string(line)
-                yield "STATE_{} == \n".format(state_hash)
+                yield f"STATE_{state_hash} == \n"
                 yield from label.splitlines(keepends=True)
                 yield "\n" * 2
         yield "=" * 49 + "\n"
@@ -329,8 +329,8 @@ get_dot_converted_string = TraceReader.get_dot_converted_string
 
 
 if __name__ == "__main__":
-    import json
     import argparse
+    import json
 
     # arg parser
     parser = argparse.ArgumentParser(description="Read TLA traces into Python objects")

--- a/tools/inv_checking_tool/src/trace_replay_tool.py
+++ b/tools/inv_checking_tool/src/trace_replay_tool.py
@@ -43,7 +43,6 @@ Example:
 
 import asyncio
 import os
-from typing import Optional, List, Tuple
 from enum import Enum
 
 
@@ -61,10 +60,10 @@ class TraceReplayer:
     and output the result as a JSON file for further processing.
     """
 
-    def __init__(self, tla_jar: Optional[str] = None, community_jar: Optional[str] = None):
+    def __init__(self, tla_jar: str | None = None, community_jar: str | None = None):
         self.tla_jar, self.community_jar = self._resolve_jar_paths(tla_jar, community_jar)
 
-    def _resolve_jar_paths(self, tla_jar: Optional[str], community_jar: Optional[str]) -> Tuple[str, str]:
+    def _resolve_jar_paths(self, tla_jar: str | None, community_jar: str | None) -> tuple[str, str]:
         """Resolve JAR paths, using defaults if not provided."""
         if tla_jar is None or community_jar is None:
             specula_root = os.environ.get("SPECULA_ROOT")
@@ -89,10 +88,10 @@ class TraceReplayer:
         spec_file: str,
         input_trace: str,
         output_trace: str,
-        config_file: Optional[str],
+        config_file: str | None,
         trace_format: TraceFormat,
-        java_opts: Optional[List[str]] = None,
-    ) -> List[str]:
+        java_opts: list[str] | None = None,
+    ) -> list[str]:
         """Build the TLC command for trace replay."""
         classpath = f"{self.tla_jar}:{self.community_jar}"
 
@@ -115,12 +114,12 @@ class TraceReplayer:
         trace_file: str,
         work_dir: str,
         output_file: str,
-        config_file: Optional[str] = None,
+        config_file: str | None = None,
         trace_format: TraceFormat = TraceFormat.JSON,
-        java_opts: Optional[List[str]] = None,
+        java_opts: list[str] | None = None,
         timeout: int = 300,
-        tlc_output_file: Optional[str] = None,
-    ) -> Tuple[str, str]:
+        tlc_output_file: str | None = None,
+    ) -> tuple[str, str]:
         """Replay a trace file and save the result as JSON.
 
         Args:

--- a/tools/inv_checking_tool/src/trace_replay_tool.py
+++ b/tools/inv_checking_tool/src/trace_replay_tool.py
@@ -158,9 +158,9 @@ class TraceReplayer:
 
         try:
             stdout, _ = await asyncio.wait_for(process.communicate(), timeout=timeout)
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
             process.kill()
-            raise RuntimeError(f"Trace replay timed out after {timeout}s")
+            raise RuntimeError(f"Trace replay timed out after {timeout}s") from e
 
         output = stdout.decode("utf-8", errors="replace")
 

--- a/tools/inv_checking_tool/src/trace_replay_tool.py
+++ b/tools/inv_checking_tool/src/trace_replay_tool.py
@@ -49,7 +49,8 @@ from enum import Enum
 
 class TraceFormat(Enum):
     """Supported trace input formats."""
-    TLC = "tlc"    # Binary .bin format
+
+    TLC = "tlc"  # Binary .bin format
     JSON = "json"  # JSON format
 
 
@@ -60,23 +61,15 @@ class TraceReplayer:
     and output the result as a JSON file for further processing.
     """
 
-    def __init__(
-        self,
-        tla_jar: Optional[str] = None,
-        community_jar: Optional[str] = None
-    ):
+    def __init__(self, tla_jar: Optional[str] = None, community_jar: Optional[str] = None):
         self.tla_jar, self.community_jar = self._resolve_jar_paths(tla_jar, community_jar)
 
-    def _resolve_jar_paths(
-        self,
-        tla_jar: Optional[str],
-        community_jar: Optional[str]
-    ) -> Tuple[str, str]:
+    def _resolve_jar_paths(self, tla_jar: Optional[str], community_jar: Optional[str]) -> Tuple[str, str]:
         """Resolve JAR paths, using defaults if not provided."""
         if tla_jar is None or community_jar is None:
-            specula_root = os.environ.get('SPECULA_ROOT')
+            specula_root = os.environ.get("SPECULA_ROOT")
             if specula_root:
-                default_lib = os.path.join(specula_root, 'lib')
+                default_lib = os.path.join(specula_root, "lib")
             else:
                 this_file = os.path.abspath(__file__)
                 tla_mcp_dir = os.path.dirname(this_file)
@@ -84,7 +77,7 @@ class TraceReplayer:
                 tool_dir = os.path.dirname(src_dir)
                 tools_dir = os.path.dirname(tool_dir)
                 specula_root = os.path.dirname(tools_dir)
-                default_lib = os.path.join(specula_root, 'lib')
+                default_lib = os.path.join(specula_root, "lib")
 
             tla_jar = tla_jar or os.path.join(default_lib, "tla2tools.jar")
             community_jar = community_jar or os.path.join(default_lib, "CommunityModules-deps.jar")
@@ -98,7 +91,7 @@ class TraceReplayer:
         output_trace: str,
         config_file: Optional[str],
         trace_format: TraceFormat,
-        java_opts: Optional[List[str]] = None
+        java_opts: Optional[List[str]] = None,
     ) -> List[str]:
         """Build the TLC command for trace replay."""
         classpath = f"{self.tla_jar}:{self.community_jar}"
@@ -126,7 +119,7 @@ class TraceReplayer:
         trace_format: TraceFormat = TraceFormat.JSON,
         java_opts: Optional[List[str]] = None,
         timeout: int = 300,
-        tlc_output_file: Optional[str] = None
+        tlc_output_file: Optional[str] = None,
     ) -> Tuple[str, str]:
         """Replay a trace file and save the result as JSON.
 
@@ -157,26 +150,20 @@ class TraceReplayer:
             output_trace=output_file,
             config_file=config_file,
             trace_format=trace_format,
-            java_opts=java_opts
+            java_opts=java_opts,
         )
 
         process = await asyncio.create_subprocess_exec(
-            *cmd,
-            cwd=work_dir,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT
+            *cmd, cwd=work_dir, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT
         )
 
         try:
-            stdout, _ = await asyncio.wait_for(
-                process.communicate(),
-                timeout=timeout
-            )
+            stdout, _ = await asyncio.wait_for(process.communicate(), timeout=timeout)
         except asyncio.TimeoutError:
             process.kill()
             raise RuntimeError(f"Trace replay timed out after {timeout}s")
 
-        output = stdout.decode('utf-8', errors='replace')
+        output = stdout.decode("utf-8", errors="replace")
 
         # TLC exits with non-zero codes for invariant/property violations
         # (e.g. 12 for invariant violation). This is expected when replaying
@@ -186,8 +173,8 @@ class TraceReplayer:
 
         # Save TLC text output so TLCOutputReader can parse it.
         if not tlc_output_file:
-            tlc_output_file = output_file.rsplit('.', 1)[0] + '_tlc_output.txt'
-        with open(tlc_output_file, 'w') as f:
+            tlc_output_file = output_file.rsplit(".", 1)[0] + "_tlc_output.txt"
+        with open(tlc_output_file, "w") as f:
             f.write(output)
 
         return tlc_output_file, output_file

--- a/tools/inv_checking_tool/src/utils/__init__.py
+++ b/tools/inv_checking_tool/src/utils/__init__.py
@@ -1,7 +1,7 @@
 """Utility modules for TLC output processing."""
 
+from .path_parser import get_value_at_path, parse_variable_path
 from .preprocessing import preprocess_tlc_output, strip_ansi_codes
-from .path_parser import parse_variable_path, get_value_at_path
 
 __all__ = [
     "preprocess_tlc_output",

--- a/tools/inv_checking_tool/src/utils/path_parser.py
+++ b/tools/inv_checking_tool/src/utils/path_parser.py
@@ -70,7 +70,6 @@ def parse_variable_path(path: str) -> list[str | int]:
 
         # Handle multiple brackets in one segment: a[0][1]
         remaining = segment
-        first_in_segment = True
 
         while remaining:
             # Check for leading bracket (for subsequent indices)
@@ -107,7 +106,6 @@ def parse_variable_path(path: str) -> list[str | int]:
                     parts.append(index)
 
             remaining = remaining[match.end() :]
-            first_in_segment = False
 
     return parts
 

--- a/tools/inv_checking_tool/src/utils/path_parser.py
+++ b/tools/inv_checking_tool/src/utils/path_parser.py
@@ -15,18 +15,20 @@ from typing import Any, List, Union
 # Pattern to match path segments with optional array index
 # Matches: "name", "name[0]", "name[key]"
 PATH_SEGMENT_PATTERN = re.compile(
-    r'([a-zA-Z_][a-zA-Z0-9_]*)'  # Variable name
-    r'(?:\[([^\]]+)\])?'         # Optional index in brackets
+    r"([a-zA-Z_][a-zA-Z0-9_]*)"  # Variable name
+    r"(?:\[([^\]]+)\])?"  # Optional index in brackets
 )
 
 
 class PathParseError(Exception):
     """Exception raised when path parsing fails."""
+
     pass
 
 
 class PathAccessError(Exception):
     """Exception raised when path access fails."""
+
     pass
 
 
@@ -61,7 +63,7 @@ def parse_variable_path(path: str) -> List[Union[str, int]]:
     parts = []
 
     # Split by dots, but handle brackets specially
-    segments = path.split('.')
+    segments = path.split(".")
 
     for segment in segments:
         if not segment:
@@ -73,13 +75,13 @@ def parse_variable_path(path: str) -> List[Union[str, int]]:
 
         while remaining:
             # Check for leading bracket (for subsequent indices)
-            if remaining.startswith('['):
-                bracket_end = remaining.find(']')
+            if remaining.startswith("["):
+                bracket_end = remaining.find("]")
                 if bracket_end == -1:
                     raise PathParseError(f"Unclosed bracket in path: {path}")
 
                 index_str = remaining[1:bracket_end]
-                remaining = remaining[bracket_end + 1:]
+                remaining = remaining[bracket_end + 1 :]
 
                 # Try to parse as integer
                 try:
@@ -105,7 +107,7 @@ def parse_variable_path(path: str) -> List[Union[str, int]]:
                     # Keep as string key
                     parts.append(index)
 
-            remaining = remaining[match.end():]
+            remaining = remaining[match.end() :]
             first_in_segment = False
 
     return parts
@@ -147,32 +149,26 @@ def get_value_at_path(data: Any, path: Union[str, List[Union[str, int]]]) -> Any
                     else:
                         available = list(current.keys())[:10]
                         raise PathAccessError(
-                            f"Key '{part}' not found at path '{'.'.join(traversed[:-1])}'. "
-                            f"Available keys: {available}"
+                            f"Key '{part}' not found at path '{'.'.join(traversed[:-1])}'. Available keys: {available}"
                         )
                 else:
                     current = current[part]
             elif isinstance(current, (list, tuple)):
                 if not isinstance(part, int):
                     raise PathAccessError(
-                        f"Cannot use non-integer key '{part}' to index list "
-                        f"at path '{'.'.join(traversed[:-1])}'"
+                        f"Cannot use non-integer key '{part}' to index list at path '{'.'.join(traversed[:-1])}'"
                     )
                 if part < 0 or part >= len(current):
                     raise PathAccessError(
-                        f"Index {part} out of range (length={len(current)}) "
-                        f"at path '{'.'.join(traversed[:-1])}'"
+                        f"Index {part} out of range (length={len(current)}) at path '{'.'.join(traversed[:-1])}'"
                     )
                 current = current[part]
             else:
                 raise PathAccessError(
-                    f"Cannot traverse into {type(current).__name__} "
-                    f"at path '{'.'.join(traversed[:-1])}'"
+                    f"Cannot traverse into {type(current).__name__} at path '{'.'.join(traversed[:-1])}'"
                 )
         except (KeyError, IndexError, TypeError) as e:
-            raise PathAccessError(
-                f"Failed to access path '{'.'.join(traversed)}': {e}"
-            ) from e
+            raise PathAccessError(f"Failed to access path '{'.'.join(traversed)}': {e}") from e
 
     return current
 

--- a/tools/inv_checking_tool/src/utils/path_parser.py
+++ b/tools/inv_checking_tool/src/utils/path_parser.py
@@ -9,8 +9,7 @@ And retrieve values from nested Python data structures.
 """
 
 import re
-from typing import Any, List, Union
-
+from typing import Any
 
 # Pattern to match path segments with optional array index
 # Matches: "name", "name[0]", "name[key]"
@@ -32,7 +31,7 @@ class PathAccessError(Exception):
     pass
 
 
-def parse_variable_path(path: str) -> List[Union[str, int]]:
+def parse_variable_path(path: str) -> list[str | int]:
     """Parse a dot-separated path into a list of keys/indices.
 
     Supports the following path formats:
@@ -113,7 +112,7 @@ def parse_variable_path(path: str) -> List[Union[str, int]]:
     return parts
 
 
-def get_value_at_path(data: Any, path: Union[str, List[Union[str, int]]]) -> Any:
+def get_value_at_path(data: Any, path: str | list[str | int]) -> Any:
     """Get a value from nested data structure using a path.
 
     Args:

--- a/tools/inv_checking_tool/src/utils/preprocessing.py
+++ b/tools/inv_checking_tool/src/utils/preprocessing.py
@@ -13,7 +13,7 @@ from typing import Optional, Tuple
 
 
 # Pattern to match ANSI escape codes
-ANSI_ESCAPE_PATTERN = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+ANSI_ESCAPE_PATTERN = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
 # Marker for identifying TLC error trace sections
 ERROR_BEHAVIOR_MARKER = "The behavior up to this point is:"
@@ -34,7 +34,7 @@ def strip_ansi_codes(text: str) -> str:
     Returns:
         Text with all ANSI escape codes removed.
     """
-    return ANSI_ESCAPE_PATTERN.sub('', text)
+    return ANSI_ESCAPE_PATTERN.sub("", text)
 
 
 def extract_violation_info(content: str) -> Tuple[Optional[str], Optional[str]]:
@@ -131,7 +131,7 @@ def preprocess_tlc_output(file_path: str) -> Tuple[str, dict]:
         FileNotFoundError: If the file does not exist.
         ValueError: If the file does not contain a valid TLC trace.
     """
-    with open(file_path, 'r', encoding='utf-8', errors='replace') as f:
+    with open(file_path, "r", encoding="utf-8", errors="replace") as f:
         content = f.read()
 
     # Strip ANSI codes
@@ -181,4 +181,4 @@ def convert_to_trace_format(content: str) -> str:
     if not converted_lines:
         raise ValueError("Failed to convert TLC output to trace format.")
 
-    return ''.join(converted_lines)
+    return "".join(converted_lines)

--- a/tools/inv_checking_tool/src/utils/preprocessing.py
+++ b/tools/inv_checking_tool/src/utils/preprocessing.py
@@ -9,8 +9,6 @@ This module handles various input formats including:
 
 import io
 import re
-from typing import Optional, Tuple
-
 
 # Pattern to match ANSI escape codes
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
@@ -37,7 +35,7 @@ def strip_ansi_codes(text: str) -> str:
     return ANSI_ESCAPE_PATTERN.sub("", text)
 
 
-def extract_violation_info(content: str) -> Tuple[Optional[str], Optional[str]]:
+def extract_violation_info(content: str) -> tuple[str | None, str | None]:
     """Extract the violated invariant/property name from TLC output.
 
     Args:
@@ -99,7 +97,7 @@ def extract_statistics(content: str) -> dict:
     return stats
 
 
-def extract_counterexample_path(content: str) -> Optional[str]:
+def extract_counterexample_path(content: str) -> str | None:
     """Extract the counterexample file path from TLC output."""
     match = None
     for line in content.splitlines():
@@ -112,7 +110,7 @@ def extract_counterexample_path(content: str) -> Optional[str]:
     return match
 
 
-def preprocess_tlc_output(file_path: str) -> Tuple[str, dict]:
+def preprocess_tlc_output(file_path: str) -> tuple[str, dict]:
     """Preprocess a TLC output file for parsing.
 
     This function handles various input formats:
@@ -131,7 +129,7 @@ def preprocess_tlc_output(file_path: str) -> Tuple[str, dict]:
         FileNotFoundError: If the file does not exist.
         ValueError: If the file does not contain a valid TLC trace.
     """
-    with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+    with open(file_path, encoding="utf-8", errors="replace") as f:
         content = f.read()
 
     # Strip ANSI codes

--- a/tools/inv_checking_tool/tests/test_mcp_handlers.py
+++ b/tools/inv_checking_tool/tests/test_mcp_handlers.py
@@ -6,11 +6,10 @@ Run with:
 """
 
 import json
-import os
 import sys
-import tempfile
-import pytest
 from pathlib import Path
+
+import pytest
 
 # Add parent directories to path for imports
 current_dir = Path(__file__).parent
@@ -18,8 +17,7 @@ package_dir = current_dir.parent
 tools_dir = package_dir.parent
 sys.path.insert(0, str(tools_dir))
 
-from inv_checking_tool.src.mcp.handlers import SummaryHandler, StateHandler, CompareHandler
-
+from inv_checking_tool.src.mcp.handlers import CompareHandler, StateHandler, SummaryHandler
 
 # Path to test data - use local test data file that ships with the tests
 TEST_DATA_DIR = Path(__file__).parent / "test_data"

--- a/tools/inv_checking_tool/tests/test_mcp_handlers.py
+++ b/tools/inv_checking_tool/tests/test_mcp_handlers.py
@@ -75,10 +75,7 @@ class TestStateHandler:
     @pytest.mark.asyncio
     async def test_get_single_state(self, handler):
         """Test getting a single state."""
-        result = await handler.handle({
-            "file_path": str(SAMPLE_OUTPUT_FILE),
-            "index": 1
-        })
+        result = await handler.handle({"file_path": str(SAMPLE_OUTPUT_FILE), "index": 1})
         data = json.loads(result)
 
         assert data["success"] is True
@@ -89,10 +86,7 @@ class TestStateHandler:
     @pytest.mark.asyncio
     async def test_get_last_state(self, handler):
         """Test getting the last state."""
-        result = await handler.handle({
-            "file_path": str(SAMPLE_OUTPUT_FILE),
-            "index": -1
-        })
+        result = await handler.handle({"file_path": str(SAMPLE_OUTPUT_FILE), "index": -1})
         data = json.loads(result)
 
         assert data["success"] is True
@@ -101,11 +95,7 @@ class TestStateHandler:
     @pytest.mark.asyncio
     async def test_get_state_with_path(self, handler):
         """Test querying a nested path."""
-        result = await handler.handle({
-            "file_path": str(SAMPLE_OUTPUT_FILE),
-            "index": 1,
-            "path": "currentTerm.s1"
-        })
+        result = await handler.handle({"file_path": str(SAMPLE_OUTPUT_FILE), "index": 1, "path": "currentTerm.s1"})
         data = json.loads(result)
 
         assert data["success"] is True
@@ -115,10 +105,7 @@ class TestStateHandler:
     @pytest.mark.asyncio
     async def test_get_multiple_states(self, handler):
         """Test getting multiple states."""
-        result = await handler.handle({
-            "file_path": str(SAMPLE_OUTPUT_FILE),
-            "indices": "1:3"
-        })
+        result = await handler.handle({"file_path": str(SAMPLE_OUTPUT_FILE), "indices": "1:3"})
         data = json.loads(result)
 
         assert data["success"] is True
@@ -128,10 +115,7 @@ class TestStateHandler:
     @pytest.mark.asyncio
     async def test_get_states_from_end(self, handler):
         """Test getting last N states."""
-        result = await handler.handle({
-            "file_path": str(SAMPLE_OUTPUT_FILE),
-            "indices": "-3:"
-        })
+        result = await handler.handle({"file_path": str(SAMPLE_OUTPUT_FILE), "indices": "-3:"})
         data = json.loads(result)
 
         assert data["success"] is True
@@ -142,11 +126,9 @@ class TestStateHandler:
     @pytest.mark.asyncio
     async def test_get_state_with_variables(self, handler):
         """Test filtering to specific variables."""
-        result = await handler.handle({
-            "file_path": str(SAMPLE_OUTPUT_FILE),
-            "index": 1,
-            "variables": ["currentTerm", "state"]
-        })
+        result = await handler.handle(
+            {"file_path": str(SAMPLE_OUTPUT_FILE), "index": 1, "variables": ["currentTerm", "state"]}
+        )
         data = json.loads(result)
 
         assert data["success"] is True
@@ -157,9 +139,7 @@ class TestStateHandler:
     @pytest.mark.asyncio
     async def test_missing_index(self, handler):
         """Test error when neither index nor indices provided."""
-        result = await handler.handle({
-            "file_path": str(SAMPLE_OUTPUT_FILE)
-        })
+        result = await handler.handle({"file_path": str(SAMPLE_OUTPUT_FILE)})
         data = json.loads(result)
 
         assert data["success"] is False
@@ -175,11 +155,7 @@ class TestCompareHandler:
     @pytest.mark.asyncio
     async def test_compare_states(self, handler):
         """Test comparing two states."""
-        result = await handler.handle({
-            "file_path": str(SAMPLE_OUTPUT_FILE),
-            "index1": -2,
-            "index2": -1
-        })
+        result = await handler.handle({"file_path": str(SAMPLE_OUTPUT_FILE), "index1": -2, "index2": -1})
         data = json.loads(result)
 
         assert data["success"] is True
@@ -192,10 +168,7 @@ class TestCompareHandler:
     @pytest.mark.asyncio
     async def test_track_variable(self, handler):
         """Test tracking variable changes."""
-        result = await handler.handle({
-            "file_path": str(SAMPLE_OUTPUT_FILE),
-            "track_variable": "currentTerm"
-        })
+        result = await handler.handle({"file_path": str(SAMPLE_OUTPUT_FILE), "track_variable": "currentTerm"})
         data = json.loads(result)
 
         assert data["success"] is True
@@ -207,11 +180,9 @@ class TestCompareHandler:
     @pytest.mark.asyncio
     async def test_track_variable_with_path(self, handler):
         """Test tracking variable with sub-path."""
-        result = await handler.handle({
-            "file_path": str(SAMPLE_OUTPUT_FILE),
-            "track_variable": "state",
-            "track_path": "s1"
-        })
+        result = await handler.handle(
+            {"file_path": str(SAMPLE_OUTPUT_FILE), "track_variable": "state", "track_path": "s1"}
+        )
         data = json.loads(result)
 
         assert data["success"] is True
@@ -220,9 +191,7 @@ class TestCompareHandler:
     @pytest.mark.asyncio
     async def test_missing_mode_params(self, handler):
         """Test error when neither compare nor track params provided."""
-        result = await handler.handle({
-            "file_path": str(SAMPLE_OUTPUT_FILE)
-        })
+        result = await handler.handle({"file_path": str(SAMPLE_OUTPUT_FILE)})
         data = json.loads(result)
 
         assert data["success"] is False

--- a/tools/inv_checking_tool/tests/test_tlc_output_reader.py
+++ b/tools/inv_checking_tool/tests/test_tlc_output_reader.py
@@ -7,12 +7,13 @@ Or run directly:
     python tools/inv_checking_tool/tests/test_tlc_output_reader.py
 """
 
+import json
 import os
 import sys
-import json
 import tempfile
-import pytest
 from pathlib import Path
+
+import pytest
 
 # Add parent directories to path for imports
 current_dir = Path(__file__).parent
@@ -22,16 +23,15 @@ sys.path.insert(0, str(tools_dir))
 
 from inv_checking_tool import TLCOutputReader
 from inv_checking_tool.src.utils.path_parser import (
-    parse_variable_path,
-    get_value_at_path,
-    PathParseError,
     PathAccessError,
+    PathParseError,
+    get_value_at_path,
+    parse_variable_path,
 )
 from inv_checking_tool.src.utils.preprocessing import (
-    strip_ansi_codes,
     extract_violation_info,
+    strip_ansi_codes,
 )
-
 
 # Path to test data - use local test data file that ships with the tests
 TEST_DATA_DIR = Path(__file__).parent / "test_data"

--- a/tools/inv_checking_tool/tests/test_tlc_output_reader.py
+++ b/tools/inv_checking_tool/tests/test_tlc_output_reader.py
@@ -294,7 +294,7 @@ class TestTLCOutputReader:
         """Test comparing last two states."""
         diff = reader.compare_states(-2, -1)
         assert diff["state1_index"] == 19
-        assert diff["state2_index"] == 20 
+        assert diff["state2_index"] == 20
 
     def test_find_variable_changes(self, reader):
         """Test finding where a variable changes."""
@@ -315,9 +315,7 @@ class TestTLCOutputReader:
     def test_search_states(self, reader):
         """Test searching states with predicate."""
         # Find states where s1 is Candidate
-        leader_states = reader.search_states(
-            lambda s: s.get("state", {}).get("s1") == "Candidate"
-        )
+        leader_states = reader.search_states(lambda s: s.get("state", {}).get("s1") == "Candidate")
         assert isinstance(leader_states, list)
         assert all(isinstance(i, int) for i in leader_states)
 
@@ -359,7 +357,7 @@ class TestTLCOutputReaderEdgeCases:
                 [[1, {}], {"name": "Next"}, [2, {}]],
             ],
         }
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as trace_file:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as trace_file:
             json.dump(trace, trace_file)
             trace_file.flush()
 
@@ -367,7 +365,7 @@ class TestTLCOutputReaderEdgeCases:
 \"CounterExample written: {trace_file.name}\"
 The number of states generated: 100
 """
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.log', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
             f.write(content)
             f.flush()
 
@@ -392,13 +390,16 @@ The number of states generated: 100
         """Test loading trace with complex nested structures."""
         trace = {
             "state": [
-                [1, {
-                    "config": {"s1": {"a": 1, "b": 2}, "s2": {"a": 3, "b": 4}},
-                    "log": [{"term": 1, "value": "x"}, {"term": 2, "value": "y"}],
-                }],
+                [
+                    1,
+                    {
+                        "config": {"s1": {"a": 1, "b": 2}, "s2": {"a": 3, "b": 4}},
+                        "log": [{"term": 1, "value": "x"}, {"term": 2, "value": "y"}],
+                    },
+                ],
             ],
         }
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as trace_file:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as trace_file:
             json.dump(trace, trace_file)
             trace_file.flush()
 
@@ -406,7 +407,7 @@ The number of states generated: 100
 CounterExample written: {trace_file.name}
 The number of states generated: 100
 """
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.log', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
             f.write(content)
             f.flush()
 
@@ -444,14 +445,14 @@ def run_tests():
     skipped = 0
 
     for test_class in test_classes:
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"Running {test_class.__name__}")
-        print('='*60)
+        print("=" * 60)
 
         # Check for skip condition
-        if hasattr(test_class, 'pytestmark'):
+        if hasattr(test_class, "pytestmark"):
             for mark in test_class.pytestmark:
-                if mark.name == 'skipif' and mark.args[0]:
+                if mark.name == "skipif" and mark.args[0]:
                     print(f"  SKIPPED: {mark.kwargs.get('reason', 'No reason')}")
                     skipped += 1
                     continue
@@ -460,7 +461,7 @@ def run_tests():
 
         # Get fixture if needed
         fixture = None
-        if hasattr(instance, 'reader'):
+        if hasattr(instance, "reader"):
             try:
                 if SAMPLE_OUTPUT_FILE.exists():
                     fixture = TLCOutputReader(str(SAMPLE_OUTPUT_FILE))
@@ -469,13 +470,14 @@ def run_tests():
                 continue
 
         for name in dir(instance):
-            if name.startswith('test_'):
+            if name.startswith("test_"):
                 method = getattr(instance, name)
                 try:
                     # Inject fixture if method accepts it
                     import inspect
+
                     sig = inspect.signature(method)
-                    if 'reader' in sig.parameters and fixture:
+                    if "reader" in sig.parameters and fixture:
                         method(fixture)
                     else:
                         method()
@@ -499,9 +501,9 @@ def run_tests():
                         traceback.print_exc()
                         failed += 1
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Results: {passed} passed, {failed} failed, {skipped} skipped")
-    print('='*60)
+    print("=" * 60)
 
     return failed == 0
 

--- a/tools/spec_analyzer/mcp_server.py
+++ b/tools/spec_analyzer/mcp_server.py
@@ -25,7 +25,7 @@ import sys
 import os
 
 # Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 
 from spec_mcp import SpecAnalyzerMCPServer
 from spec_mcp.utils.logger import logger
@@ -53,13 +53,13 @@ Examples:
       }
     }
   }
-        """
+        """,
     )
     parser.add_argument(
         "--log-level",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         default="INFO",
-        help="Logging level (default: INFO)"
+        help="Logging level (default: INFO)",
     )
     return parser.parse_args()
 

--- a/tools/spec_analyzer/mcp_server.py
+++ b/tools/spec_analyzer/mcp_server.py
@@ -19,10 +19,10 @@ Usage:
     }
 """
 
-import asyncio
 import argparse
-import sys
+import asyncio
 import os
+import sys
 
 # Add src to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))

--- a/tools/spec_analyzer/src/spec_mcp/handlers/base.py
+++ b/tools/spec_analyzer/src/spec_mcp/handlers/base.py
@@ -59,10 +59,7 @@ class BaseHandler(ABC):
         try:
             # 1. Validate arguments
             logger.info(f"[{self.tool_name}] Validating arguments...")
-            validated_args = validate_arguments(
-                arguments,
-                self.argument_schema
-            )
+            validated_args = validate_arguments(arguments, self.argument_schema)
 
             # 2. Execute tool logic
             logger.info(f"[{self.tool_name}] Executing...")
@@ -75,18 +72,14 @@ class BaseHandler(ABC):
 
         except ValidationError as e:
             logger.error(f"[{self.tool_name}] Validation error: {e}")
-            return format_error_response(
-                tool_name=self.tool_name,
-                error_type="ValidationError",
-                error_message=str(e)
-            )
+            return format_error_response(tool_name=self.tool_name, error_type="ValidationError", error_message=str(e))
         except ExecutionError as e:
             logger.error(f"[{self.tool_name}] Execution error: {e}")
             return format_error_response(
                 tool_name=self.tool_name,
                 error_type="ExecutionError",
                 error_message=str(e),
-                details=e.details if hasattr(e, 'details') else None
+                details=e.details if hasattr(e, "details") else None,
             )
         except Exception as e:
             logger.error(f"[{self.tool_name}] Unexpected error: {e}")
@@ -95,5 +88,5 @@ class BaseHandler(ABC):
                 tool_name=self.tool_name,
                 error_type="UnexpectedError",
                 error_message=str(e),
-                traceback=traceback.format_exc()
+                traceback=traceback.format_exc(),
             )

--- a/tools/spec_analyzer/src/spec_mcp/handlers/base.py
+++ b/tools/spec_analyzer/src/spec_mcp/handlers/base.py
@@ -3,12 +3,12 @@
 import json
 import traceback
 from abc import ABC, abstractmethod
-from typing import Dict, Any
+from typing import Any
 
+from ..utils.errors import ExecutionError, ValidationError
+from ..utils.formatters import format_error_response
 from ..utils.logger import logger
 from ..utils.validators import validate_arguments
-from ..utils.formatters import format_error_response
-from ..utils.errors import ValidationError, ExecutionError
 
 
 class BaseHandler(ABC):
@@ -28,12 +28,12 @@ class BaseHandler(ABC):
 
     @property
     @abstractmethod
-    def argument_schema(self) -> Dict[str, Any]:
+    def argument_schema(self) -> dict[str, Any]:
         """JSON schema for arguments validation."""
         pass
 
     @abstractmethod
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Execute the tool logic.
 
         Args:
@@ -47,7 +47,7 @@ class BaseHandler(ABC):
         """
         pass
 
-    async def handle(self, arguments: Dict[str, Any]) -> str:
+    async def handle(self, arguments: dict[str, Any]) -> str:
         """Handle tool call with validation and error handling.
 
         Args:

--- a/tools/spec_analyzer/src/spec_mcp/handlers/vav_handler.py
+++ b/tools/spec_analyzer/src/spec_mcp/handlers/vav_handler.py
@@ -27,22 +27,11 @@ class VAVHandler(BaseHandler):
         return {
             "type": "object",
             "properties": {
-                "spec_file": {
-                    "type": "string",
-                    "description": "Path to TLA+ spec file (absolute path)"
-                },
-                "timeout": {
-                    "type": "integer",
-                    "description": "Timeout in seconds (default: 60)",
-                    "default": 60
-                },
-                "debug": {
-                    "type": "boolean",
-                    "description": "Enable debug output (default: false)",
-                    "default": False
-                }
+                "spec_file": {"type": "string", "description": "Path to TLA+ spec file (absolute path)"},
+                "timeout": {"type": "integer", "description": "Timeout in seconds (default: 60)", "default": 60},
+                "debug": {"type": "boolean", "description": "Enable debug output (default: false)", "default": False},
             },
-            "required": ["spec_file"]
+            "required": ["spec_file"],
         }
 
     async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -67,37 +56,33 @@ class VAVHandler(BaseHandler):
 
         # Validate spec file exists
         if not os.path.exists(spec_file):
-            raise ExecutionError(
-                f"Spec file not found: {spec_file}",
-                details={"spec_file": spec_file, "exists": False}
-            )
+            raise ExecutionError(f"Spec file not found: {spec_file}", details={"spec_file": spec_file, "exists": False})
 
         # Find CFA jar
         cfa_jar = self._find_cfa_jar()
         if not cfa_jar:
             raise ExecutionError(
                 "CFA tool JAR not found. Please ensure the CFA tool is built.",
-                details={"searched_paths": self._get_search_paths()}
+                details={"searched_paths": self._get_search_paths()},
             )
 
         # Find TLA tools jar (needed for SANY parser)
         tla_jar = self._find_tla_jar()
         if not tla_jar:
-            raise ExecutionError(
-                "TLA+ tools JAR not found.",
-                details={"searched_paths": self._get_tla_search_paths()}
-            )
+            raise ExecutionError("TLA+ tools JAR not found.", details={"searched_paths": self._get_tla_search_paths()})
 
         # Build command
         # The CFA tool expects: input.tla output.tla --algorithm vav
         output_file = "/tmp/vav_output.tla"
         cmd = [
             "java",
-            "-cp", f"{cfa_jar}:{tla_jar}",
+            "-cp",
+            f"{cfa_jar}:{tla_jar}",
             "CFG.SANYTransformerCli",
             spec_file,
             output_file,
-            "--algorithm", "vav"
+            "--algorithm",
+            "vav",
         ]
 
         if debug:
@@ -106,12 +91,7 @@ class VAVHandler(BaseHandler):
         logger.info(f"Running VAV analysis: {' '.join(cmd)}")
 
         try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=timeout
-            )
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 
             output = result.stdout + result.stderr
             logger.info(f"VAV output:\n{output}")
@@ -124,24 +104,19 @@ class VAVHandler(BaseHandler):
                 "issue_count": len(issues),
                 "summary": self._generate_summary(issues),
                 "raw_output": output,
-                "spec_file": spec_file
+                "spec_file": spec_file,
             }
 
         except subprocess.TimeoutExpired:
             raise ExecutionError(
-                f"VAV analysis timed out after {timeout} seconds",
-                details={"spec_file": spec_file, "timeout": timeout}
+                f"VAV analysis timed out after {timeout} seconds", details={"spec_file": spec_file, "timeout": timeout}
             )
         except FileNotFoundError:
             raise ExecutionError(
-                "Java not found. Please ensure Java is installed and in PATH",
-                details={"command": "java"}
+                "Java not found. Please ensure Java is installed and in PATH", details={"command": "java"}
             )
         except Exception as e:
-            raise ExecutionError(
-                f"Failed to run VAV analysis: {e}",
-                details={"error": str(e)}
-            )
+            raise ExecutionError(f"Failed to run VAV analysis: {e}", details={"error": str(e)})
 
     def _find_cfa_jar(self) -> str:
         """Find the CFA tool JAR file."""
@@ -152,7 +127,7 @@ class VAVHandler(BaseHandler):
 
     def _get_search_paths(self) -> List[str]:
         """Get list of paths to search for CFA JAR."""
-        specula_root = os.environ.get('SPECULA_ROOT')
+        specula_root = os.environ.get("SPECULA_ROOT")
         if not specula_root:
             # Calculate relative to this file
             this_file = os.path.abspath(__file__)
@@ -164,10 +139,10 @@ class VAVHandler(BaseHandler):
             specula_root = os.path.dirname(tools_dir)
 
         return [
-            os.path.join(specula_root, 'tools', 'cfa', 'target',
-                        'tlaplus-parser-1.0-SNAPSHOT-jar-with-dependencies.jar'),
-            os.path.join(specula_root, 'tools', 'cfa', 'target',
-                        'tlaplus-parser-1.0-SNAPSHOT.jar'),
+            os.path.join(
+                specula_root, "tools", "cfa", "target", "tlaplus-parser-1.0-SNAPSHOT-jar-with-dependencies.jar"
+            ),
+            os.path.join(specula_root, "tools", "cfa", "target", "tlaplus-parser-1.0-SNAPSHOT.jar"),
         ]
 
     def _find_tla_jar(self) -> str:
@@ -179,7 +154,7 @@ class VAVHandler(BaseHandler):
 
     def _get_tla_search_paths(self) -> List[str]:
         """Get list of paths to search for TLA JAR."""
-        specula_root = os.environ.get('SPECULA_ROOT')
+        specula_root = os.environ.get("SPECULA_ROOT")
         if not specula_root:
             this_file = os.path.abspath(__file__)
             handlers_dir = os.path.dirname(this_file)
@@ -190,7 +165,7 @@ class VAVHandler(BaseHandler):
             specula_root = os.path.dirname(tools_dir)
 
         return [
-            os.path.join(specula_root, 'lib', 'tla2tools.jar'),
+            os.path.join(specula_root, "lib", "tla2tools.jar"),
         ]
 
     def _parse_vav_output(self, output: str) -> List[Dict[str, Any]]:
@@ -208,23 +183,23 @@ class VAVHandler(BaseHandler):
         # [MISSING] FuncName branch N: Variables not assigned: [var1, var2]
         #   Path: ...
         missing_pattern = re.compile(
-            r'\[MISSING\]\s+(\w+)(?:\s+branch\s+(\d+))?:\s*'
-            r'(?:Variables not assigned|Branch missing variables):\s*\[([^\]]+)\]\s*'
-            r'(?:\n\s*Path:\s*(.+))?',
-            re.MULTILINE
+            r"\[MISSING\]\s+(\w+)(?:\s+branch\s+(\d+))?:\s*"
+            r"(?:Variables not assigned|Branch missing variables):\s*\[([^\]]+)\]\s*"
+            r"(?:\n\s*Path:\s*(.+))?",
+            re.MULTILINE,
         )
 
         for match in missing_pattern.finditer(output):
             func_name = match.group(1)
             branch = match.group(2)
-            variables = [v.strip() for v in match.group(3).split(',')]
+            variables = [v.strip() for v in match.group(3).split(",")]
             path = match.group(4).strip() if match.group(4) else None
 
             issue = {
                 "type": "MISSING",
                 "function": func_name,
                 "variables": variables,
-                "message": f"Variables {variables} not assigned in {func_name}"
+                "message": f"Variables {variables} not assigned in {func_name}",
             }
             if branch:
                 issue["branch"] = int(branch)
@@ -239,10 +214,10 @@ class VAVHandler(BaseHandler):
         #   First: ...
         #   Second: ...
         duplicate_pattern = re.compile(
-            r'\[DUPLICATE\]\s+(\w+):\s*Variable\s+\'(\w+)\'\s+assigned multiple times\s*'
-            r'(?:\n\s*First:\s*(.+))?\s*'
-            r'(?:\n\s*Second:\s*(.+))?',
-            re.MULTILINE
+            r"\[DUPLICATE\]\s+(\w+):\s*Variable\s+\'(\w+)\'\s+assigned multiple times\s*"
+            r"(?:\n\s*First:\s*(.+))?\s*"
+            r"(?:\n\s*Second:\s*(.+))?",
+            re.MULTILINE,
         )
 
         for match in duplicate_pattern.finditer(output):
@@ -255,7 +230,7 @@ class VAVHandler(BaseHandler):
                 "type": "DUPLICATE",
                 "function": func_name,
                 "variable": variable,
-                "message": f"Variable '{variable}' assigned multiple times in {func_name}"
+                "message": f"Variable '{variable}' assigned multiple times in {func_name}",
             }
             if first_loc:
                 issue["first_assignment"] = first_loc

--- a/tools/spec_analyzer/src/spec_mcp/handlers/vav_handler.py
+++ b/tools/spec_analyzer/src/spec_mcp/handlers/vav_handler.py
@@ -107,16 +107,16 @@ class VAVHandler(BaseHandler):
                 "spec_file": spec_file,
             }
 
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
             raise ExecutionError(
                 f"VAV analysis timed out after {timeout} seconds", details={"spec_file": spec_file, "timeout": timeout}
-            )
-        except FileNotFoundError:
+            ) from e
+        except FileNotFoundError as e:
             raise ExecutionError(
                 "Java not found. Please ensure Java is installed and in PATH", details={"command": "java"}
-            )
+            ) from e
         except Exception as e:
-            raise ExecutionError(f"Failed to run VAV analysis: {e}", details={"error": str(e)})
+            raise ExecutionError(f"Failed to run VAV analysis: {e}", details={"error": str(e)}) from e
 
     def _find_cfa_jar(self) -> str:
         """Find the CFA tool JAR file."""

--- a/tools/spec_analyzer/src/spec_mcp/handlers/vav_handler.py
+++ b/tools/spec_analyzer/src/spec_mcp/handlers/vav_handler.py
@@ -3,11 +3,11 @@
 import os
 import re
 import subprocess
-from typing import Dict, Any, List
+from typing import Any
 
-from .base import BaseHandler
 from ..utils.errors import ExecutionError
 from ..utils.logger import logger
+from .base import BaseHandler
 
 
 class VAVHandler(BaseHandler):
@@ -23,7 +23,7 @@ class VAVHandler(BaseHandler):
         return "run_vav_analysis"
 
     @property
-    def argument_schema(self) -> Dict[str, Any]:
+    def argument_schema(self) -> dict[str, Any]:
         return {
             "type": "object",
             "properties": {
@@ -34,7 +34,7 @@ class VAVHandler(BaseHandler):
             "required": ["spec_file"],
         }
 
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Run VAV analysis on a TLA+ spec.
 
         Args:
@@ -125,7 +125,7 @@ class VAVHandler(BaseHandler):
                 return path
         return None
 
-    def _get_search_paths(self) -> List[str]:
+    def _get_search_paths(self) -> list[str]:
         """Get list of paths to search for CFA JAR."""
         specula_root = os.environ.get("SPECULA_ROOT")
         if not specula_root:
@@ -152,7 +152,7 @@ class VAVHandler(BaseHandler):
                 return path
         return None
 
-    def _get_tla_search_paths(self) -> List[str]:
+    def _get_tla_search_paths(self) -> list[str]:
         """Get list of paths to search for TLA JAR."""
         specula_root = os.environ.get("SPECULA_ROOT")
         if not specula_root:
@@ -168,7 +168,7 @@ class VAVHandler(BaseHandler):
             os.path.join(specula_root, "lib", "tla2tools.jar"),
         ]
 
-    def _parse_vav_output(self, output: str) -> List[Dict[str, Any]]:
+    def _parse_vav_output(self, output: str) -> list[dict[str, Any]]:
         """Parse VAV output to extract issues.
 
         Args:
@@ -241,7 +241,7 @@ class VAVHandler(BaseHandler):
 
         return issues
 
-    def _generate_summary(self, issues: List[Dict[str, Any]]) -> str:
+    def _generate_summary(self, issues: list[dict[str, Any]]) -> str:
         """Generate a human-readable summary of issues.
 
         Args:

--- a/tools/spec_analyzer/src/spec_mcp/mcp_server.py
+++ b/tools/spec_analyzer/src/spec_mcp/mcp_server.py
@@ -52,21 +52,12 @@ class SpecAnalyzerMCPServer:
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "spec_file": {
-                                "type": "string",
-                                "description": "Path to TLA+ spec file (absolute path)"
-                            },
-                            "timeout": {
-                                "type": "integer",
-                                "description": "Timeout in seconds (default: 60)"
-                            },
-                            "debug": {
-                                "type": "boolean",
-                                "description": "Enable debug output (default: false)"
-                            }
+                            "spec_file": {"type": "string", "description": "Path to TLA+ spec file (absolute path)"},
+                            "timeout": {"type": "integer", "description": "Timeout in seconds (default: 60)"},
+                            "debug": {"type": "boolean", "description": "Enable debug output (default: false)"},
                         },
-                        "required": ["spec_file"]
-                    }
+                        "required": ["spec_file"],
+                    },
                 )
             ]
 
@@ -84,10 +75,7 @@ class SpecAnalyzerMCPServer:
             if name not in self.handlers:
                 error_msg = f"Unknown tool: {name}"
                 logger.error(error_msg)
-                return [types.TextContent(
-                    type="text",
-                    text=f'{{"success": false, "error": "{error_msg}"}}'
-                )]
+                return [types.TextContent(type="text", text=f'{{"success": false, "error": "{error_msg}"}}')]
 
             # Call the handler
             handler = self.handlers[name]
@@ -107,8 +95,4 @@ class SpecAnalyzerMCPServer:
         logger.info(f"Registered {len(self.handlers)} tools")
 
         async with stdio_server() as (read_stream, write_stream):
-            await self.server.run(
-                read_stream,
-                write_stream,
-                self.server.create_initialization_options()
-            )
+            await self.server.run(read_stream, write_stream, self.server.create_initialization_options())

--- a/tools/spec_analyzer/src/spec_mcp/mcp_server.py
+++ b/tools/spec_analyzer/src/spec_mcp/mcp_server.py
@@ -1,8 +1,8 @@
 """TLA+ Spec Analyzer MCP Server."""
 
+from mcp import types
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp import types
 
 from .utils.logger import logger, setup_logging
 

--- a/tools/spec_analyzer/src/spec_mcp/utils/errors.py
+++ b/tools/spec_analyzer/src/spec_mcp/utils/errors.py
@@ -3,11 +3,13 @@
 
 class MCPError(Exception):
     """Base exception for MCP errors."""
+
     pass
 
 
 class ValidationError(MCPError):
     """Argument validation error."""
+
     pass
 
 

--- a/tools/spec_analyzer/src/spec_mcp/utils/formatters.py
+++ b/tools/spec_analyzer/src/spec_mcp/utils/formatters.py
@@ -4,8 +4,7 @@ import json
 from typing import Dict, Any
 
 
-def format_error_response(tool_name: str, error_type: str,
-                          error_message: str, **kwargs) -> str:
+def format_error_response(tool_name: str, error_type: str, error_message: str, **kwargs) -> str:
     """Format error response as JSON string.
 
     Args:
@@ -17,12 +16,7 @@ def format_error_response(tool_name: str, error_type: str,
     Returns:
         JSON string of error response
     """
-    result = {
-        "success": False,
-        "tool": tool_name,
-        "error_type": error_type,
-        "error_message": error_message
-    }
+    result = {"success": False, "tool": tool_name, "error_type": error_type, "error_message": error_message}
     result.update(kwargs)
     return json.dumps(result, indent=2)
 

--- a/tools/spec_analyzer/src/spec_mcp/utils/formatters.py
+++ b/tools/spec_analyzer/src/spec_mcp/utils/formatters.py
@@ -1,7 +1,7 @@
 """Response formatting utilities."""
 
 import json
-from typing import Dict, Any
+from typing import Any
 
 
 def format_error_response(tool_name: str, error_type: str, error_message: str, **kwargs) -> str:
@@ -21,7 +21,7 @@ def format_error_response(tool_name: str, error_type: str, error_message: str, *
     return json.dumps(result, indent=2)
 
 
-def format_success_response(data: Dict[str, Any]) -> str:
+def format_success_response(data: dict[str, Any]) -> str:
     """Format success response as JSON string.
 
     Args:

--- a/tools/spec_analyzer/src/spec_mcp/utils/logger.py
+++ b/tools/spec_analyzer/src/spec_mcp/utils/logger.py
@@ -8,8 +8,8 @@ This module provides centralized logging configuration, ensuring that:
 
 import logging
 import logging.handlers
-import sys
 import os
+import sys
 
 # Default log directory
 DEFAULT_LOG_DIR = os.path.join(os.path.expanduser("~"), ".specula", "logs", "spec_analyzer")

--- a/tools/spec_analyzer/src/spec_mcp/utils/logger.py
+++ b/tools/spec_analyzer/src/spec_mcp/utils/logger.py
@@ -16,9 +16,7 @@ DEFAULT_LOG_DIR = os.path.join(os.path.expanduser("~"), ".specula", "logs", "spe
 
 
 def setup_logging(
-    name: str = "spec-analyzer-mcp",
-    log_dir: str = DEFAULT_LOG_DIR,
-    level: int = logging.INFO
+    name: str = "spec-analyzer-mcp", log_dir: str = DEFAULT_LOG_DIR, level: int = logging.INFO
 ) -> logging.Logger:
     """Configure and return the root logger.
 
@@ -43,14 +41,12 @@ def setup_logging(
         root_logger.handlers.clear()
 
     # Formatter
-    formatter = logging.Formatter(
-        '[%(asctime)s] [%(levelname)s] [%(name)s] [%(threadName)s] %(message)s'
-    )
+    formatter = logging.Formatter("[%(asctime)s] [%(levelname)s] [%(name)s] [%(threadName)s] %(message)s")
 
     # 1. Rotating File Handler
     # Max size 10MB, keep 5 backups
     file_handler = logging.handlers.RotatingFileHandler(
-        log_file, maxBytes=10*1024*1024, backupCount=5, encoding='utf-8'
+        log_file, maxBytes=10 * 1024 * 1024, backupCount=5, encoding="utf-8"
     )
     file_handler.setFormatter(formatter)
     file_handler.setLevel(level)

--- a/tools/spec_analyzer/src/spec_mcp/utils/validators.py
+++ b/tools/spec_analyzer/src/spec_mcp/utils/validators.py
@@ -6,8 +6,7 @@ from typing import Dict, Any
 from .errors import ValidationError
 
 
-def validate_arguments(arguments: Dict[str, Any],
-                      schema: Dict[str, Any]) -> Dict[str, Any]:
+def validate_arguments(arguments: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
     """Validate arguments against JSON schema.
 
     Args:
@@ -35,8 +34,7 @@ def validate_arguments(arguments: Dict[str, Any],
         raise ValidationError(f"Invalid schema: {e.message}")
 
 
-def _apply_defaults(arguments: Dict[str, Any],
-                   schema: Dict[str, Any]) -> Dict[str, Any]:
+def _apply_defaults(arguments: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
     """Apply default values from schema to arguments.
 
     Args:

--- a/tools/spec_analyzer/src/spec_mcp/utils/validators.py
+++ b/tools/spec_analyzer/src/spec_mcp/utils/validators.py
@@ -1,12 +1,13 @@
 """Argument validation utilities."""
 
+from typing import Any
+
 import jsonschema
-from typing import Dict, Any
 
 from .errors import ValidationError
 
 
-def validate_arguments(arguments: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
+def validate_arguments(arguments: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:
     """Validate arguments against JSON schema.
 
     Args:
@@ -34,7 +35,7 @@ def validate_arguments(arguments: Dict[str, Any], schema: Dict[str, Any]) -> Dic
         raise ValidationError(f"Invalid schema: {e.message}")
 
 
-def _apply_defaults(arguments: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
+def _apply_defaults(arguments: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:
     """Apply default values from schema to arguments.
 
     Args:

--- a/tools/spec_analyzer/src/spec_mcp/utils/validators.py
+++ b/tools/spec_analyzer/src/spec_mcp/utils/validators.py
@@ -30,9 +30,9 @@ def validate_arguments(arguments: dict[str, Any], schema: dict[str, Any]) -> dic
         return validated
 
     except jsonschema.ValidationError as e:
-        raise ValidationError(f"Invalid arguments: {e.message}")
+        raise ValidationError(f"Invalid arguments: {e.message}") from e
     except jsonschema.SchemaError as e:
-        raise ValidationError(f"Invalid schema: {e.message}")
+        raise ValidationError(f"Invalid schema: {e.message}") from e
 
 
 def _apply_defaults(arguments: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:

--- a/tools/trace_debugger/README.md
+++ b/tools/trace_debugger/README.md
@@ -501,7 +501,7 @@ Document each fix in `fix_log.md`:
 ### Prerequisites
 
 - **Java 11+**: Required to run TLC
-- **Python 3.8+**: Required for the debugger tool
+- **Python 3.10+**: Required for the debugger tool
 - **TLA+ Tools**: `tla2tools.jar` and `CommunityModules-deps.jar`
 
 ### Setup
@@ -660,7 +660,7 @@ The `examples/demo/` directory contains complete demonstrations:
 ### Software Requirements
 
 - **Java**: JDK 11 or higher
-- **Python**: 3.8 or higher
+- **Python**: 3.10 or higher
 - **TLA+ Tools**: tla2tools.jar (version 1.7.1+)
 - **CommunityModules**: CommunityModules-deps.jar (for JSON support)
 

--- a/tools/trace_debugger/examples/demo/coarse_grained_localization.py
+++ b/tools/trace_debugger/examples/demo/coarse_grained_localization.py
@@ -5,6 +5,7 @@ import json
 import os
 import threading
 
+
 class DebugClient:
     def __init__(self, port=4712):
         self.port = port
@@ -17,7 +18,7 @@ class DebugClient:
         while time.time() - start < 30:
             try:
                 self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                self.sock.connect(('127.0.0.1', self.port))
+                self.sock.connect(("127.0.0.1", self.port))
                 return True
             except ConnectionRefusedError:
                 print(".", end="", flush=True)
@@ -27,11 +28,13 @@ class DebugClient:
 
     def send(self, type_, command=None, args=None):
         msg = {"seq": self.seq, "type": type_}
-        if command: msg["command"] = command
-        if args: msg["arguments"] = args
+        if command:
+            msg["command"] = command
+        if args:
+            msg["arguments"] = args
         body = json.dumps(msg)
         full = f"Content-Length: {len(body)}\r\n\r\n{body}"
-        self.sock.sendall(full.encode('utf-8'))
+        self.sock.sendall(full.encode("utf-8"))
         self.seq += 1
         return self.seq - 1
 
@@ -40,13 +43,15 @@ class DebugClient:
             head = b""
             while b"\r\n\r\n" not in head:
                 chunk = self.sock.recv(1)
-                if not chunk: return None
+                if not chunk:
+                    return None
                 head += chunk
             content_len = int(head.decode().split("Content-Length: ")[1].strip())
             body = b""
             while len(body) < content_len:
                 chunk = self.sock.recv(content_len - len(body))
-                if not chunk: return None
+                if not chunk:
+                    return None
                 body += chunk
             return json.loads(body)
         except Exception as e:
@@ -57,24 +62,27 @@ class DebugClient:
         req_seq = self.send("request", command, args)
         while True:
             msg = self.receive()
-            if not msg: return None
+            if not msg:
+                return None
             if msg.get("type") == "response" and msg.get("request_seq") == req_seq:
                 return msg
+
 
 def get_specula_root():
     """Auto-detect Specula root directory."""
     # Try environment variable first
-    specula_root = os.environ.get('SPECULA_ROOT')
+    specula_root = os.environ.get("SPECULA_ROOT")
     if specula_root:
         return specula_root
     # Calculate relative to this file: tools/trace_debugger/examples/demo/xxx.py
     # Go up to specula root: ../../../../
     this_file = os.path.abspath(__file__)
-    demo_dir = os.path.dirname(this_file)           # .../demo
-    examples_dir = os.path.dirname(demo_dir)        # .../examples
+    demo_dir = os.path.dirname(this_file)  # .../demo
+    examples_dir = os.path.dirname(demo_dir)  # .../examples
     trace_debugger_dir = os.path.dirname(examples_dir)  # .../trace_debugger
-    tools_dir = os.path.dirname(trace_debugger_dir)     # .../tools
-    return os.path.dirname(tools_dir)                   # .../Specula
+    tools_dir = os.path.dirname(trace_debugger_dir)  # .../tools
+    return os.path.dirname(tools_dir)  # .../Specula
+
 
 def run_breakpoint_experiment():
     specula_root = get_specula_root()
@@ -88,31 +96,29 @@ def run_breakpoint_experiment():
     env = os.environ.copy()
     env["JSON"] = "../traces/confchange_disable_validation.ndjson"
 
-    print("="*70)
+    print("=" * 70)
     print("PHASE 3: Multi-Breakpoint Diagnosis")
     print("Goal: Find where SendAppendEntriesRequest fails at l=29")
-    print("="*70)
+    print("=" * 70)
 
     cmd = [
-        "java", "-XX:+UseParallelGC", "-Xmx4G",
-        "-cp", classpath,
+        "java",
+        "-XX:+UseParallelGC",
+        "-Xmx4G",
+        "-cp",
+        classpath,
         "tlc2.TLC",
-        "-debugger", "port=4712",
-        "-config", cfg_file,
-        spec_file
+        "-debugger",
+        "port=4712",
+        "-config",
+        cfg_file,
+        spec_file,
     ]
 
-    proc = subprocess.Popen(
-        cmd,
-        cwd=work_dir,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        env=env
-    )
+    proc = subprocess.Popen(cmd, cwd=work_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
 
     def read_stdout(pipe):
-        for line in iter(pipe.readline, ''):
+        for line in iter(pipe.readline, ""):
             pass
         pipe.close()
 
@@ -123,7 +129,8 @@ def run_breakpoint_experiment():
         print("\n>>> Waiting for TLC...")
         while True:
             line = proc.stdout.readline()
-            if not line: break
+            if not line:
+                break
             if "Debugger is listening" in line:
                 print(">>> TLC Ready!")
                 break
@@ -155,16 +162,13 @@ def run_breakpoint_experiment():
             breakpoints.append({"line": line, "condition": "l = 29"})
             print(f"    Line {line:3d}: {desc}")
 
-        client.request("setBreakpoints", {
-            "source": {"name": spec_file, "path": spec_path},
-            "breakpoints": breakpoints
-        })
+        client.request("setBreakpoints", {"source": {"name": spec_file, "path": spec_path}, "breakpoints": breakpoints})
 
         client.request("configurationDone", {})
         client.request("continue", {})
 
         print("\n>>> Running... Waiting for breakpoints to hit...")
-        print("="*70)
+        print("=" * 70)
 
         hit_count = 0
         max_hits = 20  # Limit to avoid infinite loops
@@ -209,7 +213,7 @@ def run_breakpoint_experiment():
                     print(f"\n❌ TERMINATED after {hit_count} breakpoint hits")
                     break
 
-        print("\n" + "="*70)
+        print("\n" + "=" * 70)
         print(f"SUMMARY: Hit {hit_count} breakpoint(s)")
 
         if hit_count == 0:
@@ -221,17 +225,20 @@ def run_breakpoint_experiment():
             print("   The execution stopped before reaching later breakpoints")
             print("   This tells us WHERE the failure occurred!")
 
-        print("="*70)
+        print("=" * 70)
 
         client.request("disconnect", {})
 
     except Exception as e:
         print(f"\n❌ Error: {e}")
         import traceback
+
         traceback.print_exc()
     finally:
-        if client.sock: client.sock.close()
+        if client.sock:
+            client.sock.close()
         proc.terminate()
+
 
 if __name__ == "__main__":
     run_breakpoint_experiment()

--- a/tools/trace_debugger/examples/demo/coarse_grained_localization.py
+++ b/tools/trace_debugger/examples/demo/coarse_grained_localization.py
@@ -1,9 +1,9 @@
-import subprocess
-import time
-import socket
 import json
 import os
+import socket
+import subprocess
 import threading
+import time
 
 
 class DebugClient:

--- a/tools/trace_debugger/examples/demo/coarse_grained_localization.py
+++ b/tools/trace_debugger/examples/demo/coarse_grained_localization.py
@@ -118,7 +118,7 @@ def run_breakpoint_experiment():
     proc = subprocess.Popen(cmd, cwd=work_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
 
     def read_stdout(pipe):
-        for line in iter(pipe.readline, ""):
+        for _line in iter(pipe.readline, ""):
             pass
         pipe.close()
 

--- a/tools/trace_debugger/examples/demo/fine_grained_localization.py
+++ b/tools/trace_debugger/examples/demo/fine_grained_localization.py
@@ -120,7 +120,7 @@ def run_inspection():
     proc = subprocess.Popen(cmd, cwd=work_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
 
     def read_stdout(pipe):
-        for line in iter(pipe.readline, ""):
+        for _line in iter(pipe.readline, ""):
             pass
         pipe.close()
 

--- a/tools/trace_debugger/examples/demo/fine_grained_localization.py
+++ b/tools/trace_debugger/examples/demo/fine_grained_localization.py
@@ -1,9 +1,9 @@
-import subprocess
-import time
-import socket
 import json
 import os
+import socket
+import subprocess
 import threading
+import time
 
 
 class DebugClient:

--- a/tools/trace_debugger/examples/demo/fine_grained_localization.py
+++ b/tools/trace_debugger/examples/demo/fine_grained_localization.py
@@ -5,6 +5,7 @@ import json
 import os
 import threading
 
+
 class DebugClient:
     def __init__(self, port=4712):
         self.port = port
@@ -17,7 +18,7 @@ class DebugClient:
         while time.time() - start < 30:
             try:
                 self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                self.sock.connect(('127.0.0.1', self.port))
+                self.sock.connect(("127.0.0.1", self.port))
                 return True
             except ConnectionRefusedError:
                 print(".", end="", flush=True)
@@ -27,11 +28,13 @@ class DebugClient:
 
     def send(self, type_, command=None, args=None):
         msg = {"seq": self.seq, "type": type_}
-        if command: msg["command"] = command
-        if args: msg["arguments"] = args
+        if command:
+            msg["command"] = command
+        if args:
+            msg["arguments"] = args
         body = json.dumps(msg)
         full = f"Content-Length: {len(body)}\r\n\r\n{body}"
-        self.sock.sendall(full.encode('utf-8'))
+        self.sock.sendall(full.encode("utf-8"))
         self.seq += 1
         return self.seq - 1
 
@@ -40,13 +43,15 @@ class DebugClient:
             head = b""
             while b"\r\n\r\n" not in head:
                 chunk = self.sock.recv(1)
-                if not chunk: return None
+                if not chunk:
+                    return None
                 head += chunk
             content_len = int(head.decode().split("Content-Length: ")[1].strip())
             body = b""
             while len(body) < content_len:
                 chunk = self.sock.recv(content_len - len(body))
-                if not chunk: return None
+                if not chunk:
+                    return None
                 body += chunk
             return json.loads(body)
         except Exception as e:
@@ -57,24 +62,27 @@ class DebugClient:
         req_seq = self.send("request", command, args)
         while True:
             msg = self.receive()
-            if not msg: return None
+            if not msg:
+                return None
             if msg.get("type") == "response" and msg.get("request_seq") == req_seq:
                 return msg
+
 
 def get_specula_root():
     """Auto-detect Specula root directory."""
     # Try environment variable first
-    specula_root = os.environ.get('SPECULA_ROOT')
+    specula_root = os.environ.get("SPECULA_ROOT")
     if specula_root:
         return specula_root
     # Calculate relative to this file: tools/trace_debugger/examples/demo/xxx.py
     # Go up to specula root: ../../../../
     this_file = os.path.abspath(__file__)
-    demo_dir = os.path.dirname(this_file)           # .../demo
-    examples_dir = os.path.dirname(demo_dir)        # .../examples
+    demo_dir = os.path.dirname(this_file)  # .../demo
+    examples_dir = os.path.dirname(demo_dir)  # .../examples
     trace_debugger_dir = os.path.dirname(examples_dir)  # .../trace_debugger
-    tools_dir = os.path.dirname(trace_debugger_dir)     # .../tools
-    return os.path.dirname(tools_dir)                   # .../Specula
+    tools_dir = os.path.dirname(trace_debugger_dir)  # .../tools
+    return os.path.dirname(tools_dir)  # .../Specula
+
 
 def run_inspection():
     specula_root = get_specula_root()
@@ -91,30 +99,28 @@ def run_inspection():
     env = os.environ.copy()
     env["JSON"] = "../traces/confchange_disable_validation.ndjson"
 
-    print("="*70)
+    print("=" * 70)
     print("PHASE 4: Deep Dive into AppendEntries")
-    print("="*70)
+    print("=" * 70)
 
     cmd = [
-        "java", "-XX:+UseParallelGC", "-Xmx4G",
-        "-cp", classpath,
+        "java",
+        "-XX:+UseParallelGC",
+        "-Xmx4G",
+        "-cp",
+        classpath,
         "tlc2.TLC",
-        "-debugger", "port=4712",
-        "-config", cfg_file,
-        spec_file
+        "-debugger",
+        "port=4712",
+        "-config",
+        cfg_file,
+        spec_file,
     ]
 
-    proc = subprocess.Popen(
-        cmd,
-        cwd=work_dir,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        env=env
-    )
+    proc = subprocess.Popen(cmd, cwd=work_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
 
     def read_stdout(pipe):
-        for line in iter(pipe.readline, ''):
+        for line in iter(pipe.readline, ""):
             pass
         pipe.close()
 
@@ -125,7 +131,8 @@ def run_inspection():
         print("\n>>> Waiting for TLC...")
         while True:
             line = proc.stdout.readline()
-            if not line: break
+            if not line:
+                break
             if "Debugger is listening" in line:
                 print(">>> TLC Ready!")
                 break
@@ -149,10 +156,8 @@ def run_inspection():
             # AppendEntriesIfLogged 相关
             (spec_file, 323, "AppendEntriesIfLogged entry"),
             (spec_file, 327, "AppendEntries call"),
-
             # AppendEntries 函数（在 etcdraft_progress.tla 的 Line 516）
             (spec_file_base, 517, "AppendEntriesInRangeToPeer call"),
-
             # AppendEntriesInRangeToPeer 内部关键点
             (spec_file_base, 435, "AppendEntriesInRangeToPeer entry"),
             (spec_file_base, 436, "Condition: i /= j"),
@@ -180,16 +185,13 @@ def run_inspection():
         # 设置每个文件的断点
         for file, breakpoints in breakpoints_by_file.items():
             path = spec_path_trace if file == spec_file else spec_path_base
-            client.request("setBreakpoints", {
-                "source": {"name": file, "path": path},
-                "breakpoints": breakpoints
-            })
+            client.request("setBreakpoints", {"source": {"name": file, "path": path}, "breakpoints": breakpoints})
 
         client.request("configurationDone", {})
         client.request("continue", {})
 
         print("\n>>> Running... Waiting for breakpoints to hit...")
-        print("="*70)
+        print("=" * 70)
 
         hit_count = 0
         max_hits = 50  # 增加限制，看更多断点
@@ -236,9 +238,9 @@ def run_inspection():
                     print(f"\n>>> TLC Terminated after {hit_count} breakpoint hits")
                     break
 
-        print("\n" + "="*70)
+        print("\n" + "=" * 70)
         print(f"SUMMARY: Hit {hit_count} breakpoint(s)")
-        print("="*70)
+        print("=" * 70)
 
         print("\nBreakpoint Hit Summary:")
         for bp_file, bp_line, bp_desc in breakpoints_def:
@@ -256,10 +258,13 @@ def run_inspection():
     except Exception as e:
         print(f"\n❌ Error: {e}")
         import traceback
+
         traceback.print_exc()
     finally:
-        if client.sock: client.sock.close()
+        if client.sock:
+            client.sock.close()
         proc.terminate()
+
 
 if __name__ == "__main__":
     run_inspection()

--- a/tools/trace_debugger/examples/demo/variable_inspection.py
+++ b/tools/trace_debugger/examples/demo/variable_inspection.py
@@ -48,7 +48,7 @@ class DebugClient:
                     return None
                 body += chunk
             return json.loads(body)
-        except:
+        except BaseException:
             return None
 
     def request(self, command, args=None):
@@ -131,7 +131,7 @@ proc = subprocess.Popen(
 
 
 def read_stdout(pipe):
-    for line in iter(pipe.readline, ""):
+    for _line in iter(pipe.readline, ""):
         pass
     pipe.close()
 

--- a/tools/trace_debugger/examples/demo/variable_inspection.py
+++ b/tools/trace_debugger/examples/demo/variable_inspection.py
@@ -1,4 +1,9 @@
-import subprocess, time, socket, json, os, threading
+import json
+import os
+import socket
+import subprocess
+import threading
+import time
 
 
 class DebugClient:
@@ -23,7 +28,7 @@ class DebugClient:
         if args:
             msg["arguments"] = args
         body = json.dumps(msg)
-        self.sock.sendall(f"Content-Length: {len(body)}\r\n\r\n{body}".encode("utf-8"))
+        self.sock.sendall(f"Content-Length: {len(body)}\r\n\r\n{body}".encode())
         self.seq += 1
         return self.seq - 1
 

--- a/tools/trace_debugger/examples/demo/variable_inspection.py
+++ b/tools/trace_debugger/examples/demo/variable_inspection.py
@@ -1,54 +1,67 @@
 import subprocess, time, socket, json, os, threading
 
+
 class DebugClient:
     def __init__(self, port=4712):
         self.port, self.sock, self.seq = port, None, 1
+
     def connect(self):
         start = time.time()
         while time.time() - start < 30:
             try:
                 self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                self.sock.connect(('127.0.0.1', self.port))
+                self.sock.connect(("127.0.0.1", self.port))
                 return True
             except ConnectionRefusedError:
                 time.sleep(1.0)
         return False
+
     def send(self, type_, command=None, args=None):
         msg = {"seq": self.seq, "type": type_}
-        if command: msg["command"] = command
-        if args: msg["arguments"] = args
+        if command:
+            msg["command"] = command
+        if args:
+            msg["arguments"] = args
         body = json.dumps(msg)
-        self.sock.sendall(f"Content-Length: {len(body)}\r\n\r\n{body}".encode('utf-8'))
+        self.sock.sendall(f"Content-Length: {len(body)}\r\n\r\n{body}".encode("utf-8"))
         self.seq += 1
         return self.seq - 1
+
     def receive(self):
         try:
             head = b""
             while b"\r\n\r\n" not in head:
                 chunk = self.sock.recv(1)
-                if not chunk: return None
+                if not chunk:
+                    return None
                 head += chunk
             content_len = int(head.decode().split("Content-Length: ")[1].strip())
             body = b""
             while len(body) < content_len:
                 chunk = self.sock.recv(content_len - len(body))
-                if not chunk: return None
+                if not chunk:
+                    return None
                 body += chunk
             return json.loads(body)
-        except: return None
+        except:
+            return None
+
     def request(self, command, args=None):
         req_seq = self.send("request", command, args)
         while True:
             msg = self.receive()
-            if not msg: return None
+            if not msg:
+                return None
             if msg.get("type") == "response" and msg.get("request_seq") == req_seq:
                 return msg
+
 
 def evaluate_expression(client, frame_id, expr):
     resp = client.request("evaluate", {"expression": expr, "frameId": frame_id, "context": "watch"})
     if resp and resp.get("success"):
         return resp["body"].get("result")
     return None
+
 
 def get_variable_value(client, frame_id, var_name):
     scopes_resp = client.request("scopes", {"frameId": frame_id})
@@ -63,20 +76,22 @@ def get_variable_value(client, frame_id, var_name):
                             return v["value"]
     return None
 
+
 def get_specula_root():
     """Auto-detect Specula root directory."""
     # Try environment variable first
-    specula_root = os.environ.get('SPECULA_ROOT')
+    specula_root = os.environ.get("SPECULA_ROOT")
     if specula_root:
         return specula_root
     # Calculate relative to this file: tools/trace_debugger/examples/demo/xxx.py
     # Go up to specula root: ../../../../
     this_file = os.path.abspath(__file__)
-    demo_dir = os.path.dirname(this_file)           # .../demo
-    examples_dir = os.path.dirname(demo_dir)        # .../examples
+    demo_dir = os.path.dirname(this_file)  # .../demo
+    examples_dir = os.path.dirname(demo_dir)  # .../examples
     trace_debugger_dir = os.path.dirname(examples_dir)  # .../trace_debugger
-    tools_dir = os.path.dirname(trace_debugger_dir)     # .../tools
-    return os.path.dirname(tools_dir)                   # .../Specula
+    tools_dir = os.path.dirname(trace_debugger_dir)  # .../tools
+    return os.path.dirname(tools_dir)  # .../Specula
+
 
 specula_root = get_specula_root()
 work_dir = os.path.join(specula_root, "data/workloads/etcdraft/scenarios/progress_inflights/spec")
@@ -88,103 +103,131 @@ env["JSON"] = "../traces/confchange_disable_validation.ndjson"
 
 print("检查 Line 438 处，i 和 j 的值，以及 Line 439 条件是否满足...")
 
-proc = subprocess.Popen([
-    "java", "-XX:+UseParallelGC", "-Xmx4G",
-    "-cp", f"{tla_jar}:{community_jar}",
-    "tlc2.TLC", "-debugger", "port=4712",
-    "-config", "Traceetcdraft_progress.cfg", "Traceetcdraft_progress.tla"
-], cwd=work_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
+proc = subprocess.Popen(
+    [
+        "java",
+        "-XX:+UseParallelGC",
+        "-Xmx4G",
+        "-cp",
+        f"{tla_jar}:{community_jar}",
+        "tlc2.TLC",
+        "-debugger",
+        "port=4712",
+        "-config",
+        "Traceetcdraft_progress.cfg",
+        "Traceetcdraft_progress.tla",
+    ],
+    cwd=work_dir,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+    env=env,
+)
+
 
 def read_stdout(pipe):
-    for line in iter(pipe.readline, ''): pass
+    for line in iter(pipe.readline, ""):
+        pass
     pipe.close()
+
 
 client = DebugClient()
 
 try:
     while True:
         line = proc.stdout.readline()
-        if not line or "Debugger is listening" in line: break
-    
+        if not line or "Debugger is listening" in line:
+            break
+
     t = threading.Thread(target=read_stdout, args=(proc.stdout,))
     t.daemon = True
     t.start()
-    
+
     if not client.connect():
         print("Connection failed")
         exit(1)
-    
+
     client.request("initialize", {"adapterID": "tlc"})
     spec_path = os.path.join(work_dir, "etcdraft_progress.tla")
-    
+
     # 断点在 Line 438（state[i] = Leader 检查通过后）
-    client.request("setBreakpoints", {
-        "source": {"name": "etcdraft_progress.tla", "path": spec_path},
-        "breakpoints": [{"line": 438, "condition": "l = 29"}]
-    })
-    
+    client.request(
+        "setBreakpoints",
+        {
+            "source": {"name": "etcdraft_progress.tla", "path": spec_path},
+            "breakpoints": [{"line": 438, "condition": "l = 29"}],
+        },
+    )
+
     client.request("configurationDone", {})
     client.request("continue", {})
-    
+
     checked_combinations = set()
     hit_count = 0
-    
+
     print("\n检查所有在 Line 438 的 (i, j) 组合：\n")
-    
+
     while hit_count < 20:  # Check first 20 hits
         msg = client.receive()
-        if msg is None: break
+        if msg is None:
+            break
         if msg.get("type") == "event" and msg.get("event") == "stopped":
             hit_count += 1
-            
+
             stack_resp = client.request("stackTrace", {"threadId": 0})
             if not stack_resp or "body" not in stack_resp:
                 client.request("continue", {})
                 continue
-            
+
             frames = stack_resp["body"]["stackFrames"]
             if not frames:
                 client.request("continue", {})
                 continue
-            
+
             frame_id = frames[0]["id"]
-            
+
             i_val = get_variable_value(client, frame_id, "i")
             j_val = get_variable_value(client, frame_id, "j")
-            
+
             if (i_val, j_val) not in checked_combinations:
                 checked_combinations.add((i_val, j_val))
-                
+
                 # Check Line 439 condition
                 j_in_set_expr = f'"{j_val}" \\in GetConfig("{i_val}") \\union GetOutgoingConfig("{i_val}") \\union GetLearners("{i_val}")'
                 j_in_set = evaluate_expression(client, frame_id, j_in_set_expr)
-                
+
                 status = "✅" if j_in_set == "TRUE" else "❌"
                 print(f"  {status} i={i_val}, j={j_val}: Line 439 condition = {j_in_set}")
-                
+
                 if j_in_set != "TRUE":
                     # 查看具体的集合
                     get_config = evaluate_expression(client, frame_id, f'GetConfig("{i_val}")')
                     get_outgoing = evaluate_expression(client, frame_id, f'GetOutgoingConfig("{i_val}")')
                     get_learners = evaluate_expression(client, frame_id, f'GetLearners("{i_val}")')
-                    union = evaluate_expression(client, frame_id, f'GetConfig("{i_val}") \\union GetOutgoingConfig("{i_val}") \\union GetLearners("{i_val}")')
-                    
+                    union = evaluate_expression(
+                        client,
+                        frame_id,
+                        f'GetConfig("{i_val}") \\union GetOutgoingConfig("{i_val}") \\union GetLearners("{i_val}")',
+                    )
+
                     print(f"       GetConfig({i_val}) = {get_config}")
                     print(f"       GetOutgoingConfig({i_val}) = {get_outgoing}")
                     print(f"       GetLearners({i_val}) = {get_learners}")
                     print(f"       Union = {union}")
                     print(f"       j={j_val} not in Union!")
-            
+
             client.request("continue", {})
-    
+
     print(f"\n检查了 {len(checked_combinations)} 个不同的 (i, j) 组合")
-    
+
     client.request("disconnect", {})
 
 except Exception as e:
     print(f"Error: {e}")
     import traceback
+
     traceback.print_exc()
 finally:
-    if client.sock: client.sock.close()
+    if client.sock:
+        client.sock.close()
     proc.terminate()

--- a/tools/trace_debugger/mcp_server.py
+++ b/tools/trace_debugger/mcp_server.py
@@ -19,10 +19,10 @@ Usage:
     }
 """
 
-import asyncio
 import argparse
-import sys
+import asyncio
 import os
+import sys
 
 # Add src to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))

--- a/tools/trace_debugger/mcp_server.py
+++ b/tools/trace_debugger/mcp_server.py
@@ -25,7 +25,7 @@ import sys
 import os
 
 # Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 
 from tla_mcp import TLADebuggerMCPServer
 from tla_mcp.utils.logger import logger
@@ -53,13 +53,13 @@ Examples:
       }
     }
   }
-        """
+        """,
     )
     parser.add_argument(
         "--log-level",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         default="INFO",
-        help="Logging level (default: INFO)"
+        help="Logging level (default: INFO)",
     )
     return parser.parse_args()
 

--- a/tools/trace_debugger/src/__init__.py
+++ b/tools/trace_debugger/src/__init__.py
@@ -1,12 +1,12 @@
 """TLA+ Trace Validation Debugger."""
 
 from .debugger import (
-    DebugSession,
     Breakpoint,
     BreakpointHit,
     BreakpointStatistics,
-    collect_variable_values,
+    DebugSession,
     check_conditions_at_breakpoint,
+    collect_variable_values,
 )
 
 __all__ = [

--- a/tools/trace_debugger/src/client/dap_client.py
+++ b/tools/trace_debugger/src/client/dap_client.py
@@ -6,12 +6,14 @@ from collections import deque
 
 logger = logging.getLogger(__name__)
 
+
 class DAPClient:
     """
     High-performance DAP client with an internal event queue.
     Ensures no events are lost while waiting for responses.
     """
-    def __init__(self, host='127.0.0.1', port=4712, timeout=30):
+
+    def __init__(self, host="127.0.0.1", port=4712, timeout=30):
         self.host = host
         self.port = port
         self.timeout = timeout
@@ -35,17 +37,20 @@ class DAPClient:
         return False
 
     def disconnect(self):
-        if self.sock: self.sock.close()
+        if self.sock:
+            self.sock.close()
         self.connected = False
 
     def send(self, type_, command=None, args=None):
         msg = {"seq": self.seq, "type": type_}
-        if command: msg["command"] = command
-        if args: msg["arguments"] = args
+        if command:
+            msg["command"] = command
+        if args:
+            msg["arguments"] = args
         body = json.dumps(msg)
         full = f"Content-Length: {len(body)}\r\n\r\n{body}"
         try:
-            self.sock.sendall(full.encode('utf-8'))
+            self.sock.sendall(full.encode("utf-8"))
         except (BrokenPipeError, OSError) as e:
             logger.info(f"Connection lost while sending '{command}': {e}")
             self.connected = False
@@ -55,31 +60,36 @@ class DAPClient:
 
     def _read_once(self, timeout=None):
         """Reads one message and dispatches it to the appropriate queue."""
-        if not self.connected: return None
-        if timeout: self.sock.settimeout(timeout)
-        else: self.sock.settimeout(None)
+        if not self.connected:
+            return None
+        if timeout:
+            self.sock.settimeout(timeout)
+        else:
+            self.sock.settimeout(None)
 
         try:
             while b"\r\n\r\n" not in self._buffer:
                 chunk = self.sock.recv(4096)
-                if not chunk: return None
+                if not chunk:
+                    return None
                 self._buffer += chunk
-            
+
             header_part, self._buffer = self._buffer.split(b"\r\n\r\n", 1)
             content_length = 0
-            for line in header_part.decode('utf-8').split("\r\n"):
+            for line in header_part.decode("utf-8").split("\r\n"):
                 if line.startswith("Content-Length:"):
                     content_length = int(line.split(":")[1].strip())
-            
+
             while len(self._buffer) < content_length:
                 chunk = self.sock.recv(4096)
-                if not chunk: return None
+                if not chunk:
+                    return None
                 self._buffer += chunk
-            
+
             body = self._buffer[:content_length]
             self._buffer = self._buffer[content_length:]
-            msg = json.loads(body.decode('utf-8'))
-            
+            msg = json.loads(body.decode("utf-8"))
+
             if msg.get("type") == "event":
                 self.event_queue.append(msg)
                 # Heartbeat for UI
@@ -87,7 +97,7 @@ class DAPClient:
                     pass
             elif msg.get("type") == "response":
                 self.pending_responses[msg.get("request_seq")] = msg
-            
+
             return msg
         except socket.timeout:
             return None
@@ -101,7 +111,7 @@ class DAPClient:
         if req_seq is None:
             return None
         start_time = time.time()
-        while time.time() - start_time < 10: # 10s timeout per request
+        while time.time() - start_time < 10:  # 10s timeout per request
             if req_seq in self.pending_responses:
                 return self.pending_responses.pop(req_seq)
             self._read_once(timeout=0.1)

--- a/tools/trace_debugger/src/client/dap_client.py
+++ b/tools/trace_debugger/src/client/dap_client.py
@@ -1,7 +1,7 @@
-import socket
 import json
-import time
 import logging
+import socket
+import time
 from collections import deque
 
 logger = logging.getLogger(__name__)
@@ -99,9 +99,9 @@ class DAPClient:
                 self.pending_responses[msg.get("request_seq")] = msg
 
             return msg
-        except socket.timeout:
+        except TimeoutError:
             return None
-        except Exception as e:
+        except Exception:
             self.connected = False
             return None
 

--- a/tools/trace_debugger/src/debugger/__init__.py
+++ b/tools/trace_debugger/src/debugger/__init__.py
@@ -40,9 +40,9 @@ _src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _src_dir not in sys.path:
     sys.path.insert(0, _src_dir)
 
-from debugger.breakpoint import Breakpoint, BreakpointHit, BreakpointStatistics
-from debugger.session import DebugSession
-from debugger.utils import check_conditions_at_breakpoint, collect_variable_values
+from debugger.breakpoint import Breakpoint, BreakpointHit, BreakpointStatistics  # noqa: E402
+from debugger.session import DebugSession  # noqa: E402
+from debugger.utils import check_conditions_at_breakpoint, collect_variable_values  # noqa: E402
 
 __all__ = [
     # Core classes

--- a/tools/trace_debugger/src/debugger/__init__.py
+++ b/tools/trace_debugger/src/debugger/__init__.py
@@ -10,14 +10,16 @@ Quick Start:
     ...     spec_file="Traceetcdraft_progress.tla",
     ...     config_file="Traceetcdraft_progress.cfg",
     ...     trace_file="../traces/confchange_disable_validation.ndjson",
-    ...     work_dir="/path/to/spec"
+    ...     work_dir="/path/to/spec",
     ... )
     >>>
     >>> session.start()
-    >>> session.set_breakpoints([
-    ...     Breakpoint(line=522, condition='TLCGet("level") = 29', description="TraceNext entry"),
-    ...     Breakpoint(line=489, condition='TLCGet("level") = 29', description="SendAppendEntriesRequest"),
-    ... ])
+    >>> session.set_breakpoints(
+    ...     [
+    ...         Breakpoint(line=522, condition='TLCGet("level") = 29', description="TraceNext entry"),
+    ...         Breakpoint(line=489, condition='TLCGet("level") = 29', description="SendAppendEntriesRequest"),
+    ...     ]
+    ... )
     >>>
     >>> stats = session.run_until_done(timeout=120)
     >>> stats.print_summary()
@@ -45,12 +47,10 @@ from debugger.utils import collect_variable_values, check_conditions_at_breakpoi
 __all__ = [
     # Core classes
     "DebugSession",
-
     # Breakpoint data structures
     "Breakpoint",
     "BreakpointHit",
     "BreakpointStatistics",
-
     # Utility functions
     "collect_variable_values",
     "check_conditions_at_breakpoint",

--- a/tools/trace_debugger/src/debugger/__init__.py
+++ b/tools/trace_debugger/src/debugger/__init__.py
@@ -42,7 +42,7 @@ if _src_dir not in sys.path:
 
 from debugger.breakpoint import Breakpoint, BreakpointHit, BreakpointStatistics
 from debugger.session import DebugSession
-from debugger.utils import collect_variable_values, check_conditions_at_breakpoint
+from debugger.utils import check_conditions_at_breakpoint, collect_variable_values
 
 __all__ = [
     # Core classes

--- a/tools/trace_debugger/src/debugger/breakpoint.py
+++ b/tools/trace_debugger/src/debugger/breakpoint.py
@@ -1,7 +1,6 @@
 """Breakpoint data structures and statistics."""
 
 from dataclasses import dataclass, field
-from typing import List, Optional
 
 
 @dataclass
@@ -16,8 +15,8 @@ class Breakpoint:
     """
 
     line: int
-    file: Optional[str] = None
-    condition: Optional[str] = None
+    file: str | None = None
+    condition: str | None = None
     description: str = ""
 
 
@@ -47,10 +46,10 @@ class BreakpointStatistics:
         total_hits: Total number of breakpoint hits across all breakpoints
     """
 
-    hits: List[BreakpointHit] = field(default_factory=list)
+    hits: list[BreakpointHit] = field(default_factory=list)
     total_hits: int = 0
 
-    def get_hit_count(self, line: int, file: Optional[str] = None) -> int:
+    def get_hit_count(self, line: int, file: str | None = None) -> int:
         """Get hit count for a specific breakpoint.
 
         Args:
@@ -65,7 +64,7 @@ class BreakpointStatistics:
                 return hit.hit_count
         return 0
 
-    def get_never_hit(self) -> List[BreakpointHit]:
+    def get_never_hit(self) -> list[BreakpointHit]:
         """Get breakpoints that were never hit.
 
         Returns:
@@ -73,7 +72,7 @@ class BreakpointStatistics:
         """
         return [hit for hit in self.hits if hit.hit_count == 0]
 
-    def get_hit_breakpoints(self) -> List[BreakpointHit]:
+    def get_hit_breakpoints(self) -> list[BreakpointHit]:
         """Get breakpoints that were hit at least once.
 
         Returns:
@@ -88,11 +87,11 @@ class BreakpointStatistics:
             show_all: If True, show all breakpoints. If False, only show hit breakpoints.
         """
         print(f"\n{'=' * 70}")
-        print(f"Breakpoint Statistics Summary")
+        print("Breakpoint Statistics Summary")
         print(f"{'=' * 70}")
         print(f"Total hits: {self.total_hits}")
         print(f"Breakpoints hit: {len(self.get_hit_breakpoints())}/{len(self.hits)}")
-        print(f"\nDetailed breakdown:")
+        print("\nDetailed breakdown:")
 
         for hit in self.hits:
             if not show_all and hit.hit_count == 0:

--- a/tools/trace_debugger/src/debugger/breakpoint.py
+++ b/tools/trace_debugger/src/debugger/breakpoint.py
@@ -14,6 +14,7 @@ class Breakpoint:
         condition: Optional TLA+ expression to conditionally break
         description: Human-readable description for reporting
     """
+
     line: int
     file: Optional[str] = None
     condition: Optional[str] = None
@@ -30,6 +31,7 @@ class BreakpointHit:
         description: Breakpoint description
         hit_count: Number of times this breakpoint was hit
     """
+
     file: str
     line: int
     description: str
@@ -44,6 +46,7 @@ class BreakpointStatistics:
         hits: List of breakpoint hit statistics
         total_hits: Total number of breakpoint hits across all breakpoints
     """
+
     hits: List[BreakpointHit] = field(default_factory=list)
     total_hits: int = 0
 
@@ -84,9 +87,9 @@ class BreakpointStatistics:
         Args:
             show_all: If True, show all breakpoints. If False, only show hit breakpoints.
         """
-        print(f"\n{'='*70}")
+        print(f"\n{'=' * 70}")
         print(f"Breakpoint Statistics Summary")
-        print(f"{'='*70}")
+        print(f"{'=' * 70}")
         print(f"Total hits: {self.total_hits}")
         print(f"Breakpoints hit: {len(self.get_hit_breakpoints())}/{len(self.hits)}")
         print(f"\nDetailed breakdown:")
@@ -97,8 +100,7 @@ class BreakpointStatistics:
 
             status = "✅" if hit.hit_count > 0 else "❌"
             file_display = hit.file if hit.file else "(default)"
-            print(f"  {status} {file_display:30s} Line {hit.line:3d}: "
-                  f"{hit.hit_count:3d} hits - {hit.description}")
+            print(f"  {status} {file_display:30s} Line {hit.line:3d}: {hit.hit_count:3d} hits - {hit.description}")
 
         # Summary of never-hit breakpoints
         never_hit = self.get_never_hit()

--- a/tools/trace_debugger/src/debugger/session.py
+++ b/tools/trace_debugger/src/debugger/session.py
@@ -1,9 +1,8 @@
 """Debug session management for TLA+ trace validation."""
 
+import logging
 import os
 import sys
-import logging
-from typing import List, Dict, Optional
 
 # Add parent directory to path for imports
 _src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -11,8 +10,8 @@ if _src_dir not in sys.path:
     sys.path.insert(0, _src_dir)
 
 from client.dap_client import DAPClient
+from debugger.breakpoint import Breakpoint, BreakpointHit, BreakpointStatistics
 from executor.tlc_process import TLCExecutor
-from debugger.breakpoint import Breakpoint, BreakpointStatistics, BreakpointHit
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +44,8 @@ class DebugSession:
         config_file: str,
         trace_file: str,
         work_dir: str,
-        tla_jar: Optional[str] = None,
-        community_jar: Optional[str] = None,
+        tla_jar: str | None = None,
+        community_jar: str | None = None,
         port: int = 4712,
         host: str = "127.0.0.1",
     ):
@@ -96,8 +95,8 @@ class DebugSession:
 
         # Session state
         self.is_running = False
-        self.breakpoints: List[Breakpoint] = []
-        self.breakpoint_hits: Dict[tuple, BreakpointHit] = {}  # (file, line) -> BreakpointHit
+        self.breakpoints: list[Breakpoint] = []
+        self.breakpoint_hits: dict[tuple, BreakpointHit] = {}  # (file, line) -> BreakpointHit
 
     def start(self) -> bool:
         """Start TLC debugger and establish connection.
@@ -135,7 +134,7 @@ class DebugSession:
             logger.error(f"Error starting debug session: {e}")
             return False
 
-    def set_breakpoints(self, breakpoints: List[Breakpoint]):
+    def set_breakpoints(self, breakpoints: list[Breakpoint]):
         """Set breakpoints.
 
         Args:
@@ -184,7 +183,7 @@ class DebugSession:
 
         logger.info(f"Set {len(breakpoints)} breakpoint(s) across {len(breakpoints_by_file)} file(s)")
 
-    def run_until_done(self, timeout: Optional[int] = None, on_breakpoint_hit=None) -> BreakpointStatistics:
+    def run_until_done(self, timeout: int | None = None, on_breakpoint_hit=None) -> BreakpointStatistics:
         """Run until termination or timeout.
 
         Args:
@@ -236,7 +235,7 @@ class DebugSession:
                 output_text = event.get("body", {}).get("output", "")
                 # Look for final completion message (not intermediate "Finished checking")
                 if "Finished in" in output_text and " at " in output_text:
-                    logger.info(f"TLC execution finished (detected from output)")
+                    logger.info("TLC execution finished (detected from output)")
                     # Give TLC a moment to send any remaining events
                     time.sleep(0.1)
                     break
@@ -288,7 +287,7 @@ class DebugSession:
 
         return stats
 
-    def evaluate_at_breakpoint(self, expression: str, frame_id: int = 0) -> Optional[str]:
+    def evaluate_at_breakpoint(self, expression: str, frame_id: int = 0) -> str | None:
         """Evaluate expression at current breakpoint.
 
         Called when breakpoint is hit. Evaluates a TLA+ expression.
@@ -306,7 +305,7 @@ class DebugSession:
             return resp["body"].get("result")
         return None
 
-    def get_variables_at_breakpoint(self, var_names: List[str], frame_id: int = 0) -> Dict[str, str]:
+    def get_variables_at_breakpoint(self, var_names: list[str], frame_id: int = 0) -> dict[str, str]:
         """Get variable values at current breakpoint.
 
         Supports:
@@ -359,7 +358,7 @@ class DebugSession:
             scopes_resp = self.client.request("scopes", {"frameId": frame_id})
 
             if not scopes_resp or not scopes_resp.get("success"):
-                logger.warning(f"DEBUG: Failed to get scopes or request unsuccessful")
+                logger.warning("DEBUG: Failed to get scopes or request unsuccessful")
                 return result
 
             logger.info(f"DEBUG: Available scopes: {[s['name'] for s in scopes_resp['body']['scopes']]}")
@@ -400,7 +399,7 @@ class DebugSession:
         logger.info(f"DEBUG: get_variables_at_breakpoint - Found {len(result)} variable(s): {list(result.keys())}")
         return result
 
-    def step_over(self) -> Optional[Dict[str, str]]:
+    def step_over(self) -> dict[str, str] | None:
         """Execute next line (step over function calls).
 
         This executes the current TLA+ expression/statement and stops at the next line,
@@ -424,7 +423,7 @@ class DebugSession:
             logger.info(f"Stepped to {location['file']}:{location['line']}")
         return location
 
-    def step_into(self) -> Optional[Dict[str, str]]:
+    def step_into(self) -> dict[str, str] | None:
         """Step into action/function calls.
 
         In TLA+, this enters the definition of an action when it's called.
@@ -449,7 +448,7 @@ class DebugSession:
             logger.info(f"Stepped into {location['file']}:{location['line']}")
         return location
 
-    def step_out(self) -> Optional[Dict[str, str]]:
+    def step_out(self) -> dict[str, str] | None:
         """Step out of current action/function.
 
         Returns to the caller of the current action. Useful when you've stepped
@@ -473,7 +472,7 @@ class DebugSession:
             logger.info(f"Stepped out to {location['file']}:{location['line']}")
         return location
 
-    def _wait_for_stop_event(self, timeout: int = 10) -> Optional[Dict[str, str]]:
+    def _wait_for_stop_event(self, timeout: int = 10) -> dict[str, str] | None:
         """Wait for stopped event and return current location.
 
         This is a helper method for step operations. After sending a step request

--- a/tools/trace_debugger/src/debugger/session.py
+++ b/tools/trace_debugger/src/debugger/session.py
@@ -28,21 +28,28 @@ class DebugSession:
         ...     spec_file="Traceetcdraft_progress.tla",
         ...     config_file="Traceetcdraft_progress.cfg",
         ...     trace_file="../traces/confchange_disable_validation.ndjson",
-        ...     work_dir="/path/to/spec"
+        ...     work_dir="/path/to/spec",
         ... )
         >>> session.start()
-        >>> session.set_breakpoints([
-        ...     Breakpoint(line=522, condition='TLCGet("level") = 29', description="TraceNext entry")
-        ... ])
+        >>> session.set_breakpoints(
+        ...     [Breakpoint(line=522, condition='TLCGet("level") = 29', description="TraceNext entry")]
+        ... )
         >>> stats = session.run_until_done(timeout=120)
         >>> stats.print_summary()
         >>> session.close()
     """
 
-    def __init__(self, spec_file: str, config_file: str, trace_file: str,
-                 work_dir: str, tla_jar: Optional[str] = None,
-                 community_jar: Optional[str] = None, port: int = 4712,
-                 host: str = '127.0.0.1'):
+    def __init__(
+        self,
+        spec_file: str,
+        config_file: str,
+        trace_file: str,
+        work_dir: str,
+        tla_jar: Optional[str] = None,
+        community_jar: Optional[str] = None,
+        port: int = 4712,
+        host: str = "127.0.0.1",
+    ):
         """Initialize debug session.
 
         Args:
@@ -66,19 +73,19 @@ class DebugSession:
         # Try to find lib directory relative to this file or use environment variable
         if tla_jar is None or community_jar is None:
             # Try environment variable first
-            specula_root = os.environ.get('SPECULA_ROOT')
+            specula_root = os.environ.get("SPECULA_ROOT")
             if specula_root:
-                default_lib = os.path.join(specula_root, 'lib')
+                default_lib = os.path.join(specula_root, "lib")
             else:
                 # Calculate relative to this file: tools/trace_debugger/src/debugger/session.py
                 # Go up to specula root: ../../../../lib
                 this_file = os.path.abspath(__file__)
                 debugger_src_dir = os.path.dirname(this_file)  # .../src/debugger
-                src_dir = os.path.dirname(debugger_src_dir)     # .../src
-                tool_dir = os.path.dirname(src_dir)             # .../trace_debugger
-                tools_dir = os.path.dirname(tool_dir)           # .../tools
-                specula_root = os.path.dirname(tools_dir)       # .../specula
-                default_lib = os.path.join(specula_root, 'lib')
+                src_dir = os.path.dirname(debugger_src_dir)  # .../src
+                tool_dir = os.path.dirname(src_dir)  # .../trace_debugger
+                tools_dir = os.path.dirname(tool_dir)  # .../tools
+                specula_root = os.path.dirname(tools_dir)  # .../specula
+                default_lib = os.path.join(specula_root, "lib")
 
         self.tla_jar = tla_jar or os.path.join(default_lib, "tla2tools.jar")
         self.community_jar = community_jar or os.path.join(default_lib, "CommunityModules-deps.jar")
@@ -106,7 +113,7 @@ class DebugSession:
                 config_file=self.config_file,
                 trace_file=self.trace_file,
                 cwd=self.work_dir,
-                port=self.port
+                port=self.port,
             ):
                 logger.error("Failed to start TLC executor")
                 return False
@@ -164,25 +171,20 @@ class DebugSession:
             logger.info(f"DEBUG: file_path: {file_path}")
             logger.info(f"DEBUG: breakpoints: {bp_list}")
 
-            self.client.request("setBreakpoints", {
-                "source": {"name": file_name, "path": file_path},
-                "breakpoints": bp_list
-            })
+            self.client.request(
+                "setBreakpoints", {"source": {"name": file_name, "path": file_path}, "breakpoints": bp_list}
+            )
 
             # Initialize statistics tracking
             for bp in bps:
                 key = (file_name, bp.line)
                 self.breakpoint_hits[key] = BreakpointHit(
-                    file=file_name,
-                    line=bp.line,
-                    description=bp.description,
-                    hit_count=0
+                    file=file_name, line=bp.line, description=bp.description, hit_count=0
                 )
 
         logger.info(f"Set {len(breakpoints)} breakpoint(s) across {len(breakpoints_by_file)} file(s)")
 
-    def run_until_done(self, timeout: Optional[int] = None,
-                       on_breakpoint_hit=None) -> BreakpointStatistics:
+    def run_until_done(self, timeout: Optional[int] = None, on_breakpoint_hit=None) -> BreakpointStatistics:
         """Run until termination or timeout.
 
         Args:
@@ -200,6 +202,7 @@ class DebugSession:
 
         total_hits = 0
         import time
+
         start_time = time.time()
 
         while True:
@@ -254,8 +257,8 @@ class DebugSession:
                         # Update hit count (only for our breakpoints)
                         # Try exact match first, then with .tla extension
                         key = (file_name, line)
-                        if key not in self.breakpoint_hits and not file_name.endswith('.tla'):
-                            key = (file_name + '.tla', line)
+                        if key not in self.breakpoint_hits and not file_name.endswith(".tla"):
+                            key = (file_name + ".tla", line)
 
                         if key in self.breakpoint_hits:
                             self.breakpoint_hits[key].hit_count += 1
@@ -281,15 +284,11 @@ class DebugSession:
                 break
 
         # Build statistics
-        stats = BreakpointStatistics(
-            hits=list(self.breakpoint_hits.values()),
-            total_hits=total_hits
-        )
+        stats = BreakpointStatistics(hits=list(self.breakpoint_hits.values()), total_hits=total_hits)
 
         return stats
 
-    def evaluate_at_breakpoint(self, expression: str,
-                               frame_id: int = 0) -> Optional[str]:
+    def evaluate_at_breakpoint(self, expression: str, frame_id: int = 0) -> Optional[str]:
         """Evaluate expression at current breakpoint.
 
         Called when breakpoint is hit. Evaluates a TLA+ expression.
@@ -301,18 +300,13 @@ class DebugSession:
         Returns:
             str: Evaluation result, or None if failed
         """
-        resp = self.client.request("evaluate", {
-            "expression": expression,
-            "frameId": frame_id,
-            "context": "watch"
-        })
+        resp = self.client.request("evaluate", {"expression": expression, "frameId": frame_id, "context": "watch"})
 
         if resp and resp.get("success"):
             return resp["body"].get("result")
         return None
 
-    def get_variables_at_breakpoint(self, var_names: List[str],
-                                    frame_id: int = 0) -> Dict[str, str]:
+    def get_variables_at_breakpoint(self, var_names: List[str], frame_id: int = 0) -> Dict[str, str]:
         """Get variable values at current breakpoint.
 
         Supports:
@@ -335,13 +329,13 @@ class DebugSession:
         complex_exprs = []
 
         # Expressions contain: operators, function calls, field access, indexing
-        expression_indicators = ['.', '[', '+', '-', '*', '/', '(', ')', '=', '<', '>', '\\']
+        expression_indicators = [".", "[", "+", "-", "*", "/", "(", ")", "=", "<", ">", "\\"]
 
         for var_name in var_names:
             # Check if it's a complex expression
             is_expr = any(char in var_name for char in expression_indicators)
             # Also check if it has spaces (likely an expression like "l + 1")
-            is_expr = is_expr or ' ' in var_name
+            is_expr = is_expr or " " in var_name
 
             if is_expr:
                 complex_exprs.append(var_name)
@@ -377,9 +371,7 @@ class DebugSession:
                 logger.info(f"DEBUG: Checking scope '{scope_name}' (vref={vref})")
 
                 if vref > 0:
-                    vars_resp = self.client.request("variables", {
-                        "variablesReference": vref
-                    })
+                    vars_resp = self.client.request("variables", {"variablesReference": vref})
                     if vars_resp and vars_resp.get("success"):
                         variables = vars_resp["body"]["variables"]
                         logger.info(f"DEBUG: Scope '{scope_name}' has {len(variables)} variable(s) at first level")
@@ -390,9 +382,7 @@ class DebugSession:
                             # Only query containers (vref > 0), skip leaf nodes
                             if var_ref > 0:
                                 logger.info(f"DEBUG:   Querying container '{v['name']}' (vref={var_ref})")
-                                nested_resp = self.client.request("variables", {
-                                    "variablesReference": var_ref
-                                })
+                                nested_resp = self.client.request("variables", {"variablesReference": var_ref})
 
                                 if nested_resp and nested_resp.get("success"):
                                     nested_vars = nested_resp["body"]["variables"]
@@ -496,6 +486,7 @@ class DebugSession:
             Dict with file, line, frame_id (all as strings), or None if timeout
         """
         import time
+
         start_time = time.time()
 
         while (time.time() - start_time) < timeout:
@@ -520,7 +511,7 @@ class DebugSession:
                         return {
                             "file": frame.get("source", {}).get("name", ""),
                             "line": str(frame.get("line", 0)),
-                            "frame_id": str(frame.get("id", 0))
+                            "frame_id": str(frame.get("id", 0)),
                         }
 
             # If TLC terminates during stepping, return None

--- a/tools/trace_debugger/src/debugger/session.py
+++ b/tools/trace_debugger/src/debugger/session.py
@@ -9,9 +9,9 @@ _src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _src_dir not in sys.path:
     sys.path.insert(0, _src_dir)
 
-from client.dap_client import DAPClient
-from debugger.breakpoint import Breakpoint, BreakpointHit, BreakpointStatistics
-from executor.tlc_process import TLCExecutor
+from client.dap_client import DAPClient  # noqa: E402
+from debugger.breakpoint import Breakpoint, BreakpointHit, BreakpointStatistics  # noqa: E402
+from executor.tlc_process import TLCExecutor  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/tools/trace_debugger/src/debugger/utils.py
+++ b/tools/trace_debugger/src/debugger/utils.py
@@ -23,7 +23,7 @@ def collect_variable_values(
     condition: str,
     variables: List[str],
     max_samples: int = 10,
-    breakpoint_file: Optional[str] = None
+    breakpoint_file: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Collect variable values across multiple breakpoint hits.
 
@@ -49,7 +49,7 @@ def collect_variable_values(
         ...     breakpoint_line=438,
         ...     condition='TLCGet("level") = 29',
         ...     variables=["i", "j", "GetConfig(i)"],
-        ...     max_samples=10
+        ...     max_samples=10,
         ... )
         >>> for v in values:
         ...     print(f"i={v['i']}, j={v['j']}, GetConfig(i)={v['GetConfig(i)']}")
@@ -62,7 +62,7 @@ def collect_variable_values(
         line=breakpoint_line,
         file=breakpoint_file,
         condition=condition,
-        description=f"Collecting variables: {', '.join(variables)}"
+        description=f"Collecting variables: {', '.join(variables)}",
     )
     session.set_breakpoints([bp])
 
@@ -120,10 +120,7 @@ def collect_variable_values(
     return samples
 
 
-def check_conditions_at_breakpoint(
-    session: DebugSession,
-    conditions: Dict[str, str]
-) -> Dict[str, Any]:
+def check_conditions_at_breakpoint(session: DebugSession, conditions: Dict[str, str]) -> Dict[str, Any]:
     """Check multiple conditions at current breakpoint.
 
     This assumes the debugger is already stopped at a breakpoint.
@@ -139,11 +136,9 @@ def check_conditions_at_breakpoint(
 
     Example:
         >>> # Assume we're stopped at a breakpoint
-        >>> results = check_conditions_at_breakpoint(session, {
-        ...     "i != j": "i /= j",
-        ...     "range valid": "range[1] <= range[2]",
-        ...     "is leader": "state[i] = Leader"
-        ... })
+        >>> results = check_conditions_at_breakpoint(
+        ...     session, {"i != j": "i /= j", "range valid": "range[1] <= range[2]", "is leader": "state[i] = Leader"}
+        ... )
         >>> for desc, result in results.items():
         ...     print(f"{desc}: {result}")
     """

--- a/tools/trace_debugger/src/debugger/utils.py
+++ b/tools/trace_debugger/src/debugger/utils.py
@@ -11,8 +11,8 @@ _src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _src_dir not in sys.path:
     sys.path.insert(0, _src_dir)
 
-from debugger.breakpoint import Breakpoint
-from debugger.session import DebugSession
+from debugger.breakpoint import Breakpoint  # noqa: E402
+from debugger.session import DebugSession  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/tools/trace_debugger/src/debugger/utils.py
+++ b/tools/trace_debugger/src/debugger/utils.py
@@ -1,18 +1,18 @@
 """Utility functions for advanced debugging scenarios."""
 
+import logging
 import os
 import sys
 import time
-import logging
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 # Add parent directory to path for imports
 _src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _src_dir not in sys.path:
     sys.path.insert(0, _src_dir)
 
-from debugger.session import DebugSession
 from debugger.breakpoint import Breakpoint
+from debugger.session import DebugSession
 
 logger = logging.getLogger(__name__)
 
@@ -21,10 +21,10 @@ def collect_variable_values(
     session: DebugSession,
     breakpoint_line: int,
     condition: str,
-    variables: List[str],
+    variables: list[str],
     max_samples: int = 10,
-    breakpoint_file: Optional[str] = None,
-) -> List[Dict[str, Any]]:
+    breakpoint_file: str | None = None,
+) -> list[dict[str, Any]]:
     """Collect variable values across multiple breakpoint hits.
 
     This is useful for understanding why a condition fails by examining
@@ -120,7 +120,7 @@ def collect_variable_values(
     return samples
 
 
-def check_conditions_at_breakpoint(session: DebugSession, conditions: Dict[str, str]) -> Dict[str, Any]:
+def check_conditions_at_breakpoint(session: DebugSession, conditions: dict[str, str]) -> dict[str, Any]:
     """Check multiple conditions at current breakpoint.
 
     This assumes the debugger is already stopped at a breakpoint.

--- a/tools/trace_debugger/src/executor/tlc_process.py
+++ b/tools/trace_debugger/src/executor/tlc_process.py
@@ -6,6 +6,7 @@ import time
 
 logger = logging.getLogger(__name__)
 
+
 class TLCExecutor:
     def __init__(self, tla_jar_path=None, community_jar_path=None):
         self.process = None
@@ -21,18 +22,17 @@ class TLCExecutor:
         try:
             # Find and kill processes matching: java + tlc2.TLC + -debugger + port=<port>
             import psutil
+
             killed_count = 0
-            for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
+            for proc in psutil.process_iter(["pid", "name", "cmdline"]):
                 try:
-                    cmdline = proc.info.get('cmdline', [])
+                    cmdline = proc.info.get("cmdline", [])
                     if not cmdline:
                         continue
 
-                    cmdline_str = ' '.join(cmdline)
+                    cmdline_str = " ".join(cmdline)
                     # Check if it's a TLC debugger process on our port
-                    if ('tlc2.TLC' in cmdline_str and
-                        '-debugger' in cmdline_str and
-                        f'port={port}' in cmdline_str):
+                    if "tlc2.TLC" in cmdline_str and "-debugger" in cmdline_str and f"port={port}" in cmdline_str:
                         logger.warning(f"Found zombie TLC process (PID {proc.pid}), killing...")
                         proc.kill()
                         proc.wait(timeout=3)
@@ -48,8 +48,9 @@ class TLCExecutor:
             # If psutil is not available, fall back to pkill
             logger.warning("psutil not available, using pkill fallback")
             try:
-                subprocess.run(['pkill', '-9', '-f', f'tlc2.TLC.*-debugger.*port={port}'],
-                             stderr=subprocess.DEVNULL, check=False)
+                subprocess.run(
+                    ["pkill", "-9", "-f", f"tlc2.TLC.*-debugger.*port={port}"], stderr=subprocess.DEVNULL, check=False
+                )
                 time.sleep(0.5)
             except Exception as e:
                 logger.warning(f"Could not cleanup zombie processes: {e}")
@@ -60,13 +61,27 @@ class TLCExecutor:
 
         classpath = f"{self.tla_jar_path}:{self.community_jar_path}"
         env = os.environ.copy()
-        if trace_file: env["JSON"] = trace_file
+        if trace_file:
+            env["JSON"] = trace_file
 
-        cmd = ["java", "-XX:+UseParallelGC", "-Xmx4G", "-cp", classpath,
-               "tlc2.TLC", "-debugger", f"port={port}", "-config", config_file, spec_file]
+        cmd = [
+            "java",
+            "-XX:+UseParallelGC",
+            "-Xmx4G",
+            "-cp",
+            classpath,
+            "tlc2.TLC",
+            "-debugger",
+            f"port={port}",
+            "-config",
+            config_file,
+            spec_file,
+        ]
 
         logger.info(f"Launching TLC: {' '.join(cmd)}")
-        self.process = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
+        self.process = subprocess.Popen(
+            cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env
+        )
 
         def drain_and_watch():
             """Drain TLC stdout and signal readiness or failure.

--- a/tools/trace_debugger/src/executor/tlc_process.py
+++ b/tools/trace_debugger/src/executor/tlc_process.py
@@ -1,7 +1,7 @@
+import logging
+import os
 import subprocess
 import threading
-import os
-import logging
 import time
 
 logger = logging.getLogger(__name__)

--- a/tools/trace_debugger/src/tla_mcp/handlers/base.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/base.py
@@ -82,10 +82,7 @@ class BaseHandler(ABC):
         try:
             # 1. Validate arguments
             logger.info(f"[{self.tool_name}] Validating arguments...")
-            validated_args = validate_arguments(
-                arguments,
-                self.argument_schema
-            )
+            validated_args = validate_arguments(arguments, self.argument_schema)
 
             # 2. Execute tool logic
             logger.info(f"[{self.tool_name}] Executing...")
@@ -98,18 +95,14 @@ class BaseHandler(ABC):
 
         except ValidationError as e:
             logger.error(f"[{self.tool_name}] Validation error: {e}")
-            return format_error_response(
-                tool_name=self.tool_name,
-                error_type="ValidationError",
-                error_message=str(e)
-            )
+            return format_error_response(tool_name=self.tool_name, error_type="ValidationError", error_message=str(e))
         except ExecutionError as e:
             logger.error(f"[{self.tool_name}] Execution error: {e}")
             return format_error_response(
                 tool_name=self.tool_name,
                 error_type="ExecutionError",
                 error_message=str(e),
-                details=e.details if hasattr(e, 'details') else None
+                details=e.details if hasattr(e, "details") else None,
             )
         except Exception as e:
             logger.error(f"[{self.tool_name}] Unexpected error: {e}")
@@ -118,5 +111,5 @@ class BaseHandler(ABC):
                 tool_name=self.tool_name,
                 error_type="UnexpectedError",
                 error_message=str(e),
-                traceback=traceback.format_exc()
+                traceback=traceback.format_exc(),
             )

--- a/tools/trace_debugger/src/tla_mcp/handlers/base.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/base.py
@@ -3,12 +3,12 @@
 import json
 import traceback
 from abc import ABC, abstractmethod
-from typing import Dict, Any
+from typing import Any
 
+from ..utils.errors import ExecutionError, ValidationError
+from ..utils.formatters import format_error_response
 from ..utils.logger import logger
 from ..utils.validators import validate_arguments
-from ..utils.formatters import format_error_response
-from ..utils.errors import ValidationError, ExecutionError
 
 
 class BaseHandler(ABC):
@@ -28,7 +28,7 @@ class BaseHandler(ABC):
 
     @property
     @abstractmethod
-    def argument_schema(self) -> Dict[str, Any]:
+    def argument_schema(self) -> dict[str, Any]:
         """JSON schema for arguments validation.
 
         Should be a valid JSON Schema (draft 7) object with:
@@ -49,7 +49,7 @@ class BaseHandler(ABC):
         pass
 
     @abstractmethod
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Execute the tool logic.
 
         Args:
@@ -64,7 +64,7 @@ class BaseHandler(ABC):
         """
         pass
 
-    async def handle(self, arguments: Dict[str, Any]) -> str:
+    async def handle(self, arguments: dict[str, Any]) -> str:
         """Handle tool call with validation and error handling.
 
         This is the main entry point for tool execution. It:

--- a/tools/trace_debugger/src/tla_mcp/handlers/clean_traces.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/clean_traces.py
@@ -2,11 +2,11 @@
 
 import glob
 import os
-from typing import Dict, Any, List
+from typing import Any
 
-from .base import BaseHandler
 from ..utils.errors import ExecutionError
 from ..utils.logger import logger
+from .base import BaseHandler
 
 
 class CleanTracesHandler(BaseHandler):
@@ -20,7 +20,7 @@ class CleanTracesHandler(BaseHandler):
         return "clean_traces"
 
     @property
-    def argument_schema(self) -> Dict[str, Any]:
+    def argument_schema(self) -> dict[str, Any]:
         return {
             "type": "object",
             "properties": {
@@ -29,7 +29,7 @@ class CleanTracesHandler(BaseHandler):
             "required": ["spec_file"],
         }
 
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Delete TTrace output files for a spec file.
 
         Args:
@@ -54,8 +54,8 @@ class CleanTracesHandler(BaseHandler):
         pattern = os.path.join(spec_dir, f"{spec_basename}_TTrace_*")
         matched_files = sorted(glob.glob(pattern))
 
-        deleted_files: List[str] = []
-        failed_files: List[str] = []
+        deleted_files: list[str] = []
+        failed_files: list[str] = []
 
         for file_path in matched_files:
             try:

--- a/tools/trace_debugger/src/tla_mcp/handlers/clean_traces.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/clean_traces.py
@@ -24,12 +24,9 @@ class CleanTracesHandler(BaseHandler):
         return {
             "type": "object",
             "properties": {
-                "spec_file": {
-                    "type": "string",
-                    "description": "Path to the TLA+ spec file (e.g., Traceetcdraft.tla)"
-                },
+                "spec_file": {"type": "string", "description": "Path to the TLA+ spec file (e.g., Traceetcdraft.tla)"},
             },
-            "required": ["spec_file"]
+            "required": ["spec_file"],
         }
 
     async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -44,15 +41,11 @@ class CleanTracesHandler(BaseHandler):
         spec_file = arguments["spec_file"]
 
         if not os.path.exists(spec_file):
-            raise ExecutionError(
-                f"Spec file not found: {spec_file}",
-                details={"spec_file": spec_file, "exists": False}
-            )
+            raise ExecutionError(f"Spec file not found: {spec_file}", details={"spec_file": spec_file, "exists": False})
 
         if not os.path.isfile(spec_file):
             raise ExecutionError(
-                f"Spec path is not a file: {spec_file}",
-                details={"spec_file": spec_file, "is_file": False}
+                f"Spec path is not a file: {spec_file}", details={"spec_file": spec_file, "is_file": False}
             )
 
         spec_dir = os.path.dirname(spec_file) or "."

--- a/tools/trace_debugger/src/tla_mcp/handlers/spec_validation.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/spec_validation.py
@@ -2,10 +2,10 @@
 
 import os
 import subprocess
-from typing import Dict, Any
+from typing import Any
 
-from .base import BaseHandler
 from ..utils.errors import ExecutionError
+from .base import BaseHandler
 
 
 class SpecValidationHandler(BaseHandler):
@@ -20,7 +20,7 @@ class SpecValidationHandler(BaseHandler):
         return "validate_spec_syntax"
 
     @property
-    def argument_schema(self) -> Dict[str, Any]:
+    def argument_schema(self) -> dict[str, Any]:
         return {
             "type": "object",
             "properties": {
@@ -32,7 +32,7 @@ class SpecValidationHandler(BaseHandler):
             "required": ["spec_file", "config_file", "work_dir"],
         }
 
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Validate TLA+ spec syntax.
 
         Args:

--- a/tools/trace_debugger/src/tla_mcp/handlers/spec_validation.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/spec_validation.py
@@ -114,13 +114,13 @@ class SpecValidationHandler(BaseHandler):
                 "work_dir": work_dir,
             }
 
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
             raise ExecutionError(
                 "Syntax validation timed out after 10 seconds", details={"spec_file": spec_file, "timeout": 10}
-            )
-        except FileNotFoundError:
+            ) from e
+        except FileNotFoundError as e:
             raise ExecutionError(
                 "Java not found. Please ensure Java is installed and in PATH", details={"command": "java"}
-            )
+            ) from e
         except Exception as e:
-            raise ExecutionError(f"Failed to run syntax validation: {e}", details={"error": str(e)})
+            raise ExecutionError(f"Failed to run syntax validation: {e}", details={"error": str(e)}) from e

--- a/tools/trace_debugger/src/tla_mcp/handlers/spec_validation.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/spec_validation.py
@@ -24,24 +24,12 @@ class SpecValidationHandler(BaseHandler):
         return {
             "type": "object",
             "properties": {
-                "spec_file": {
-                    "type": "string",
-                    "description": "TLA+ spec file name"
-                },
-                "config_file": {
-                    "type": "string",
-                    "description": "TLC config file name"
-                },
-                "work_dir": {
-                    "type": "string",
-                    "description": "Working directory (absolute path)"
-                },
-                "tla_jar": {
-                    "type": "string",
-                    "description": "Path to tla2tools.jar (optional)"
-                }
+                "spec_file": {"type": "string", "description": "TLA+ spec file name"},
+                "config_file": {"type": "string", "description": "TLC config file name"},
+                "work_dir": {"type": "string", "description": "Working directory (absolute path)"},
+                "tla_jar": {"type": "string", "description": "Path to tla2tools.jar (optional)"},
             },
-            "required": ["spec_file", "config_file", "work_dir"]
+            "required": ["spec_file", "config_file", "work_dir"],
         }
 
     async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -67,9 +55,9 @@ class SpecValidationHandler(BaseHandler):
         # Determine JAR path
         if not tla_jar:
             # Use default path (same logic as DebugSession)
-            specula_root = os.environ.get('SPECULA_ROOT')
+            specula_root = os.environ.get("SPECULA_ROOT")
             if specula_root:
-                tla_jar = os.path.join(specula_root, 'lib', 'tla2tools.jar')
+                tla_jar = os.path.join(specula_root, "lib", "tla2tools.jar")
             else:
                 # Calculate relative to this file
                 this_file = os.path.abspath(__file__)
@@ -79,31 +67,22 @@ class SpecValidationHandler(BaseHandler):
                 tool_dir = os.path.dirname(src_dir)
                 tools_dir = os.path.dirname(tool_dir)
                 specula_root = os.path.dirname(tools_dir)
-                tla_jar = os.path.join(specula_root, 'lib', 'tla2tools.jar')
+                tla_jar = os.path.join(specula_root, "lib", "tla2tools.jar")
 
         # Check if JAR exists
         if not os.path.exists(tla_jar):
-            raise ExecutionError(
-                f"TLA+ tools JAR not found: {tla_jar}",
-                details={"tla_jar": tla_jar, "exists": False}
-            )
+            raise ExecutionError(f"TLA+ tools JAR not found: {tla_jar}", details={"tla_jar": tla_jar, "exists": False})
 
         # Check if work_dir exists
         if not os.path.isdir(work_dir):
             raise ExecutionError(
-                f"Working directory not found: {work_dir}",
-                details={"work_dir": work_dir, "exists": False}
+                f"Working directory not found: {work_dir}", details={"work_dir": work_dir, "exists": False}
             )
 
         # Build SANY command for syntax check
         # SANY is the TLA+ syntax analyzer - it only parses and checks semantics,
         # without doing any state exploration (much faster than TLC)
-        cmd = [
-            "java",
-            "-cp", tla_jar,
-            "tla2sany.SANY",
-            spec_file
-        ]
+        cmd = ["java", "-cp", tla_jar, "tla2sany.SANY", spec_file]
 
         try:
             # Run SANY with short timeout (syntax check should be very fast, < 1 second)
@@ -112,7 +91,7 @@ class SpecValidationHandler(BaseHandler):
                 cwd=work_dir,
                 capture_output=True,
                 text=True,
-                timeout=10  # 10 seconds is more than enough for syntax check
+                timeout=10,  # 10 seconds is more than enough for syntax check
             )
 
             output = result.stdout + result.stderr
@@ -121,9 +100,9 @@ class SpecValidationHandler(BaseHandler):
             # Extract error messages if validation failed
             errors = []
             if not syntax_valid:
-                for line in output.split('\n'):
+                for line in output.split("\n"):
                     line = line.strip()
-                    if 'Error:' in line or 'error' in line.lower():
+                    if "Error:" in line or "error" in line.lower():
                         errors.append(line)
 
             return {
@@ -132,24 +111,16 @@ class SpecValidationHandler(BaseHandler):
                 "errors": errors,
                 "spec_file": spec_file,
                 "config_file": config_file,
-                "work_dir": work_dir
+                "work_dir": work_dir,
             }
 
         except subprocess.TimeoutExpired:
             raise ExecutionError(
-                "Syntax validation timed out after 10 seconds",
-                details={
-                    "spec_file": spec_file,
-                    "timeout": 10
-                }
+                "Syntax validation timed out after 10 seconds", details={"spec_file": spec_file, "timeout": 10}
             )
         except FileNotFoundError:
             raise ExecutionError(
-                "Java not found. Please ensure Java is installed and in PATH",
-                details={"command": "java"}
+                "Java not found. Please ensure Java is installed and in PATH", details={"command": "java"}
             )
         except Exception as e:
-            raise ExecutionError(
-                f"Failed to run syntax validation: {e}",
-                details={"error": str(e)}
-            )
+            raise ExecutionError(f"Failed to run syntax validation: {e}", details={"error": str(e)})

--- a/tools/trace_debugger/src/tla_mcp/handlers/trace_debugging.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/trace_debugging.py
@@ -15,7 +15,7 @@ _src_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 if _src_dir not in sys.path:
     sys.path.insert(0, _src_dir)
 
-from debugger import Breakpoint, DebugSession
+from debugger import Breakpoint, DebugSession  # noqa: E402
 
 
 class TraceDebuggingHandler(BaseHandler):

--- a/tools/trace_debugger/src/tla_mcp/handlers/trace_debugging.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/trace_debugging.py
@@ -4,18 +4,18 @@ import asyncio
 import os
 import sys
 import time
-from typing import Dict, Any, List
+from typing import Any
 
-from .base import BaseHandler
 from ..utils.errors import ExecutionError
 from ..utils.logger import logger
+from .base import BaseHandler
 
 # Add debugger to path
 _src_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 if _src_dir not in sys.path:
     sys.path.insert(0, _src_dir)
 
-from debugger import DebugSession, Breakpoint
+from debugger import Breakpoint, DebugSession
 
 
 class TraceDebuggingHandler(BaseHandler):
@@ -30,7 +30,7 @@ class TraceDebuggingHandler(BaseHandler):
         return "run_trace_debugging"
 
     @property
-    def argument_schema(self) -> Dict[str, Any]:
+    def argument_schema(self) -> dict[str, Any]:
         return {
             "type": "object",
             "properties": {
@@ -62,7 +62,7 @@ class TraceDebuggingHandler(BaseHandler):
             "required": ["spec_file", "config_file", "trace_file", "work_dir", "breakpoints"],
         }
 
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Execute trace validation with breakpoints.
 
         Args:
@@ -81,12 +81,12 @@ class TraceDebuggingHandler(BaseHandler):
         start_time = time.time()
 
         # 1. Create DebugSession
-        logger.info(f"Creating DebugSession...")
+        logger.info("Creating DebugSession...")
         session = self._create_session(arguments)
 
         try:
             # 2. Start TLC debugger
-            logger.info(f"Starting TLC debugger...")
+            logger.info("Starting TLC debugger...")
             if not session.start():
                 raise ExecutionError("Failed to start TLC debugger", details={"spec_file": arguments["spec_file"]})
 
@@ -198,7 +198,7 @@ class TraceDebuggingHandler(BaseHandler):
             logger.info("Closing debug session...")
             session.close()
 
-    def _create_session(self, args: Dict[str, Any]) -> DebugSession:
+    def _create_session(self, args: dict[str, Any]) -> DebugSession:
         """Create DebugSession from arguments."""
         return DebugSession(
             spec_file=args["spec_file"],
@@ -211,7 +211,7 @@ class TraceDebuggingHandler(BaseHandler):
             port=args.get("port", 4712),
         )
 
-    def _parse_breakpoints(self, bp_list: List[Dict]) -> List[Breakpoint]:
+    def _parse_breakpoints(self, bp_list: list[dict]) -> list[Breakpoint]:
         """Parse breakpoint list from arguments."""
         breakpoints = []
         for bp in bp_list:
@@ -225,7 +225,7 @@ class TraceDebuggingHandler(BaseHandler):
             )
         return breakpoints
 
-    def _format_statistics(self, stats) -> Dict[str, Any]:
+    def _format_statistics(self, stats) -> dict[str, Any]:
         """Format BreakpointStatistics to dict."""
         return {
             "total_hits": stats.total_hits,

--- a/tools/trace_debugger/src/tla_mcp/handlers/trace_debugging.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/trace_debugging.py
@@ -34,22 +34,10 @@ class TraceDebuggingHandler(BaseHandler):
         return {
             "type": "object",
             "properties": {
-                "spec_file": {
-                    "type": "string",
-                    "description": "TLA+ spec file name"
-                },
-                "config_file": {
-                    "type": "string",
-                    "description": "TLC config file name"
-                },
-                "trace_file": {
-                    "type": "string",
-                    "description": "Trace file path (relative to work_dir or absolute)"
-                },
-                "work_dir": {
-                    "type": "string",
-                    "description": "Working directory (absolute path)"
-                },
+                "spec_file": {"type": "string", "description": "TLA+ spec file name"},
+                "config_file": {"type": "string", "description": "TLC config file name"},
+                "trace_file": {"type": "string", "description": "Trace file path (relative to work_dir or absolute)"},
+                "work_dir": {"type": "string", "description": "Working directory (absolute path)"},
                 "breakpoints": {
                     "type": "array",
                     "description": "List of breakpoints to set",
@@ -59,38 +47,19 @@ class TraceDebuggingHandler(BaseHandler):
                             "line": {"type": "integer"},
                             "file": {"type": "string"},
                             "condition": {"type": "string"},
-                            "description": {"type": "string"}
+                            "description": {"type": "string"},
                         },
-                        "required": ["line"]
-                    }
+                        "required": ["line"],
+                    },
                 },
-                "timeout": {
-                    "type": "integer",
-                    "default": 300,
-                    "description": "Timeout in seconds"
-                },
-                "tla_jar": {
-                    "type": "string",
-                    "description": "Path to tla2tools.jar (optional)"
-                },
-                "community_jar": {
-                    "type": "string",
-                    "description": "Path to CommunityModules-deps.jar (optional)"
-                },
-                "host": {
-                    "type": "string",
-                    "default": "127.0.0.1",
-                    "description": "DAP server host"
-                },
-                "port": {
-                    "type": "integer",
-                    "default": 4712,
-                    "description": "DAP server port"
-                },
+                "timeout": {"type": "integer", "default": 300, "description": "Timeout in seconds"},
+                "tla_jar": {"type": "string", "description": "Path to tla2tools.jar (optional)"},
+                "community_jar": {"type": "string", "description": "Path to CommunityModules-deps.jar (optional)"},
+                "host": {"type": "string", "default": "127.0.0.1", "description": "DAP server host"},
+                "port": {"type": "integer", "default": 4712, "description": "DAP server port"},
                 # Phase 3: evaluate and collect_variables will be added here
             },
-            "required": ["spec_file", "config_file", "trace_file",
-                        "work_dir", "breakpoints"]
+            "required": ["spec_file", "config_file", "trace_file", "work_dir", "breakpoints"],
         }
 
     async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -119,10 +88,7 @@ class TraceDebuggingHandler(BaseHandler):
             # 2. Start TLC debugger
             logger.info(f"Starting TLC debugger...")
             if not session.start():
-                raise ExecutionError(
-                    "Failed to start TLC debugger",
-                    details={"spec_file": arguments["spec_file"]}
-                )
+                raise ExecutionError("Failed to start TLC debugger", details={"spec_file": arguments["spec_file"]})
 
             # 3. Set breakpoints
             breakpoints = self._parse_breakpoints(arguments["breakpoints"])
@@ -141,7 +107,7 @@ class TraceDebuggingHandler(BaseHandler):
                 """
                 if not name:
                     return name
-                return name.replace('.tla', '')
+                return name.replace(".tla", "")
 
             def files_match(file1: str, file2: str) -> bool:
                 """Check if two filenames match, ignoring .tla extension."""
@@ -165,12 +131,9 @@ class TraceDebuggingHandler(BaseHandler):
                         logger.info(f"Evaluating expressions at {file_name}:{line}")
                         for expr in eval_config["expressions"]:
                             result = session.evaluate_at_breakpoint(expr, frame_id)
-                            evaluated_results.append({
-                                "expression": expr,
-                                "result": result,
-                                "file": file_name,
-                                "line": line
-                            })
+                            evaluated_results.append(
+                                {"expression": expr, "result": result, "file": file_name, "line": line}
+                            )
 
                 # Handle collect_variables
                 if "collect_variables" in arguments:
@@ -180,18 +143,23 @@ class TraceDebuggingHandler(BaseHandler):
                     max_samples = collect_config.get("max_samples", 10)
 
                     # Check if this is the target breakpoint and we haven't collected enough samples
-                    if line == target_line and len(collected_vars) < max_samples and files_match(file_name, target_file):
-                        logger.info(f"Collecting variables at {file_name}:{line} (sample {len(collected_vars)+1}/{max_samples})")
-                        vars_dict = session.get_variables_at_breakpoint(
-                            collect_config["variables"],
-                            frame_id
+                    if (
+                        line == target_line
+                        and len(collected_vars) < max_samples
+                        and files_match(file_name, target_file)
+                    ):
+                        logger.info(
+                            f"Collecting variables at {file_name}:{line} (sample {len(collected_vars) + 1}/{max_samples})"
                         )
-                        collected_vars.append({
-                            "sample_index": len(collected_vars),
-                            "file": file_name,
-                            "line": line,
-                            "variables": vars_dict
-                        })
+                        vars_dict = session.get_variables_at_breakpoint(collect_config["variables"], frame_id)
+                        collected_vars.append(
+                            {
+                                "sample_index": len(collected_vars),
+                                "file": file_name,
+                                "line": line,
+                                "variables": vars_dict,
+                            }
+                        )
 
             # 5. Run trace validation with callback
             timeout = arguments.get("timeout", 300)
@@ -209,10 +177,7 @@ class TraceDebuggingHandler(BaseHandler):
             # 6. Build result
             execution_time = time.time() - start_time
 
-            result = {
-                "statistics": self._format_statistics(stats),
-                "execution_time": execution_time
-            }
+            result = {"statistics": self._format_statistics(stats), "execution_time": execution_time}
 
             # Add Phase 3 results if available
             if evaluated_results:
@@ -243,19 +208,21 @@ class TraceDebuggingHandler(BaseHandler):
             tla_jar=args.get("tla_jar"),
             community_jar=args.get("community_jar"),
             host=args.get("host", "127.0.0.1"),
-            port=args.get("port", 4712)
+            port=args.get("port", 4712),
         )
 
     def _parse_breakpoints(self, bp_list: List[Dict]) -> List[Breakpoint]:
         """Parse breakpoint list from arguments."""
         breakpoints = []
         for bp in bp_list:
-            breakpoints.append(Breakpoint(
-                line=bp["line"],
-                file=bp.get("file"),
-                condition=bp.get("condition"),
-                description=bp.get("description", f"Line {bp['line']}")
-            ))
+            breakpoints.append(
+                Breakpoint(
+                    line=bp["line"],
+                    file=bp.get("file"),
+                    condition=bp.get("condition"),
+                    description=bp.get("description", f"Line {bp['line']}"),
+                )
+            )
         return breakpoints
 
     def _format_statistics(self, stats) -> Dict[str, Any]:
@@ -268,16 +235,11 @@ class TraceDebuggingHandler(BaseHandler):
                     "line": hit.line,
                     "description": hit.description,
                     "hit_count": hit.hit_count,
-                    "was_hit": hit.hit_count > 0
+                    "was_hit": hit.hit_count > 0,
                 }
                 for hit in stats.hits
             ],
             "never_hit": [
-                {
-                    "file": hit.file,
-                    "line": hit.line,
-                    "description": hit.description
-                }
-                for hit in stats.get_never_hit()
-            ]
+                {"file": hit.file, "line": hit.line, "description": hit.description} for hit in stats.get_never_hit()
+            ],
         }

--- a/tools/trace_debugger/src/tla_mcp/handlers/trace_info.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/trace_info.py
@@ -23,12 +23,9 @@ class TraceInfoHandler(BaseHandler):
         return {
             "type": "object",
             "properties": {
-                "trace_file": {
-                    "type": "string",
-                    "description": "Path to trace file (absolute or relative)"
-                }
+                "trace_file": {"type": "string", "description": "Path to trace file (absolute or relative)"}
             },
-            "required": ["trace_file"]
+            "required": ["trace_file"],
         }
 
     async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -52,20 +49,18 @@ class TraceInfoHandler(BaseHandler):
         # Check if file exists
         if not os.path.exists(trace_file):
             raise ExecutionError(
-                f"Trace file not found: {trace_file}",
-                details={"trace_file": trace_file, "exists": False}
+                f"Trace file not found: {trace_file}", details={"trace_file": trace_file, "exists": False}
             )
 
         # Check if it's a file (not directory)
         if not os.path.isfile(trace_file):
             raise ExecutionError(
-                f"Path is not a file: {trace_file}",
-                details={"trace_file": trace_file, "is_file": False}
+                f"Path is not a file: {trace_file}", details={"trace_file": trace_file, "is_file": False}
             )
 
         try:
             # Read file
-            with open(trace_file, 'r', encoding='utf-8') as f:
+            with open(trace_file, "r", encoding="utf-8") as f:
                 lines = f.readlines()
 
             # Get file size
@@ -81,16 +76,12 @@ class TraceInfoHandler(BaseHandler):
                 "file_size_bytes": file_size,
                 "first_lines": first_lines,
                 "last_lines": last_lines,
-                "trace_file": trace_file
+                "trace_file": trace_file,
             }
 
         except UnicodeDecodeError as e:
             raise ExecutionError(
-                f"Failed to read trace file (encoding error): {e}",
-                details={"trace_file": trace_file, "error": str(e)}
+                f"Failed to read trace file (encoding error): {e}", details={"trace_file": trace_file, "error": str(e)}
             )
         except IOError as e:
-            raise ExecutionError(
-                f"Failed to read trace file: {e}",
-                details={"trace_file": trace_file, "error": str(e)}
-            )
+            raise ExecutionError(f"Failed to read trace file: {e}", details={"trace_file": trace_file, "error": str(e)})

--- a/tools/trace_debugger/src/tla_mcp/handlers/trace_info.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/trace_info.py
@@ -82,6 +82,8 @@ class TraceInfoHandler(BaseHandler):
         except UnicodeDecodeError as e:
             raise ExecutionError(
                 f"Failed to read trace file (encoding error): {e}", details={"trace_file": trace_file, "error": str(e)}
-            )
+            ) from e
         except OSError as e:
-            raise ExecutionError(f"Failed to read trace file: {e}", details={"trace_file": trace_file, "error": str(e)})
+            raise ExecutionError(
+                f"Failed to read trace file: {e}", details={"trace_file": trace_file, "error": str(e)}
+            ) from e

--- a/tools/trace_debugger/src/tla_mcp/handlers/trace_info.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/trace_info.py
@@ -1,10 +1,10 @@
 """Handler for get_trace_info tool."""
 
 import os
-from typing import Dict, Any
+from typing import Any
 
-from .base import BaseHandler
 from ..utils.errors import ExecutionError
+from .base import BaseHandler
 
 
 class TraceInfoHandler(BaseHandler):
@@ -19,7 +19,7 @@ class TraceInfoHandler(BaseHandler):
         return "get_trace_info"
 
     @property
-    def argument_schema(self) -> Dict[str, Any]:
+    def argument_schema(self) -> dict[str, Any]:
         return {
             "type": "object",
             "properties": {
@@ -28,7 +28,7 @@ class TraceInfoHandler(BaseHandler):
             "required": ["trace_file"],
         }
 
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Get trace file information.
 
         Args:
@@ -60,7 +60,7 @@ class TraceInfoHandler(BaseHandler):
 
         try:
             # Read file
-            with open(trace_file, "r", encoding="utf-8") as f:
+            with open(trace_file, encoding="utf-8") as f:
                 lines = f.readlines()
 
             # Get file size
@@ -83,5 +83,5 @@ class TraceInfoHandler(BaseHandler):
             raise ExecutionError(
                 f"Failed to read trace file (encoding error): {e}", details={"trace_file": trace_file, "error": str(e)}
             )
-        except IOError as e:
+        except OSError as e:
             raise ExecutionError(f"Failed to read trace file: {e}", details={"trace_file": trace_file, "error": str(e)})

--- a/tools/trace_debugger/src/tla_mcp/handlers/trace_validation.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/trace_validation.py
@@ -136,11 +136,11 @@ class TraceValidationHandler(BaseHandler):
 
             return stdout.decode("utf-8", errors="replace")
 
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
             process.kill()
-            raise ExecutionError(f"TLC timed out after {timeout} seconds", details={"timeout": timeout})
+            raise ExecutionError(f"TLC timed out after {timeout} seconds", details={"timeout": timeout}) from e
         except Exception as e:
-            raise ExecutionError(f"Failed to run TLC: {e}", details={"command": " ".join(cmd)})
+            raise ExecutionError(f"Failed to run TLC: {e}", details={"command": " ".join(cmd)}) from e
 
     def _parse_output(self, output: str, include_last_state: bool = False) -> dict[str, Any]:
         """Parse TLC output and return structured result."""

--- a/tools/trace_debugger/src/tla_mcp/handlers/trace_validation.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/trace_validation.py
@@ -7,12 +7,11 @@ It provides concise feedback suitable for AI agents.
 import asyncio
 import os
 import re
-import subprocess
-from typing import Dict, Any, Optional, Tuple
+from typing import Any
 
-from .base import BaseHandler
 from ..utils.errors import ExecutionError
 from ..utils.logger import logger
+from .base import BaseHandler
 
 
 class TraceValidationHandler(BaseHandler):
@@ -26,7 +25,7 @@ class TraceValidationHandler(BaseHandler):
         return "run_trace_validation"
 
     @property
-    def argument_schema(self) -> Dict[str, Any]:
+    def argument_schema(self) -> dict[str, Any]:
         return {
             "type": "object",
             "properties": {
@@ -46,7 +45,7 @@ class TraceValidationHandler(BaseHandler):
             "required": ["spec_file", "config_file", "trace_file", "work_dir"],
         }
 
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Execute trace validation.
 
         Returns:
@@ -74,7 +73,7 @@ class TraceValidationHandler(BaseHandler):
         include_last_state = arguments.get("include_last_state", False)
         return self._parse_output(output, include_last_state)
 
-    def _get_jar_paths(self, args: Dict[str, Any]) -> Tuple[str, str]:
+    def _get_jar_paths(self, args: dict[str, Any]) -> tuple[str, str]:
         """Get TLA+ JAR paths."""
         tla_jar = args.get("tla_jar")
         community_jar = args.get("community_jar")
@@ -99,7 +98,7 @@ class TraceValidationHandler(BaseHandler):
 
         return tla_jar, community_jar
 
-    def _build_command(self, args: Dict[str, Any], tla_jar: str, community_jar: str) -> list:
+    def _build_command(self, args: dict[str, Any], tla_jar: str, community_jar: str) -> list:
         """Build TLC command."""
         classpath = f"{tla_jar}:{community_jar}"
         metadir = args.get("metadir", "/tmp/tlc_validation")
@@ -121,7 +120,7 @@ class TraceValidationHandler(BaseHandler):
             "0.9",
         ]
 
-    async def _run_tlc(self, cmd: list, args: Dict[str, Any]) -> str:
+    async def _run_tlc(self, cmd: list, args: dict[str, Any]) -> str:
         """Run TLC and return output."""
         env = os.environ.copy()
         env["JSON"] = args["trace_file"]
@@ -143,7 +142,7 @@ class TraceValidationHandler(BaseHandler):
         except Exception as e:
             raise ExecutionError(f"Failed to run TLC: {e}", details={"command": " ".join(cmd)})
 
-    def _parse_output(self, output: str, include_last_state: bool = False) -> Dict[str, Any]:
+    def _parse_output(self, output: str, include_last_state: bool = False) -> dict[str, Any]:
         """Parse TLC output and return structured result."""
         # Check for success
         if "Model checking completed. No error has been found." in output:
@@ -160,7 +159,7 @@ class TraceValidationHandler(BaseHandler):
         # Other error - return raw output
         return {"status": "error", "message": "TLC reported an error", "raw_output": output}
 
-    def _parse_trace_mismatch(self, output: str, include_last_state: bool = False) -> Dict[str, Any]:
+    def _parse_trace_mismatch(self, output: str, include_last_state: bool = False) -> dict[str, Any]:
         """Parse trace mismatch output."""
         # Find all states with their l values
         # Pattern: "State N: <...>" followed by "/\ l = M"

--- a/tools/trace_debugger/src/tla_mcp/handlers/trace_validation.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/trace_validation.py
@@ -30,42 +30,20 @@ class TraceValidationHandler(BaseHandler):
         return {
             "type": "object",
             "properties": {
-                "spec_file": {
-                    "type": "string",
-                    "description": "TLA+ spec file name (e.g., 'Traceetcdraft.tla')"
-                },
-                "config_file": {
-                    "type": "string",
-                    "description": "TLC config file name (e.g., 'Traceetcdraft.cfg')"
-                },
-                "trace_file": {
-                    "type": "string",
-                    "description": "Trace file path (relative to work_dir or absolute)"
-                },
-                "work_dir": {
-                    "type": "string",
-                    "description": "Working directory (absolute path)"
-                },
-                "timeout": {
-                    "type": "integer",
-                    "default": 300,
-                    "description": "Timeout in seconds (default: 300)"
-                },
-                "tla_jar": {
-                    "type": "string",
-                    "description": "Path to tla2tools.jar (optional)"
-                },
-                "community_jar": {
-                    "type": "string",
-                    "description": "Path to CommunityModules-deps.jar (optional)"
-                },
+                "spec_file": {"type": "string", "description": "TLA+ spec file name (e.g., 'Traceetcdraft.tla')"},
+                "config_file": {"type": "string", "description": "TLC config file name (e.g., 'Traceetcdraft.cfg')"},
+                "trace_file": {"type": "string", "description": "Trace file path (relative to work_dir or absolute)"},
+                "work_dir": {"type": "string", "description": "Working directory (absolute path)"},
+                "timeout": {"type": "integer", "default": 300, "description": "Timeout in seconds (default: 300)"},
+                "tla_jar": {"type": "string", "description": "Path to tla2tools.jar (optional)"},
+                "community_jar": {"type": "string", "description": "Path to CommunityModules-deps.jar (optional)"},
                 "include_last_state": {
                     "type": "boolean",
                     "default": False,
-                    "description": "Include full content of the last matched state (default: false). This state is rarely useful for debugging since it's the last SUCCESSFUL match before failure."
-                }
+                    "description": "Include full content of the last matched state (default: false). This state is rarely useful for debugging since it's the last SUCCESSFUL match before failure.",
+                },
             },
-            "required": ["spec_file", "config_file", "trace_file", "work_dir"]
+            "required": ["spec_file", "config_file", "trace_file", "work_dir"],
         }
 
     async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -102,9 +80,9 @@ class TraceValidationHandler(BaseHandler):
         community_jar = args.get("community_jar")
 
         if tla_jar is None or community_jar is None:
-            specula_root = os.environ.get('SPECULA_ROOT')
+            specula_root = os.environ.get("SPECULA_ROOT")
             if specula_root:
-                default_lib = os.path.join(specula_root, 'lib')
+                default_lib = os.path.join(specula_root, "lib")
             else:
                 # Calculate relative to this file
                 this_file = os.path.abspath(__file__)
@@ -114,7 +92,7 @@ class TraceValidationHandler(BaseHandler):
                 tool_dir = os.path.dirname(src_dir)
                 tools_dir = os.path.dirname(tool_dir)
                 specula_root = os.path.dirname(tools_dir)
-                default_lib = os.path.join(specula_root, 'lib')
+                default_lib = os.path.join(specula_root, "lib")
 
             tla_jar = tla_jar or os.path.join(default_lib, "tla2tools.jar")
             community_jar = community_jar or os.path.join(default_lib, "CommunityModules-deps.jar")
@@ -126,14 +104,21 @@ class TraceValidationHandler(BaseHandler):
         classpath = f"{tla_jar}:{community_jar}"
         metadir = args.get("metadir", "/tmp/tlc_validation")
         return [
-            "java", "-XX:+UseParallelGC", "-Xmx4G",
-            "-cp", classpath,
+            "java",
+            "-XX:+UseParallelGC",
+            "-Xmx4G",
+            "-cp",
+            classpath,
             "tlc2.TLC",
-            "-config", args["config_file"],
+            "-config",
+            args["config_file"],
             args["spec_file"],
-            "-lncheck", "final",
-            "-metadir", metadir,
-            "-fpmem", "0.9"
+            "-lncheck",
+            "final",
+            "-metadir",
+            metadir,
+            "-fpmem",
+            "0.9",
         ]
 
     async def _run_tlc(self, cmd: list, args: Dict[str, Any]) -> str:
@@ -145,69 +130,48 @@ class TraceValidationHandler(BaseHandler):
 
         try:
             process = await asyncio.create_subprocess_exec(
-                *cmd,
-                cwd=args["work_dir"],
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-                env=env
+                *cmd, cwd=args["work_dir"], stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT, env=env
             )
 
-            stdout, _ = await asyncio.wait_for(
-                process.communicate(),
-                timeout=timeout
-            )
+            stdout, _ = await asyncio.wait_for(process.communicate(), timeout=timeout)
 
-            return stdout.decode('utf-8', errors='replace')
+            return stdout.decode("utf-8", errors="replace")
 
         except asyncio.TimeoutError:
             process.kill()
-            raise ExecutionError(
-                f"TLC timed out after {timeout} seconds",
-                details={"timeout": timeout}
-            )
+            raise ExecutionError(f"TLC timed out after {timeout} seconds", details={"timeout": timeout})
         except Exception as e:
-            raise ExecutionError(
-                f"Failed to run TLC: {e}",
-                details={"command": ' '.join(cmd)}
-            )
+            raise ExecutionError(f"Failed to run TLC: {e}", details={"command": " ".join(cmd)})
 
     def _parse_output(self, output: str, include_last_state: bool = False) -> Dict[str, Any]:
         """Parse TLC output and return structured result."""
         # Check for success
         if "Model checking completed. No error has been found." in output:
             # Extract states generated
-            states_match = re.search(r'(\d+) states generated', output)
+            states_match = re.search(r"(\d+) states generated", output)
             states = int(states_match.group(1)) if states_match else 0
 
-            return {
-                "status": "success",
-                "states_generated": states,
-                "message": "Trace validation passed"
-            }
+            return {"status": "success", "states_generated": states, "message": "Trace validation passed"}
 
         # Check for temporal property violation (trace mismatch)
         if "Error: Temporal properties were violated." in output:
             return self._parse_trace_mismatch(output, include_last_state)
 
         # Other error - return raw output
-        return {
-            "status": "error",
-            "message": "TLC reported an error",
-            "raw_output": output
-        }
+        return {"status": "error", "message": "TLC reported an error", "raw_output": output}
 
     def _parse_trace_mismatch(self, output: str, include_last_state: bool = False) -> Dict[str, Any]:
         """Parse trace mismatch output."""
         # Find all states with their l values
         # Pattern: "State N: <...>" followed by "/\ l = M"
-        state_pattern = re.compile(r'State (\d+):.*?/\\ l = (\d+)', re.DOTALL)
+        state_pattern = re.compile(r"State (\d+):.*?/\\ l = (\d+)", re.DOTALL)
         states = state_pattern.findall(output)
 
         if not states:
             return {
                 "status": "trace_mismatch",
                 "message": "Trace validation failed but could not parse state info",
-                "raw_output": output
+                "raw_output": output,
             }
 
         # Get last state info
@@ -215,7 +179,7 @@ class TraceValidationHandler(BaseHandler):
         failed_trace_line = int(states[-1][1])
 
         # Extract states generated
-        states_match = re.search(r'(\d+) states generated', output)
+        states_match = re.search(r"(\d+) states generated", output)
         states_generated = int(states_match.group(1)) if states_match else last_state_number
 
         result = {
@@ -227,7 +191,7 @@ class TraceValidationHandler(BaseHandler):
                 f"Trace validation failed at trace line {failed_trace_line}. "
                 f"Use run_trace_debugging with breakpoint condition "
                 f"'TLCGet(\"level\") = {last_state_number}' to debug."
-            )
+            ),
         }
 
         # Only include last_state if explicitly requested
@@ -245,11 +209,7 @@ class TraceValidationHandler(BaseHandler):
             return ""
 
         # Find the end (next State or stats line)
-        end_patterns = [
-            f"\nState {state_number + 1}:",
-            f"\n{state_number} states generated",
-            "\nFinished in"
-        ]
+        end_patterns = [f"\nState {state_number + 1}:", f"\n{state_number} states generated", "\nFinished in"]
 
         end_idx = len(output)
         for end_pattern in end_patterns:
@@ -258,7 +218,7 @@ class TraceValidationHandler(BaseHandler):
                 end_idx = idx
 
         # Also look for any number of "N states generated"
-        stats_match = re.search(r'\n\d+ states generated', output[start_idx:])
+        stats_match = re.search(r"\n\d+ states generated", output[start_idx:])
         if stats_match:
             idx = start_idx + stats_match.start()
             if idx < end_idx:

--- a/tools/trace_debugger/src/tla_mcp/handlers/trace_validation_parallel.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/trace_validation_parallel.py
@@ -4,11 +4,11 @@ import asyncio
 import os
 import shutil
 import tempfile
-from typing import Dict, Any, List
+from typing import Any
 
-from .trace_validation import TraceValidationHandler
 from ..utils.errors import ExecutionError
 from ..utils.logger import logger
+from .trace_validation import TraceValidationHandler
 
 
 class ParallelTraceValidationHandler(TraceValidationHandler):
@@ -23,7 +23,7 @@ class ParallelTraceValidationHandler(TraceValidationHandler):
         return "run_trace_validation_parallel"
 
     @property
-    def argument_schema(self) -> Dict[str, Any]:
+    def argument_schema(self) -> dict[str, Any]:
         return {
             "type": "object",
             "properties": {
@@ -42,7 +42,7 @@ class ParallelTraceValidationHandler(TraceValidationHandler):
             "required": ["spec_file", "config_file", "trace_files", "work_dir"],
         }
 
-    async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """Execute trace validation for multiple traces in parallel."""
         trace_files = arguments["trace_files"]
         if not trace_files:
@@ -53,7 +53,7 @@ class ParallelTraceValidationHandler(TraceValidationHandler):
 
         logger.info("Running TLC validation for %d trace(s) with parallelism=%d", len(trace_files), max_parallel)
 
-        async def run_one(trace_file: str) -> Dict[str, Any]:
+        async def run_one(trace_file: str) -> dict[str, Any]:
             async with semaphore:
                 args = dict(arguments)
                 args["trace_file"] = trace_file
@@ -87,14 +87,14 @@ class ParallelTraceValidationHandler(TraceValidationHandler):
 
         return response
 
-    def _condense_result(self, result: Dict[str, Any]) -> Dict[str, Any]:
+    def _condense_result(self, result: dict[str, Any]) -> dict[str, Any]:
         condensed = {"status": result.get("status", "error")}
         suggestion = result.get("suggestion")
         if suggestion:
             condensed["suggestion"] = suggestion
         return condensed
 
-    def _summarize_status(self, results: List[Dict[str, Any]]) -> Dict[str, str]:
+    def _summarize_status(self, results: list[dict[str, Any]]) -> dict[str, str]:
         summary = {}
         for result in results:
             if result["status"] == "success":

--- a/tools/trace_debugger/src/tla_mcp/handlers/trace_validation_parallel.py
+++ b/tools/trace_debugger/src/tla_mcp/handlers/trace_validation_parallel.py
@@ -27,57 +27,31 @@ class ParallelTraceValidationHandler(TraceValidationHandler):
         return {
             "type": "object",
             "properties": {
-                "spec_file": {
-                    "type": "string",
-                    "description": "TLA+ spec file name (e.g., 'Traceetcdraft.tla')"
-                },
-                "config_file": {
-                    "type": "string",
-                    "description": "TLC config file name (e.g., 'Traceetcdraft.cfg')"
-                },
+                "spec_file": {"type": "string", "description": "TLA+ spec file name (e.g., 'Traceetcdraft.tla')"},
+                "config_file": {"type": "string", "description": "TLC config file name (e.g., 'Traceetcdraft.cfg')"},
                 "trace_files": {
                     "type": "array",
                     "description": "List of trace file paths (relative to work_dir or absolute)",
-                    "items": {"type": "string"}
+                    "items": {"type": "string"},
                 },
-                "work_dir": {
-                    "type": "string",
-                    "description": "Working directory (absolute path)"
-                },
-                "timeout": {
-                    "type": "integer",
-                    "default": 300,
-                    "description": "Timeout in seconds (default: 300)"
-                },
-                "tla_jar": {
-                    "type": "string",
-                    "description": "Path to tla2tools.jar (optional)"
-                },
-                "community_jar": {
-                    "type": "string",
-                    "description": "Path to CommunityModules-deps.jar (optional)"
-                }
+                "work_dir": {"type": "string", "description": "Working directory (absolute path)"},
+                "timeout": {"type": "integer", "default": 300, "description": "Timeout in seconds (default: 300)"},
+                "tla_jar": {"type": "string", "description": "Path to tla2tools.jar (optional)"},
+                "community_jar": {"type": "string", "description": "Path to CommunityModules-deps.jar (optional)"},
             },
-            "required": ["spec_file", "config_file", "trace_files", "work_dir"]
+            "required": ["spec_file", "config_file", "trace_files", "work_dir"],
         }
 
     async def execute(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Execute trace validation for multiple traces in parallel."""
         trace_files = arguments["trace_files"]
         if not trace_files:
-            raise ExecutionError(
-                "No trace files provided",
-                details={"trace_files": trace_files}
-            )
+            raise ExecutionError("No trace files provided", details={"trace_files": trace_files})
 
         max_parallel = min(len(trace_files), os.cpu_count() or 1)
         semaphore = asyncio.Semaphore(max_parallel)
 
-        logger.info(
-            "Running TLC validation for %d trace(s) with parallelism=%d",
-            len(trace_files),
-            max_parallel
-        )
+        logger.info("Running TLC validation for %d trace(s) with parallelism=%d", len(trace_files), max_parallel)
 
         async def run_one(trace_file: str) -> Dict[str, Any]:
             async with semaphore:
@@ -93,7 +67,7 @@ class ParallelTraceValidationHandler(TraceValidationHandler):
                     logger.error(f"Validation failed for {trace_file}: {e}")
                     condensed = {
                         "status": "error",
-                        "suggestion": f"Validation error: {e}. Run run_trace_validation on this trace for details."
+                        "suggestion": f"Validation error: {e}. Run run_trace_validation on this trace for details.",
                     }
                 finally:
                     shutil.rmtree(metadir, ignore_errors=True)
@@ -101,18 +75,12 @@ class ParallelTraceValidationHandler(TraceValidationHandler):
                 condensed["trace_file"] = trace_file
                 return condensed
 
-        results = await asyncio.gather(
-            *[run_one(trace_file) for trace_file in trace_files]
-        )
+        results = await asyncio.gather(*[run_one(trace_file) for trace_file in trace_files])
 
         passed = sum(1 for result in results if result["status"] == "success")
         failed = len(results) - passed
 
-        response = {
-            "status": "success" if not failed else "trace_mismatch",
-            "passed": passed,
-            "failed": failed
-        }
+        response = {"status": "success" if not failed else "trace_mismatch", "passed": passed, "failed": failed}
 
         if failed:
             response["failures"] = self._summarize_status(results)
@@ -133,7 +101,6 @@ class ParallelTraceValidationHandler(TraceValidationHandler):
                 continue
             trace_file = os.path.basename(result["trace_file"])
             summary[trace_file] = result.get(
-                "suggestion",
-                "Trace validation failed. Run run_trace_validation on this trace for detailed output."
+                "suggestion", "Trace validation failed. Run run_trace_validation on this trace for detailed output."
             )
         return summary

--- a/tools/trace_debugger/src/tla_mcp/mcp_server.py
+++ b/tools/trace_debugger/src/tla_mcp/mcp_server.py
@@ -19,7 +19,7 @@ class TLADebuggerMCPServer:
         """Initialize the MCP server."""
         # Initialize logging
         setup_logging()
-        
+
         self.server = Server("tla-trace-debugger")
         self.handlers = {}
         self._register_tools()
@@ -64,35 +64,26 @@ class TLADebuggerMCPServer:
                         "properties": {
                             "spec_file": {
                                 "type": "string",
-                                "description": "TLA+ spec file name (e.g., 'Traceetcdraft.tla')"
+                                "description": "TLA+ spec file name (e.g., 'Traceetcdraft.tla')",
                             },
                             "config_file": {
                                 "type": "string",
-                                "description": "TLC config file name (e.g., 'Traceetcdraft.cfg')"
+                                "description": "TLC config file name (e.g., 'Traceetcdraft.cfg')",
                             },
                             "trace_file": {
                                 "type": "string",
-                                "description": "Trace file path (relative to work_dir or absolute)"
+                                "description": "Trace file path (relative to work_dir or absolute)",
                             },
-                            "work_dir": {
-                                "type": "string",
-                                "description": "Working directory (absolute path)"
-                            },
-                            "timeout": {
-                                "type": "integer",
-                                "description": "Timeout in seconds (default: 300)"
-                            },
-                            "tla_jar": {
-                                "type": "string",
-                                "description": "Path to tla2tools.jar (optional)"
-                            },
+                            "work_dir": {"type": "string", "description": "Working directory (absolute path)"},
+                            "timeout": {"type": "integer", "description": "Timeout in seconds (default: 300)"},
+                            "tla_jar": {"type": "string", "description": "Path to tla2tools.jar (optional)"},
                             "community_jar": {
                                 "type": "string",
-                                "description": "Path to CommunityModules-deps.jar (optional)"
-                            }
+                                "description": "Path to CommunityModules-deps.jar (optional)",
+                            },
                         },
-                        "required": ["spec_file", "config_file", "trace_file", "work_dir"]
-                    }
+                        "required": ["spec_file", "config_file", "trace_file", "work_dir"],
+                    },
                 ),
                 types.Tool(
                     name="run_trace_debugging",
@@ -106,22 +97,13 @@ class TLADebuggerMCPServer:
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "spec_file": {
-                                "type": "string",
-                                "description": "TLA+ spec file name (e.g., 'Raft.tla')"
-                            },
-                            "config_file": {
-                                "type": "string",
-                                "description": "TLC config file name (e.g., 'Raft.cfg')"
-                            },
+                            "spec_file": {"type": "string", "description": "TLA+ spec file name (e.g., 'Raft.tla')"},
+                            "config_file": {"type": "string", "description": "TLC config file name (e.g., 'Raft.cfg')"},
                             "trace_file": {
                                 "type": "string",
-                                "description": "Trace file path (relative to work_dir or absolute)"
+                                "description": "Trace file path (relative to work_dir or absolute)",
                             },
-                            "work_dir": {
-                                "type": "string",
-                                "description": "Working directory (absolute path)"
-                            },
+                            "work_dir": {"type": "string", "description": "Working directory (absolute path)"},
                             "breakpoints": {
                                 "type": "array",
                                 "description": "List of breakpoints to set",
@@ -131,43 +113,28 @@ class TLADebuggerMCPServer:
                                         "line": {"type": "integer"},
                                         "file": {"type": "string"},
                                         "condition": {"type": "string"},
-                                        "description": {"type": "string"}
+                                        "description": {"type": "string"},
                                     },
-                                    "required": ["line"]
-                                }
+                                    "required": ["line"],
+                                },
                             },
-                            "timeout": {
-                                "type": "integer",
-                                "description": "Timeout in seconds (default: 300)"
-                            },
-                            "tla_jar": {
-                                "type": "string",
-                                "description": "Path to tla2tools.jar (optional)"
-                            },
+                            "timeout": {"type": "integer", "description": "Timeout in seconds (default: 300)"},
+                            "tla_jar": {"type": "string", "description": "Path to tla2tools.jar (optional)"},
                             "community_jar": {
                                 "type": "string",
-                                "description": "Path to CommunityModules-deps.jar (optional)"
+                                "description": "Path to CommunityModules-deps.jar (optional)",
                             },
-                            "host": {
-                                "type": "string",
-                                "description": "DAP server host (default: 127.0.0.1)"
-                            },
-                            "port": {
-                                "type": "integer",
-                                "description": "DAP server port (default: 4712)"
-                            },
+                            "host": {"type": "string", "description": "DAP server host (default: 127.0.0.1)"},
+                            "port": {"type": "integer", "description": "DAP server port (default: 4712)"},
                             "evaluate": {
                                 "type": "object",
                                 "description": "Optional: Evaluate expressions at a breakpoint",
                                 "properties": {
                                     "breakpoint_line": {"type": "integer"},
                                     "breakpoint_file": {"type": "string"},
-                                    "expressions": {
-                                        "type": "array",
-                                        "items": {"type": "string"}
-                                    }
+                                    "expressions": {"type": "array", "items": {"type": "string"}},
                                 },
-                                "required": ["breakpoint_line", "expressions"]
+                                "required": ["breakpoint_line", "expressions"],
                             },
                             "collect_variables": {
                                 "type": "object",
@@ -175,17 +142,14 @@ class TLADebuggerMCPServer:
                                 "properties": {
                                     "breakpoint_line": {"type": "integer"},
                                     "breakpoint_file": {"type": "string"},
-                                    "variables": {
-                                        "type": "array",
-                                        "items": {"type": "string"}
-                                    },
-                                    "max_samples": {"type": "integer"}
+                                    "variables": {"type": "array", "items": {"type": "string"}},
+                                    "max_samples": {"type": "integer"},
                                 },
-                                "required": ["breakpoint_line", "variables"]
-                            }
+                                "required": ["breakpoint_line", "variables"],
+                            },
                         },
-                        "required": ["spec_file", "config_file", "trace_file", "work_dir", "breakpoints"]
-                    }
+                        "required": ["spec_file", "config_file", "trace_file", "work_dir", "breakpoints"],
+                    },
                 ),
                 types.Tool(
                     name="run_trace_validation_parallel",
@@ -199,50 +163,36 @@ class TLADebuggerMCPServer:
                         "properties": {
                             "spec_file": {
                                 "type": "string",
-                                "description": "TLA+ spec file name (e.g., 'Traceetcdraft.tla')"
+                                "description": "TLA+ spec file name (e.g., 'Traceetcdraft.tla')",
                             },
                             "config_file": {
                                 "type": "string",
-                                "description": "TLC config file name (e.g., 'Traceetcdraft.cfg')"
+                                "description": "TLC config file name (e.g., 'Traceetcdraft.cfg')",
                             },
                             "trace_files": {
                                 "type": "array",
                                 "description": "List of trace file paths (relative to work_dir or absolute)",
-                                "items": {"type": "string"}
+                                "items": {"type": "string"},
                             },
-                            "work_dir": {
-                                "type": "string",
-                                "description": "Working directory (absolute path)"
-                            },
-                            "timeout": {
-                                "type": "integer",
-                                "description": "Timeout in seconds (default: 300)"
-                            },
-                            "tla_jar": {
-                                "type": "string",
-                                "description": "Path to tla2tools.jar (optional)"
-                            },
+                            "work_dir": {"type": "string", "description": "Working directory (absolute path)"},
+                            "timeout": {"type": "integer", "description": "Timeout in seconds (default: 300)"},
+                            "tla_jar": {"type": "string", "description": "Path to tla2tools.jar (optional)"},
                             "community_jar": {
                                 "type": "string",
-                                "description": "Path to CommunityModules-deps.jar (optional)"
-                            }
+                                "description": "Path to CommunityModules-deps.jar (optional)",
+                            },
                         },
-                        "required": ["spec_file", "config_file", "trace_files", "work_dir"]
-                    }
+                        "required": ["spec_file", "config_file", "trace_files", "work_dir"],
+                    },
                 ),
                 types.Tool(
                     name="get_trace_info",
                     description="Get basic information about a trace file (line count, size, sample lines)",
                     inputSchema={
                         "type": "object",
-                        "properties": {
-                            "trace_file": {
-                                "type": "string",
-                                "description": "Path to trace file"
-                            }
-                        },
-                        "required": ["trace_file"]
-                    }
+                        "properties": {"trace_file": {"type": "string", "description": "Path to trace file"}},
+                        "required": ["trace_file"],
+                    },
                 ),
                 types.Tool(
                     name="validate_spec_syntax",
@@ -250,42 +200,25 @@ class TLADebuggerMCPServer:
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "spec_file": {
-                                "type": "string",
-                                "description": "TLA+ spec file name"
-                            },
-                            "config_file": {
-                                "type": "string",
-                                "description": "TLC config file name"
-                            },
-                            "work_dir": {
-                                "type": "string",
-                                "description": "Working directory"
-                            },
-                            "tla_jar": {
-                                "type": "string",
-                                "description": "Path to tla2tools.jar (optional)"
-                            }
+                            "spec_file": {"type": "string", "description": "TLA+ spec file name"},
+                            "config_file": {"type": "string", "description": "TLC config file name"},
+                            "work_dir": {"type": "string", "description": "Working directory"},
+                            "tla_jar": {"type": "string", "description": "Path to tla2tools.jar (optional)"},
                         },
-                        "required": ["spec_file", "config_file", "work_dir"]
-                    }
+                        "required": ["spec_file", "config_file", "work_dir"],
+                    },
                 ),
                 types.Tool(
                     name="clean_traces",
-                    description=(
-                        "Delete TTrace output files (.tla/.bin) generated by validating a spec file. "
-                    ),
+                    description=("Delete TTrace output files (.tla/.bin) generated by validating a spec file. "),
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "spec_file": {
-                                "type": "string",
-                                "description": "Path to the TLA+ spec file"
-                            },
+                            "spec_file": {"type": "string", "description": "Path to the TLA+ spec file"},
                         },
-                        "required": ["spec_file"]
-                    }
-                )
+                        "required": ["spec_file"],
+                    },
+                ),
             ]
 
         # Register call_tool handler
@@ -302,10 +235,7 @@ class TLADebuggerMCPServer:
             if name not in self.handlers:
                 error_msg = f"Unknown tool: {name}"
                 logger.error(error_msg)
-                return [types.TextContent(
-                    type="text",
-                    text=f'{{"success": false, "error": "{error_msg}"}}'
-                )]
+                return [types.TextContent(type="text", text=f'{{"success": false, "error": "{error_msg}"}}')]
 
             # Call the handler
             handler = self.handlers[name]
@@ -333,8 +263,4 @@ class TLADebuggerMCPServer:
         logger.info(f"Registered {len(self.handlers)} tools")
 
         async with stdio_server() as (read_stream, write_stream):
-            await self.server.run(
-                read_stream,
-                write_stream,
-                self.server.create_initialization_options()
-            )
+            await self.server.run(read_stream, write_stream, self.server.create_initialization_options())

--- a/tools/trace_debugger/src/tla_mcp/mcp_server.py
+++ b/tools/trace_debugger/src/tla_mcp/mcp_server.py
@@ -1,8 +1,8 @@
 """TLA+ Trace Debugger MCP Server."""
 
+from mcp import types
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp import types
 
 from .utils.logger import logger, setup_logging
 
@@ -30,12 +30,12 @@ class TLADebuggerMCPServer:
         Tools are registered using decorators. Handlers are imported
         lazily when needed to avoid import-time dependencies.
         """
+        from .handlers.clean_traces import CleanTracesHandler
+        from .handlers.spec_validation import SpecValidationHandler
         from .handlers.trace_debugging import TraceDebuggingHandler
+        from .handlers.trace_info import TraceInfoHandler
         from .handlers.trace_validation import TraceValidationHandler
         from .handlers.trace_validation_parallel import ParallelTraceValidationHandler
-        from .handlers.trace_info import TraceInfoHandler
-        from .handlers.spec_validation import SpecValidationHandler
-        from .handlers.clean_traces import CleanTracesHandler
 
         # Initialize handlers
         self.handlers = {
@@ -242,7 +242,7 @@ class TLADebuggerMCPServer:
             result = await handler.handle(arguments)
 
             logger.info(f"Handler returned result, length: {len(result)} chars")
-            logger.info(f"About to return TextContent to MCP client...")
+            logger.info("About to return TextContent to MCP client...")
 
             # Force flush before return
             for h in logger.handlers:

--- a/tools/trace_debugger/src/tla_mcp/utils/__init__.py
+++ b/tools/trace_debugger/src/tla_mcp/utils/__init__.py
@@ -1,9 +1,9 @@
 """MCP utilities."""
 
-from .errors import MCPError, ValidationError, ExecutionError
+from .errors import ExecutionError, MCPError, ValidationError
+from .formatters import format_error_response
 from .logger import logger
 from .validators import validate_arguments
-from .formatters import format_error_response
 
 __all__ = [
     "MCPError",

--- a/tools/trace_debugger/src/tla_mcp/utils/errors.py
+++ b/tools/trace_debugger/src/tla_mcp/utils/errors.py
@@ -3,11 +3,13 @@
 
 class MCPError(Exception):
     """Base exception for MCP errors."""
+
     pass
 
 
 class ValidationError(MCPError):
     """Argument validation error."""
+
     pass
 
 

--- a/tools/trace_debugger/src/tla_mcp/utils/formatters.py
+++ b/tools/trace_debugger/src/tla_mcp/utils/formatters.py
@@ -1,7 +1,7 @@
 """Response formatting utilities."""
 
 import json
-from typing import Dict, Any, Optional
+from typing import Any
 
 
 def format_error_response(tool_name: str, error_type: str, error_message: str, **kwargs) -> str:
@@ -21,7 +21,7 @@ def format_error_response(tool_name: str, error_type: str, error_message: str, *
     return json.dumps(result, indent=2)
 
 
-def format_success_response(data: Dict[str, Any]) -> str:
+def format_success_response(data: dict[str, Any]) -> str:
     """Format success response as JSON string.
 
     Args:

--- a/tools/trace_debugger/src/tla_mcp/utils/formatters.py
+++ b/tools/trace_debugger/src/tla_mcp/utils/formatters.py
@@ -4,8 +4,7 @@ import json
 from typing import Dict, Any, Optional
 
 
-def format_error_response(tool_name: str, error_type: str,
-                          error_message: str, **kwargs) -> str:
+def format_error_response(tool_name: str, error_type: str, error_message: str, **kwargs) -> str:
     """Format error response as JSON string.
 
     Args:
@@ -17,12 +16,7 @@ def format_error_response(tool_name: str, error_type: str,
     Returns:
         JSON string of error response
     """
-    result = {
-        "success": False,
-        "tool": tool_name,
-        "error_type": error_type,
-        "error_message": error_message
-    }
+    result = {"success": False, "tool": tool_name, "error_type": error_type, "error_message": error_message}
     result.update(kwargs)
     return json.dumps(result, indent=2)
 

--- a/tools/trace_debugger/src/tla_mcp/utils/logger.py
+++ b/tools/trace_debugger/src/tla_mcp/utils/logger.py
@@ -8,9 +8,8 @@ This module provides centralized logging configuration, ensuring that:
 
 import logging
 import logging.handlers
-import sys
 import os
-from pathlib import Path
+import sys
 
 # Default log directory
 DEFAULT_LOG_DIR = os.path.join(os.path.expanduser("~"), ".specula", "logs", "trace_debugger")

--- a/tools/trace_debugger/src/tla_mcp/utils/logger.py
+++ b/tools/trace_debugger/src/tla_mcp/utils/logger.py
@@ -15,18 +15,17 @@ from pathlib import Path
 # Default log directory
 DEFAULT_LOG_DIR = os.path.join(os.path.expanduser("~"), ".specula", "logs", "trace_debugger")
 
+
 def setup_logging(
-    name: str = "tla-debugger-mcp",
-    log_dir: str = DEFAULT_LOG_DIR,
-    level: int = logging.INFO
+    name: str = "tla-debugger-mcp", log_dir: str = DEFAULT_LOG_DIR, level: int = logging.INFO
 ) -> logging.Logger:
     """Configure and return the root logger.
-    
+
     Args:
         name: Logger name.
         log_dir: Directory to store log files.
         level: Logging level.
-    
+
     Returns:
         Configured logger instance.
     """
@@ -37,20 +36,18 @@ def setup_logging(
     # Get root logger
     root_logger = logging.getLogger()
     root_logger.setLevel(level)
-    
+
     # Remove existing handlers to avoid duplication
     if root_logger.hasHandlers():
         root_logger.handlers.clear()
 
     # Formatter
-    formatter = logging.Formatter(
-        '[%(asctime)s] [%(levelname)s] [%(name)s] [%(threadName)s] %(message)s'
-    )
+    formatter = logging.Formatter("[%(asctime)s] [%(levelname)s] [%(name)s] [%(threadName)s] %(message)s")
 
     # 1. Rotating File Handler
     # Max size 10MB, keep 5 backups
     file_handler = logging.handlers.RotatingFileHandler(
-        log_file, maxBytes=10*1024*1024, backupCount=5, encoding='utf-8'
+        log_file, maxBytes=10 * 1024 * 1024, backupCount=5, encoding="utf-8"
     )
     file_handler.setFormatter(formatter)
     file_handler.setLevel(level)
@@ -67,37 +64,42 @@ def setup_logging(
     logger = logging.getLogger(name)
     logger.info(f"Logging initialized. Writing to {log_file}")
     logger.info(f"Log level: {logging.getLevelName(level)}")
-    
+
     return logger
+
 
 class StdoutGuard:
     """Context manager to guard against accidental stdout writes."""
-    
+
     class DevNull:
-        def write(self, msg): pass
-        def flush(self): pass
+        def write(self, msg):
+            pass
+
+        def flush(self):
+            pass
 
     def __enter__(self):
         self.original_stdout = sys.stdout
-        # We can't actually replace stdout if we want the MCP server to work, 
+        # We can't actually replace stdout if we want the MCP server to work,
         # because the MCP server WRITES to stdout.
-        # So this guard is tricky. 
-        # Instead of replacing it globally, we rely on the fact that 
+        # So this guard is tricky.
+        # Instead of replacing it globally, we rely on the fact that
         # the MCP library writes to the original stdout.
         # If we redirect sys.stdout to stderr, then 'print()' calls will go to stderr,
         # which is safe.
         # BUT we must ensure the MCP writer still has access to the real stdout.
         # Since we are using the 'mcp' library, we need to check how it writes.
-        
+
         # Strategy: Redirect sys.stdout to sys.stderr so that 'print()' is safe.
         # We assume the MCP server explicitly uses the transport's output stream,
         # or we might break it if it relies on sys.stdout directly.
-        
+
         # Let's check mcp_server.py first before implementing this aggressively.
         pass
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
+
 
 # Initialize a default logger instance for modules that import 'logger' directly
 # This ensures they have something to use even if setup_logging isn't called yet

--- a/tools/trace_debugger/src/tla_mcp/utils/validators.py
+++ b/tools/trace_debugger/src/tla_mcp/utils/validators.py
@@ -6,8 +6,7 @@ from typing import Dict, Any
 from .errors import ValidationError
 
 
-def validate_arguments(arguments: Dict[str, Any],
-                      schema: Dict[str, Any]) -> Dict[str, Any]:
+def validate_arguments(arguments: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
     """Validate arguments against JSON schema.
 
     Args:
@@ -35,8 +34,7 @@ def validate_arguments(arguments: Dict[str, Any],
         raise ValidationError(f"Invalid schema: {e.message}")
 
 
-def _apply_defaults(arguments: Dict[str, Any],
-                   schema: Dict[str, Any]) -> Dict[str, Any]:
+def _apply_defaults(arguments: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
     """Apply default values from schema to arguments.
 
     Args:

--- a/tools/trace_debugger/src/tla_mcp/utils/validators.py
+++ b/tools/trace_debugger/src/tla_mcp/utils/validators.py
@@ -1,12 +1,13 @@
 """Argument validation utilities."""
 
+from typing import Any
+
 import jsonschema
-from typing import Dict, Any
 
 from .errors import ValidationError
 
 
-def validate_arguments(arguments: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
+def validate_arguments(arguments: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:
     """Validate arguments against JSON schema.
 
     Args:
@@ -34,7 +35,7 @@ def validate_arguments(arguments: Dict[str, Any], schema: Dict[str, Any]) -> Dic
         raise ValidationError(f"Invalid schema: {e.message}")
 
 
-def _apply_defaults(arguments: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
+def _apply_defaults(arguments: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:
     """Apply default values from schema to arguments.
 
     Args:

--- a/tools/trace_debugger/src/tla_mcp/utils/validators.py
+++ b/tools/trace_debugger/src/tla_mcp/utils/validators.py
@@ -30,9 +30,9 @@ def validate_arguments(arguments: dict[str, Any], schema: dict[str, Any]) -> dic
         return validated
 
     except jsonschema.ValidationError as e:
-        raise ValidationError(f"Invalid arguments: {e.message}")
+        raise ValidationError(f"Invalid arguments: {e.message}") from e
     except jsonschema.SchemaError as e:
-        raise ValidationError(f"Invalid schema: {e.message}")
+        raise ValidationError(f"Invalid schema: {e.message}") from e
 
 
 def _apply_defaults(arguments: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:

--- a/tools/trace_debugger/tests/TESTING.md
+++ b/tools/trace_debugger/tests/TESTING.md
@@ -102,7 +102,7 @@ Expected total runtime: ~3-4 minutes
 ## Requirements
 
 - **Java 11+**: Required to run TLC
-- **Python 3.8+**: Required for the test suite
+- **Python 3.10+**: Required for the test suite
 - **TLA+ Tools**: `tla2tools.jar` and `CommunityModules-deps.jar` in `lib/` directory
 - **Environment variable** (optional): `SPECULA_ROOT` pointing to the specula root directory
 

--- a/tools/trace_debugger/tests/test_advanced_vars.py
+++ b/tools/trace_debugger/tests/test_advanced_vars.py
@@ -7,22 +7,22 @@ import sys
 import os
 import pytest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from tla_mcp.handlers.trace_validation import TraceValidationHandler
 
 
 def get_specula_root():
     """Auto-detect Specula root directory."""
-    specula_root = os.environ.get('SPECULA_ROOT')
+    specula_root = os.environ.get("SPECULA_ROOT")
     if specula_root:
         return specula_root
     # Calculate relative to this file: tools/trace_debugger/tests/xxx.py
     this_file = os.path.abspath(__file__)
-    tests_dir = os.path.dirname(this_file)              # .../tests
-    trace_debugger_dir = os.path.dirname(tests_dir)     # .../trace_debugger
-    tools_dir = os.path.dirname(trace_debugger_dir)     # .../tools
-    return os.path.dirname(tools_dir)                   # .../Specula
+    tests_dir = os.path.dirname(this_file)  # .../tests
+    trace_debugger_dir = os.path.dirname(tests_dir)  # .../trace_debugger
+    tools_dir = os.path.dirname(trace_debugger_dir)  # .../tools
+    return os.path.dirname(tools_dir)  # .../Specula
 
 
 @pytest.mark.asyncio
@@ -42,9 +42,7 @@ async def test_advanced_features():
         "config_file": "Traceetcdraft_progress.cfg",
         "trace_file": "../traces/confchange_disable_validation.ndjson",
         "work_dir": work_dir,
-        "breakpoints": [
-            {"line": 522, "file": "Traceetcdraft_progress.tla", "condition": 'TLCGet("level") = 29'}
-        ],
+        "breakpoints": [{"line": 522, "file": "Traceetcdraft_progress.tla", "condition": 'TLCGet("level") = 29'}],
         "timeout": 60,
         "collect_variables": {
             "breakpoint_line": 522,
@@ -65,8 +63,8 @@ async def test_advanced_features():
                 "l + 1",
                 "pl - 1",
             ],
-            "max_samples": 2
-        }
+            "max_samples": 2,
+        },
     }
 
     print(f"\nTesting with variables:")
@@ -83,12 +81,12 @@ async def test_advanced_features():
         print(f"\n✅ Collected Variables ({len(result['collected_variables'])} samples):")
         for sample in result["collected_variables"]:
             print(f"\n  Sample {sample['sample_index']}:")
-            for var_name, var_value in sample['variables'].items():
+            for var_name, var_value in sample["variables"].items():
                 print(f"    {var_name} = {var_value}")
         return True
     else:
         print("\n❌ No collected variables!")
-        if not result.get('success'):
+        if not result.get("success"):
             print(f"Error: {result.get('error_message')}")
         return False
 

--- a/tools/trace_debugger/tests/test_advanced_vars.py
+++ b/tools/trace_debugger/tests/test_advanced_vars.py
@@ -3,8 +3,9 @@
 
 import asyncio
 import json
-import sys
 import os
+import sys
+
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -67,7 +68,7 @@ async def test_advanced_features():
         },
     }
 
-    print(f"\nTesting with variables:")
+    print("\nTesting with variables:")
     for var in arguments["collect_variables"]["variables"]:
         print(f"  - {var}")
 

--- a/tools/trace_debugger/tests/test_basic.py
+++ b/tools/trace_debugger/tests/test_basic.py
@@ -5,7 +5,8 @@ import sys
 import os
 
 # Add src to path (go up one level from tests/)
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
 
 def test_imports():
     """Test that all imports work."""
@@ -13,6 +14,7 @@ def test_imports():
 
     try:
         from debugger.breakpoint import Breakpoint, BreakpointHit, BreakpointStatistics
+
         print("  ✅ breakpoint module imported")
     except Exception as e:
         print(f"  ❌ breakpoint import failed: {e}")
@@ -20,6 +22,7 @@ def test_imports():
 
     try:
         from debugger.session import DebugSession
+
         print("  ✅ session module imported")
     except Exception as e:
         print(f"  ❌ session import failed: {e}")
@@ -27,6 +30,7 @@ def test_imports():
 
     try:
         from debugger.utils import collect_variable_values
+
         print("  ✅ utils module imported")
     except Exception as e:
         print(f"  ❌ utils import failed: {e}")
@@ -34,6 +38,7 @@ def test_imports():
 
     try:
         from debugger import DebugSession, Breakpoint
+
         print("  ✅ Package-level import works")
     except Exception as e:
         print(f"  ❌ Package import failed: {e}")
@@ -67,7 +72,7 @@ def test_breakpoint_classes():
             BreakpointHit("test.tla", 200, "Second BP", 0),
             BreakpointHit("test.tla", 300, "Third BP", 5),
         ],
-        total_hits=15
+        total_hits=15,
     )
     print(f"  ✅ Created BreakpointStatistics: {stats.total_hits} total hits")
 
@@ -84,9 +89,9 @@ def test_breakpoint_classes():
 
     # Test print_summary
     print("\n  Testing print_summary():")
-    print("  " + "="*60)
+    print("  " + "=" * 60)
     stats.print_summary()
-    print("  " + "="*60)
+    print("  " + "=" * 60)
 
     print("✅ Breakpoint classes work correctly\n")
     return True
@@ -98,12 +103,7 @@ def test_session_instantiation():
 
     from debugger import DebugSession
 
-    session = DebugSession(
-        spec_file="Test.tla",
-        config_file="Test.cfg",
-        trace_file="test.ndjson",
-        work_dir="/tmp"
-    )
+    session = DebugSession(spec_file="Test.tla", config_file="Test.cfg", trace_file="test.ndjson", work_dir="/tmp")
 
     print(f"  ✅ Created DebugSession")
     print(f"     - spec_file: {session.spec_file}")
@@ -123,9 +123,9 @@ def test_session_instantiation():
 
 def main():
     """Run all tests."""
-    print("="*70)
+    print("=" * 70)
     print("Basic Functionality Tests")
-    print("="*70)
+    print("=" * 70)
     print()
 
     try:
@@ -133,17 +133,18 @@ def main():
         test_breakpoint_classes()
         test_session_instantiation()
 
-        print("="*70)
+        print("=" * 70)
         print("✅ All basic tests passed!")
-        print("="*70)
+        print("=" * 70)
         return 0
 
     except Exception as e:
         print()
-        print("="*70)
+        print("=" * 70)
         print(f"❌ Tests failed: {e}")
-        print("="*70)
+        print("=" * 70)
         import traceback
+
         traceback.print_exc()
         return 1
 

--- a/tools/trace_debugger/tests/test_basic.py
+++ b/tools/trace_debugger/tests/test_basic.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Basic test to verify imports and class instantiation."""
 
-import sys
 import os
+import sys
 
 # Add src to path (go up one level from tests/)
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -13,7 +13,6 @@ def test_imports():
     print("Testing imports...")
 
     try:
-        from debugger.breakpoint import Breakpoint, BreakpointHit, BreakpointStatistics
 
         print("  ✅ breakpoint module imported")
     except Exception as e:
@@ -21,7 +20,6 @@ def test_imports():
         raise
 
     try:
-        from debugger.session import DebugSession
 
         print("  ✅ session module imported")
     except Exception as e:
@@ -29,7 +27,6 @@ def test_imports():
         raise
 
     try:
-        from debugger.utils import collect_variable_values
 
         print("  ✅ utils module imported")
     except Exception as e:
@@ -37,7 +34,6 @@ def test_imports():
         raise
 
     try:
-        from debugger import DebugSession, Breakpoint
 
         print("  ✅ Package-level import works")
     except Exception as e:
@@ -105,7 +101,7 @@ def test_session_instantiation():
 
     session = DebugSession(spec_file="Test.tla", config_file="Test.cfg", trace_file="test.ndjson", work_dir="/tmp")
 
-    print(f"  ✅ Created DebugSession")
+    print("  ✅ Created DebugSession")
     print(f"     - spec_file: {session.spec_file}")
     print(f"     - config_file: {session.config_file}")
     print(f"     - trace_file: {session.trace_file}")
@@ -115,7 +111,7 @@ def test_session_instantiation():
     # Check defaults
     assert session.tla_jar.endswith("tla2tools.jar")
     assert session.community_jar.endswith("CommunityModules-deps.jar")
-    print(f"  ✅ Default JAR paths set correctly")
+    print("  ✅ Default JAR paths set correctly")
 
     print("✅ DebugSession instantiation works\n")
     return True

--- a/tools/trace_debugger/tests/test_basic.py
+++ b/tools/trace_debugger/tests/test_basic.py
@@ -13,6 +13,7 @@ def test_imports():
     print("Testing imports...")
 
     try:
+        from debugger.breakpoint import Breakpoint, BreakpointHit, BreakpointStatistics  # noqa: F401
 
         print("  ✅ breakpoint module imported")
     except Exception as e:
@@ -20,6 +21,7 @@ def test_imports():
         raise
 
     try:
+        from debugger.session import DebugSession  # noqa: F401
 
         print("  ✅ session module imported")
     except Exception as e:
@@ -27,6 +29,7 @@ def test_imports():
         raise
 
     try:
+        from debugger.utils import collect_variable_values  # noqa: F401
 
         print("  ✅ utils module imported")
     except Exception as e:
@@ -34,6 +37,7 @@ def test_imports():
         raise
 
     try:
+        from debugger import Breakpoint, DebugSession  # noqa: F401
 
         print("  ✅ Package-level import works")
     except Exception as e:

--- a/tools/trace_debugger/tests/test_integration.py
+++ b/tools/trace_debugger/tests/test_integration.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Integration test - simulates the examples/coarse_grained_localization.py scenario."""
 
-import sys
 import os
+import sys
 
 # Add src to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from debugger import DebugSession, Breakpoint
+from debugger import Breakpoint, DebugSession
 
 
 def get_specula_root():

--- a/tools/trace_debugger/tests/test_integration.py
+++ b/tools/trace_debugger/tests/test_integration.py
@@ -5,22 +5,22 @@ import sys
 import os
 
 # Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from debugger import DebugSession, Breakpoint
 
 
 def get_specula_root():
     """Auto-detect Specula root directory."""
-    specula_root = os.environ.get('SPECULA_ROOT')
+    specula_root = os.environ.get("SPECULA_ROOT")
     if specula_root:
         return specula_root
     # Calculate relative to this file: tools/trace_debugger/tests/xxx.py
     this_file = os.path.abspath(__file__)
-    tests_dir = os.path.dirname(this_file)              # .../tests
-    trace_debugger_dir = os.path.dirname(tests_dir)     # .../trace_debugger
-    tools_dir = os.path.dirname(trace_debugger_dir)     # .../tools
-    return os.path.dirname(tools_dir)                   # .../Specula
+    tests_dir = os.path.dirname(this_file)  # .../tests
+    trace_debugger_dir = os.path.dirname(tests_dir)  # .../trace_debugger
+    tools_dir = os.path.dirname(trace_debugger_dir)  # .../tools
+    return os.path.dirname(tools_dir)  # .../Specula
 
 
 def test_coarse_grained_localization():
@@ -31,9 +31,9 @@ def test_coarse_grained_localization():
     by setting breakpoints at key locations to identify which branch is taken.
     """
 
-    print("="*70)
+    print("=" * 70)
     print("Integration Test: Coarse-Grained Localization")
-    print("="*70)
+    print("=" * 70)
     print()
     print("Scenario: Debugging confchange_disable_validation.ndjson line 30 failure")
     print()
@@ -47,7 +47,7 @@ def test_coarse_grained_localization():
         spec_file="Traceetcdraft_progress.tla",
         config_file="Traceetcdraft_progress.cfg",
         trace_file="../traces/confchange_disable_validation.ndjson",
-        work_dir=work_dir
+        work_dir=work_dir,
     )
     print("  ✅ Session created")
     print()
@@ -70,26 +70,10 @@ def test_coarse_grained_localization():
     print()
 
     breakpoints = [
-        Breakpoint(
-            line=522,
-            condition='TLCGet("level") = 29',
-            description="TraceNext entry point"
-        ),
-        Breakpoint(
-            line=489,
-            condition='TLCGet("level") = 29',
-            description="SendAppendEntriesRequest branch"
-        ),
-        Breakpoint(
-            line=323,
-            condition='TLCGet("level") = 29',
-            description="AppendEntriesIfLogged entry"
-        ),
-        Breakpoint(
-            line=327,
-            condition='TLCGet("level") = 29',
-            description="AppendEntries action call"
-        ),
+        Breakpoint(line=522, condition='TLCGet("level") = 29', description="TraceNext entry point"),
+        Breakpoint(line=489, condition='TLCGet("level") = 29', description="SendAppendEntriesRequest branch"),
+        Breakpoint(line=323, condition='TLCGet("level") = 29', description="AppendEntriesIfLogged entry"),
+        Breakpoint(line=327, condition='TLCGet("level") = 29', description="AppendEntries action call"),
     ]
 
     for bp in breakpoints:
@@ -144,9 +128,9 @@ def test_coarse_grained_localization():
     print("  ✅ Session closed")
     print()
 
-    print("="*70)
+    print("=" * 70)
     print("✅ Integration test completed successfully!")
-    print("="*70)
+    print("=" * 70)
 
     return True
 
@@ -161,5 +145,6 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"\n❌ Test failed with error: {e}")
         import traceback
+
         traceback.print_exc()
         sys.exit(1)

--- a/tools/trace_debugger/tests/test_simple.py
+++ b/tools/trace_debugger/tests/test_simple.py
@@ -3,34 +3,37 @@
 
 import sys
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from debugger import DebugSession, Breakpoint
 
+
 def get_specula_root():
     """Auto-detect Specula root directory."""
-    specula_root = os.environ.get('SPECULA_ROOT')
+    specula_root = os.environ.get("SPECULA_ROOT")
     if specula_root:
         return specula_root
     # Calculate relative to this file: tools/trace_debugger/tests/xxx.py
     this_file = os.path.abspath(__file__)
-    tests_dir = os.path.dirname(this_file)              # .../tests
-    trace_debugger_dir = os.path.dirname(tests_dir)     # .../trace_debugger
-    tools_dir = os.path.dirname(trace_debugger_dir)     # .../tools
-    return os.path.dirname(tools_dir)                   # .../Specula
+    tests_dir = os.path.dirname(this_file)  # .../tests
+    trace_debugger_dir = os.path.dirname(tests_dir)  # .../trace_debugger
+    tools_dir = os.path.dirname(trace_debugger_dir)  # .../tools
+    return os.path.dirname(tools_dir)  # .../Specula
+
 
 specula_root = get_specula_root()
 work_dir = os.path.join(specula_root, "data/workloads/etcdraft/scenarios/progress_inflights/spec")
 
-print("="*70)
+print("=" * 70)
 print("Simple Test: Breakpoints WITHOUT conditions")
-print("="*70)
+print("=" * 70)
 
 session = DebugSession(
     spec_file="Traceetcdraft_progress.tla",
     config_file="Traceetcdraft_progress.cfg",
     trace_file="../traces/confchange_disable_validation.ndjson",
-    work_dir=work_dir
+    work_dir=work_dir,
 )
 
 print("\n1. Starting session...")
@@ -39,9 +42,7 @@ if not session.start():
     sys.exit(1)
 
 print("2. Setting breakpoint at line 522 WITHOUT condition...")
-session.set_breakpoints([
-    Breakpoint(line=522, description="TraceNext - NO CONDITION")
-])
+session.set_breakpoints([Breakpoint(line=522, description="TraceNext - NO CONDITION")])
 
 print("3. Running (60s timeout)...")
 stats = session.run_until_done(timeout=60)

--- a/tools/trace_debugger/tests/test_simple.py
+++ b/tools/trace_debugger/tests/test_simple.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """Simple test without breakpoint conditions."""
 
-import sys
 import os
+import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from debugger import DebugSession, Breakpoint
+from debugger import Breakpoint, DebugSession
 
 
 def get_specula_root():

--- a/tools/trace_debugger/tests/test_step_operations.py
+++ b/tools/trace_debugger/tests/test_step_operations.py
@@ -4,12 +4,12 @@
 This test verifies that the step operations work correctly with TLC debugger.
 """
 
+import logging
 import os
 import sys
-import time
-import logging
 import tempfile
 import textwrap
+import time
 
 # Add src to path
 test_dir = os.path.dirname(os.path.abspath(__file__))
@@ -17,7 +17,7 @@ tool_dir = os.path.dirname(test_dir)
 src_dir = os.path.join(tool_dir, "src")
 sys.path.insert(0, src_dir)
 
-from debugger import DebugSession, Breakpoint
+from debugger import Breakpoint, DebugSession
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -133,7 +133,7 @@ def test_step_over():
             location = session.step_over()
 
             if location:
-                logger.info(f"✅ Step over successful - returned location")
+                logger.info("✅ Step over successful - returned location")
                 logger.info(f"   Location: {location['file']}:{location['line']}")
                 return True
             else:
@@ -208,9 +208,9 @@ def test_step_into():
                 logger.error("❌ step_into returned None")
                 return False
 
-            logger.info(f"✅ Step into successful - returned location")
+            logger.info("✅ Step into successful - returned location")
             logger.info(f"   Location: {location['file']}:{location['line']}")
-            logger.info(f"   Note: TLA+ step_into behavior may differ from imperative languages")
+            logger.info("   Note: TLA+ step_into behavior may differ from imperative languages")
             return True
 
         except Exception as e:
@@ -276,7 +276,7 @@ def test_step_out():
             location = session.step_out()
 
             if location:
-                logger.info(f"✅ Step out successful - returned location")
+                logger.info("✅ Step out successful - returned location")
                 logger.info(f"   Location: {location['file']}:{location['line']}")
                 return True
             else:

--- a/tools/trace_debugger/tests/test_step_operations.py
+++ b/tools/trace_debugger/tests/test_step_operations.py
@@ -14,16 +14,13 @@ import textwrap
 # Add src to path
 test_dir = os.path.dirname(os.path.abspath(__file__))
 tool_dir = os.path.dirname(test_dir)
-src_dir = os.path.join(tool_dir, 'src')
+src_dir = os.path.join(tool_dir, "src")
 sys.path.insert(0, src_dir)
 
 from debugger import DebugSession, Breakpoint
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 
@@ -69,10 +66,10 @@ def create_test_spec(tmpdir):
     spec_path = os.path.join(tmpdir, "StepTest.tla")
     cfg_path = os.path.join(tmpdir, "StepTest.cfg")
 
-    with open(spec_path, 'w') as f:
+    with open(spec_path, "w") as f:
         f.write(STEP_TEST_TLA)
 
-    with open(cfg_path, 'w') as f:
+    with open(cfg_path, "w") as f:
         f.write(STEP_TEST_CFG)
 
     return "StepTest.tla", "StepTest.cfg", tmpdir
@@ -87,9 +84,9 @@ def test_step_over():
     3. When breakpoint is hit, performs step_over
     4. Verifies step_over returns a valid location or handles termination gracefully
     """
-    logger.info("="*70)
+    logger.info("=" * 70)
     logger.info("TEST: Step Over")
-    logger.info("="*70)
+    logger.info("=" * 70)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         spec_file, config_file, work_dir = create_test_spec(tmpdir)
@@ -98,7 +95,7 @@ def test_step_over():
             spec_file=spec_file,
             config_file=config_file,
             trace_file="",  # Not using trace validation
-            work_dir=work_dir
+            work_dir=work_dir,
         )
 
         try:
@@ -110,9 +107,7 @@ def test_step_over():
             logger.info("✅ Debug session started")
 
             # Set breakpoint in Next (line 14 - first line of Next)
-            session.set_breakpoints([
-                Breakpoint(line=14, description="Next action - first line")
-            ])
+            session.set_breakpoints([Breakpoint(line=14, description="Next action - first line")])
 
             # Start execution
             session.client.request("configurationDone", {})
@@ -150,6 +145,7 @@ def test_step_over():
         except Exception as e:
             logger.error(f"❌ Exception during test: {e}")
             import traceback
+
             traceback.print_exc()
             return False
 
@@ -165,19 +161,14 @@ def test_step_into():
     2. When hit, performs step_into to enter HelperAction
     3. Verifies we're inside HelperAction
     """
-    logger.info("\n" + "="*70)
+    logger.info("\n" + "=" * 70)
     logger.info("TEST: Step Into")
-    logger.info("="*70)
+    logger.info("=" * 70)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         spec_file, config_file, work_dir = create_test_spec(tmpdir)
 
-        session = DebugSession(
-            spec_file=spec_file,
-            config_file=config_file,
-            trace_file="",
-            work_dir=work_dir
-        )
+        session = DebugSession(spec_file=spec_file, config_file=config_file, trace_file="", work_dir=work_dir)
 
         try:
             # Start session
@@ -188,9 +179,7 @@ def test_step_into():
             logger.info("✅ Debug session started")
 
             # Set breakpoint at Next action where HelperAction is called (line 15)
-            session.set_breakpoints([
-                Breakpoint(line=15, description="HelperAction call in Next")
-            ])
+            session.set_breakpoints([Breakpoint(line=15, description="HelperAction call in Next")])
 
             # Start execution
             session.client.request("configurationDone", {})
@@ -227,6 +216,7 @@ def test_step_into():
         except Exception as e:
             logger.error(f"❌ Exception during test: {e}")
             import traceback
+
             traceback.print_exc()
             return False
 
@@ -242,19 +232,14 @@ def test_step_out():
     2. When hit, performs step_out to return to caller
     3. Verifies we're back in Next action
     """
-    logger.info("\n" + "="*70)
+    logger.info("\n" + "=" * 70)
     logger.info("TEST: Step Out")
-    logger.info("="*70)
+    logger.info("=" * 70)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         spec_file, config_file, work_dir = create_test_spec(tmpdir)
 
-        session = DebugSession(
-            spec_file=spec_file,
-            config_file=config_file,
-            trace_file="",
-            work_dir=work_dir
-        )
+        session = DebugSession(spec_file=spec_file, config_file=config_file, trace_file="", work_dir=work_dir)
 
         try:
             # Start session
@@ -265,9 +250,7 @@ def test_step_out():
             logger.info("✅ Debug session started")
 
             # Set breakpoint inside HelperAction (line 10)
-            session.set_breakpoints([
-                Breakpoint(line=10, description="Inside HelperAction")
-            ])
+            session.set_breakpoints([Breakpoint(line=10, description="Inside HelperAction")])
 
             # Start execution
             session.client.request("configurationDone", {})
@@ -305,6 +288,7 @@ def test_step_out():
         except Exception as e:
             logger.error(f"❌ Exception during test: {e}")
             import traceback
+
             traceback.print_exc()
             return False
 
@@ -321,19 +305,14 @@ def test_interactive_stepping():
     3. Step into a function
     4. Step out
     """
-    logger.info("\n" + "="*70)
+    logger.info("\n" + "=" * 70)
     logger.info("TEST: Interactive Stepping Workflow")
-    logger.info("="*70)
+    logger.info("=" * 70)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         spec_file, config_file, work_dir = create_test_spec(tmpdir)
 
-        session = DebugSession(
-            spec_file=spec_file,
-            config_file=config_file,
-            trace_file="",
-            work_dir=work_dir
-        )
+        session = DebugSession(spec_file=spec_file, config_file=config_file, trace_file="", work_dir=work_dir)
 
         try:
             # Start session
@@ -344,9 +323,7 @@ def test_interactive_stepping():
             logger.info("✅ Debug session started")
 
             # Set breakpoint at Next action entry (line 13)
-            session.set_breakpoints([
-                Breakpoint(line=13, description="Next action entry")
-            ])
+            session.set_breakpoints([Breakpoint(line=13, description="Next action entry")])
 
             # Start execution
             session.client.request("configurationDone", {})
@@ -390,8 +367,8 @@ def test_interactive_stepping():
                     logger.info(f"   → Inside action at line {loc['line']}")
 
                     # Evaluate variable while inside
-                    if loc.get('frame_id'):
-                        val = session.evaluate_at_breakpoint("val", int(loc['frame_id']))
+                    if loc.get("frame_id"):
+                        val = session.evaluate_at_breakpoint("val", int(loc["frame_id"]))
                         logger.info(f"   → Variable 'val' = {val}")
             except BrokenPipeError:
                 logger.info("   → TLC terminated (expected after state exploration)")
@@ -417,6 +394,7 @@ def test_interactive_stepping():
         except Exception as e:
             logger.error(f"❌ Exception during test: {e}")
             import traceback
+
             traceback.print_exc()
             return False
 
@@ -427,19 +405,19 @@ def test_interactive_stepping():
 def main():
     """Run all step operation tests."""
     logger.info("Starting Step Operations Tests")
-    logger.info("="*70)
+    logger.info("=" * 70)
 
     results = {
         "step_over": test_step_over(),
         "step_into": test_step_into(),
         "step_out": test_step_out(),
-        "interactive": test_interactive_stepping()
+        "interactive": test_interactive_stepping(),
     }
 
     # Summary
-    logger.info("\n" + "="*70)
+    logger.info("\n" + "=" * 70)
     logger.info("TEST SUMMARY")
-    logger.info("="*70)
+    logger.info("=" * 70)
 
     for test_name, passed in results.items():
         status = "✅ PASSED" if passed else "❌ FAILED"


### PR DESCRIPTION
First step toward repo CI: introduce a ruff code-cleanliness standard and bring the Python tooling into conformance. Modeled on the tlaps-bench CI's ruff setup.

## What's in this PR
- New `ruff.toml`: ruleset E, F, UP, B, SIM, I (line-length 120, py312). Ignores E501 (formatter-handled), SIM102, and SIM115 (dual-mode readers legitimately accept caller-owned handles). Excludes submodules (case-studies, tools/tlaplus*, tools/SysMoBench) and experiment/vendor dirs so they are linted in their own repos.
- `ruff check --fix` + `ruff format` applied to all tracked main-repo Python (411 auto-fixes, 53 files reformatted).
- ~66 remaining findings fixed by hand: B904 (raise ... from e), bare except narrowing, l->items rename, E402 noqa on sys.path-prefixed imports, B023 closure hoist, etc.

Scope: 61 Python files + `ruff.toml`. Pre-existing submodule pointer changes are deliberately excluded. No CI workflow here — CI wiring (ruff gate + pytest + bash -n/shellcheck + CLI smoke) is a separate later PR.

## Verification (behavior-preserving)
The mechanical phase (safe autofix + formatter) is behavior-preserving by construction. The hand edits were isolated for review by diffing the working tree against a HEAD+autofix+format reference, so only the intended manual hunks remained, and each was reviewed:
- 28x B904: traceback chaining only, no behavior change
- 9x if/else -> ternary, 2x .keys() drop, 2x -> contextlib.suppress (same exception sets): semantically equivalent
- 3x bare except narrowing: verified safe (e.g. suppress(OSError) wraps an os.remove cleanup)
- 5x l->items rename: complete, no leftover references
- 2x dead-variable removal: confirmed unread

Checks run, all green:
- ruff check (all tracked py): All checks passed
- py_compile of all 61 changed files: OK
- inv_checking_tool pytest: 64 passed
- trace_debugger test_basic.py: passed
- import sweep of changed modules: OK
