### PR TITLE
ci: lightweight CI (ruff, shell lint, tests) + portable symlinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.10"
       - name: Install ruff
         run: pip install "ruff==0.15.18"
       # Lint only tracked main-repo Python; submodules are linted in their own repos.
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.10"
       - name: Install test deps
         run: pip install pytest pytest-asyncio "mcp>=1.0.0" "jsonschema>=4.0.0"
       - name: inv_checking_tool tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+# Lightweight first-step CI: code-cleanliness + the deterministic test suites.
+# Heavier checks (TLA+ SANY parse, trace-validation golden regression, bounded
+# TLC runs) are intentionally left for a follow-up; the LLM pipeline never runs here.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR runs, but let every push-to-main build finish.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    name: Python lint (ruff)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install ruff
+        run: pip install "ruff==0.15.18"
+      # Lint only tracked main-repo Python; submodules are linted in their own repos.
+      - name: ruff check
+        run: git ls-files -z '*.py' | xargs -0 -r ruff check
+      - name: ruff format --check
+        run: git ls-files -z '*.py' | xargs -0 -r ruff format --check
+
+  shell:
+    name: Shell lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: bash -n (syntax)
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r f; do
+            bash -n "$f" || { echo "syntax error: $f"; fail=1; }
+          done < <(git ls-files '*.sh')
+          exit "$fail"
+      # shellcheck is advisory for now (scripts were never linted); tighten later.
+      - name: shellcheck (advisory)
+        continue-on-error: true
+        run: git ls-files -z '*.sh' | xargs -0 -r shellcheck
+
+  test:
+    name: Python tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test deps
+        run: pip install pytest pytest-asyncio "mcp>=1.0.0" "jsonschema>=4.0.0"
+      - name: inv_checking_tool tests
+        env:
+          PYTHONPATH: tools
+        run: pytest tools/inv_checking_tool/tests -q
+      # trace_debugger has standalone scripts; only test_basic.py runs without a live TLC.
+      - name: trace_debugger basic test
+        env:
+          PYTHONPATH: tools/trace_debugger/src
+        run: python tools/trace_debugger/tests/test_basic.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,22 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+      # Guard against the symlink footgun that broke the first CI run: an absolute
+      # target (/home/…) exists only on the author's machine, and a relative target
+      # that points outside the tree resolves nowhere. Both must fail here, not silently.
+      - name: symlinks are relative and resolve
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r f; do
+            [ -L "$f" ] || continue
+            target=$(readlink "$f")
+            case "$target" in
+              /*) echo "absolute symlink target (not portable): $f -> $target"; fail=1; continue;;
+            esac
+            [ -e "$f" ] || { echo "broken symlink: $f -> $target"; fail=1; }
+          done < <(git ls-files)
+          exit "$fail"
       - name: bash -n (syntax)
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
           set -euo pipefail
           fail=0
           while IFS= read -r f; do
+            # Skip symlinks; their targets are tracked and linted at their real path.
+            [ -L "$f" ] && continue
             bash -n "$f" || { echo "syntax error: $f"; fail=1; }
           done < <(git ls-files '*.sh')
           exit "$fail"

--- a/scripts/infra/run_model_check.sh
+++ b/scripts/infra/run_model_check.sh
@@ -1,1 +1,1 @@
-/home/ubuntu/Specula/scripts/tlc/run_model_check.sh
+../tlc/run_model_check.sh


### PR DESCRIPTION
Re-lands the CI work. The previous PR (#43) was a stacked PR whose base was `chore/ruff-cleanup`, so merging it landed the CI into that branch instead of `main`