### PR TITLE
Adversarial Reproducer⇄Challenger debate for bug confirmation (opt-in for some models like glm 5.2)

### DIFF
--- a/skills/bug-confirmation/guide.md
+++ b/skills/bug-confirmation/guide.md
@@ -18,7 +18,7 @@ Each finding goes through two phases in order: investigation (Phase 1) and repro
 
 The per-finding methodology below is identical however the phase runs; only the orchestration differs:
 
-- **Parallel per-finding (default).** A step-0 consolidate+dedup merges the two finding sources into `candidates.json`, then one Reproducer agent handles each finding, in parallel.
+- **Parallel per-finding (default).** A step-0 consolidate+dedup merges the two finding sources into `candidates.json`, then one Reproducer agent handles each finding, in parallel. Add `--debate` to have an adversarial Challenger stress-test each *confirmation* (not dismissal) to consensus. The Reproducer's turn-1 prompt is debate-agnostic — it never mentions a Challenger — so a finding's first-pass result is identical with or without `--debate`; the Reproducer only learns of the debate if a Challenger actually disagrees.
 - **Single-agent (`--legacy-confirm`).** One agent consolidates both sources and reproduces every finding in one context.
 
 Both modes write the same `confirmed-bugs.md`, emit the same `RR-NNN` repair requests, and use the same statuses. Re-check (`--recheck`, Phase 2′) is always single-agent.

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -1,12 +1,14 @@
-"""Parallel per-finding bug confirmation (Phase 4).
+"""Parallel per-finding bug confirmation (Phase 4), with an optional debate.
 
 The default Phase-4 mode: instead of one agent confirming every finding in one
 context (the legacy single-agent path, still reachable via ``--legacy-confirm``),
-this fans out one Reproducer agent per finding, in parallel, after a step-0
-consolidate+dedup of the two finding sources into ``candidates.json``. The
-Reproducer follows the bug-confirmation skill (``guide.md`` + phase docs); this
-module is the dispatcher: it owns the per-finding work, serial RR-NNN allocation,
-and aggregation into ``confirmed-bugs.md``.
+this fans out one Reproducer agent per finding, in parallel. With debate enabled
+(``--debate``), a confirmation is then stress-tested by an adversarial Challenger
+to consensus. Roles, debate rules, and the verdict vocabulary follow the
+bug-confirmation skill (``guide.md`` + the challenge/defend prompts); this module
+is the dispatcher (the group-chat manager): it owns turn order, the shared
+``debate.md``, the round cap, VERDICT comparison, serial RR-NNN allocation, and
+aggregation into ``confirmed-bugs.md``.
 
 Every agent turn goes through :func:`specula.phaselib.run_agent_blocking` — the
 same adapter path, flags, and stop-gate env as ``Phase._launch``. Rate-limit
@@ -43,6 +45,8 @@ PHASE_KEY = "bug_confirmation"
 
 # Framework terminal/loop statuses (skills/bug-confirmation/guide.md).
 CANON = ["REPRODUCED", "REPRODUCTION FAILED", "FALSE POSITIVE", "NEEDS MORE INFO", "DROPPED", "PENDING REPAIR"]
+# A verdict asserting a real bug — the only case that opens a debate.
+CONFIRM = {"REPRODUCED", "REPRODUCTION FAILED"}
 VALID_SOURCES = {"model-checking", "code-review"}
 ID_CHARS = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
 
@@ -109,6 +113,8 @@ class ConfirmConfig:
     adapter: Path
     repo_dir: str = ""
     max_parallel: int = 4
+    debate: bool = False
+    rounds: int = 5
     claude_alias: str = "claude"
     worktree: bool = True
     dry_run: bool = False
@@ -121,7 +127,7 @@ class Outcome:
     status: str
     consensus: bool
     rounds: int
-    body: str  # the Reproducer's response, used as the verdict body
+    body: str  # last A-turn response, used as the verdict body
     rr: str | None = None  # assigned RR-NNN when status is PENDING REPAIR
     bug_no: int = 0  # 1-based index in confirmed-bugs.md (the "## Bug N:" number)
 
@@ -156,7 +162,23 @@ def prompt_reproduce(cfg: ConfirmConfig, f: Finding, repo: str) -> str:
     )
 
 
-# ── one agent turn (blocking, via the shared phaselib primitive) ─────────────
+def prompt_challenge(cfg: ConfirmConfig, f: Finding, repo: str, debate: str) -> str:
+    return render(
+        "confirmation/challenge",
+        finding_id=f.id,
+        canon=" / ".join(CANON),
+        debate=debate,
+        context=_context(cfg, f, repo),
+    )
+
+
+def prompt_defend(cfg: ConfirmConfig, f: Finding, repo: str, debate: str) -> str:
+    return render(
+        "confirmation/defend", finding_id=f.id, canon=" / ".join(CANON), debate=debate, context=_context(cfg, f, repo)
+    )
+
+
+# ── one debate turn (blocking, via the shared phaselib primitive) ────────────
 
 
 def run_turn(cfg: ConfirmConfig, f: Finding, role: str, turn_no: int, prompt: str) -> tuple[str | None, str]:
@@ -214,22 +236,52 @@ def setup_repo(cfg: ConfirmConfig, f: Finding) -> tuple[str, Callable[[], None]]
     return str(wt), cleanup
 
 
-# ── one finding: reproduce → verdict ─────────────────────────────────────────
+# ── one finding: reproduce, then optional debate ─────────────────────────────
 
 
 def run_finding(cfg: ConfirmConfig, f: Finding) -> Outcome:
     f.fdir.mkdir(parents=True, exist_ok=True)
     (cfg.ws.work_dir(cfg.name) / "repro").mkdir(parents=True, exist_ok=True)
-    transcript = f.fdir / "debate.md"
+    debate = f.fdir / "debate.md"
     repo_for_agent, cleanup = setup_repo(cfg, f)
     try:
+        # Turn 1 — Reproducer (neutral): investigate + reproduce.
         a_verdict, a_text = run_turn(cfg, f, "A", 1, prompt_reproduce(cfg, f, repo_for_agent))
-        transcript.write_text(f"# {f.id}\n\n## Reproduce\n\n{a_text}\n")
+        debate.write_text(f"# Debate: {f.id}\n\n## A (turn 1 — reproduce)\n\n{a_text}\n")
         if a_verdict is None:
-            _log(f"  [{f.id}] Reproducer produced no VERDICT → NEEDS MORE INFO")
+            _log(f"  [{f.id}] A produced no VERDICT → NEEDS MORE INFO")
             return Outcome(f, "NEEDS MORE INFO", False, 0, a_text)
-        _log(f"  [{f.id}] {a_verdict}")
-        return Outcome(f, a_verdict, True, 0, a_text)
+        if a_verdict not in CONFIRM:
+            _log(f"  [{f.id}] A: {a_verdict} (dismissal) — no debate")
+            return Outcome(f, a_verdict, True, 0, a_text)
+        if not cfg.debate:
+            _log(f"  [{f.id}] A: {a_verdict} (debate off) — verdict final")
+            return Outcome(f, a_verdict, True, 0, a_text)
+
+        _log(f"  [{f.id}] A: {a_verdict} → opening debate")
+        last_a_text = a_text
+        turn = 1
+        for rnd in range(1, cfg.rounds + 1):
+            turn += 1
+            b_verdict, b_text = run_turn(
+                cfg, f, "B", turn, prompt_challenge(cfg, f, repo_for_agent, debate.read_text())
+            )
+            debate.write_text(debate.read_text() + f"\n## B (round {rnd})\n\n{b_text}\n")
+            # B agrees with A's current verdict → consensus already. Do NOT pull A
+            # into a defense it does not need: A only ever hears about the debate
+            # when B actually disagrees (the defend turn is where it is introduced).
+            if b_verdict is not None and b_verdict == a_verdict:
+                _log(f"  [{f.id}] round {rnd}: B={b_verdict} agrees — consensus, A not invoked")
+                return Outcome(f, a_verdict, True, rnd, last_a_text)
+            turn += 1
+            a_verdict, a_text = run_turn(cfg, f, "A", turn, prompt_defend(cfg, f, repo_for_agent, debate.read_text()))
+            debate.write_text(debate.read_text() + f"\n## A (round {rnd})\n\n{a_text}\n")
+            last_a_text = a_text or last_a_text
+            _log(f"  [{f.id}] round {rnd}: B={b_verdict} A={a_verdict}")
+            if a_verdict and b_verdict and a_verdict == b_verdict:
+                return Outcome(f, a_verdict, True, rnd, last_a_text)
+        _log(f"  [{f.id}] no consensus after {cfg.rounds} rounds → NEEDS MORE INFO")
+        return Outcome(f, "NEEDS MORE INFO", False, cfg.rounds, last_a_text)
     finally:
         cleanup()
 
@@ -474,6 +526,7 @@ def aggregate(cfg: ConfirmConfig, outcomes: list[Outcome]) -> None:
         lines.append("")
         lines.append(f"- **Finding ID**: {o.finding.id}")
         lines.append(f"- **Status**: {o.status}{rr}")
+        lines.append(f"- **Debate**: {'consensus' if o.consensus else 'NO CONSENSUS'} in {o.rounds} round(s)")
         lines.append(f"- **Transcript**: {o.finding.fdir / 'debate.md'}")
         lines.append("")
         lines.append(o.body.strip())
@@ -540,7 +593,10 @@ def _drive_confirmation(cfg: ConfirmConfig) -> int:
         return _withhold(cfg, f"consolidate failed ({e}) — deliverable withheld; downstream gate + retry settle it")
 
     findings = load_findings(cfg)
-    _log(f"Parallel confirmation: {cfg.name} — {len(findings)} findings, max_parallel={cfg.max_parallel}")
+    _log(
+        f"Parallel confirmation: {cfg.name} — {len(findings)} findings, "
+        f"debate={'ON' if cfg.debate else 'OFF'}, max_parallel={cfg.max_parallel}"
+    )
     if not findings:
         if not cfg.dry_run:
             aggregate(cfg, [])

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -1148,6 +1148,8 @@ Options:
   --dry-run           Print commands without executing
   --check             Only verify prerequisites exist
   --legacy-confirm    Single-agent confirmation (one agent, all findings) instead of parallel
+  --debate            Add an adversarial Challenger after each confirmation (parallel mode; default off)
+  --rounds=N          Max debate rounds with --debate (default: 5)
   --recheck           Re-check mode: settle RECHECK repair requests (confirmation back-edge; single-agent)
   --max-repair-rounds=N  Per-request repair cap honored in --recheck (default: 0 = unlimited)
   --max-parallel=N    Concurrent findings in parallel mode / concurrent agents in --legacy-confirm (default: 1)
@@ -1175,6 +1177,12 @@ Prerequisites:
         if arg == "--legacy-confirm":
             extra["legacy"] = True
             return True
+        if arg == "--debate":
+            extra["debate"] = True
+            return True
+        if arg.startswith("--rounds="):
+            extra["rounds"] = arg[len("--rounds=") :]
+            return True
         return False
 
     def run_alternate(
@@ -1197,6 +1205,8 @@ Prerequisites:
         # would be circular.
         from specula.confirmlib import ConfirmConfig, run_parallel_confirmation
 
+        debate = bool(ws.opts.get("debate"))
+        rounds = int(str(ws.opts.get("rounds", "5")))
         # `max_parallel` here is the per-finding concurrency. The pipeline default
         # is 1 — it means "concurrent targets" for the other phases, but that is
         # degenerate for per-finding fan-out (findings would run one at a time, so
@@ -1213,6 +1223,8 @@ Prerequisites:
                 adapter=adapter,
                 repo_dir=ws.find_repo_dir(name),
                 max_parallel=findings_parallel,
+                debate=debate,
+                rounds=rounds,
                 claude_alias=claude_alias,
                 dry_run=dry_run,
                 prompt_extra=self._read_prompt_extra(ws, name),

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -78,6 +78,7 @@ Options:
   --skip-classification  Skip Phase 4b severity classification
   --skip-repair-loop     Skip the confirmation back-edge repair loop (default: enabled)
   --legacy-confirm       Phase 4a: single-agent confirmation instead of the default parallel per-finding
+  --confirm-debate       Phase 4a: add the adversarial Challenger debate (parallel mode; default off)
   --max-repair-rounds=N  Per-request repair cap, enforced by re-check (default: 0 = unlimited)
   --enable-reviews        Enable review steps (disabled by default)
   --max-parallel=N       Max concurrent agents per phase (default: 1)
@@ -306,6 +307,7 @@ class Pipeline:
         self.skip_classification = False
         self.skip_repair_loop = False
         self.confirm_legacy = False  # --legacy-confirm: single-agent Phase 4a instead of the default parallel
+        self.confirm_debate = False  # --confirm-debate: add the adversarial Challenger (parallel mode)
         # `or`: bash ${VAR:-default} treats an exported-but-empty var as unset
         self.max_repair_rounds = os.environ.get("MAX_REPAIR_ROUNDS") or "0"
         self.skip_reviews = True
@@ -350,6 +352,8 @@ class Pipeline:
                 self.skip_repair_loop = True
             elif arg == "--legacy-confirm":
                 self.confirm_legacy = True
+            elif arg == "--confirm-debate":
+                self.confirm_debate = True
             elif arg.startswith("--max-repair-rounds="):
                 self.max_repair_rounds = arg.split("=", 1)[1]
             elif arg == "--enable-reviews":
@@ -667,9 +671,12 @@ class Pipeline:
         pre: list[str] = []
         if self.confirm_legacy:
             pre.append("--legacy-confirm")
+        if self.confirm_debate:
+            pre.append("--debate")
         mode = "single-agent, legacy" if self.confirm_legacy else "parallel per-finding"
+        debate = " + debate" if self.confirm_debate and not self.confirm_legacy else ""
         self._phase(
-            f"PHASE 4: BUG CONFIRMATION ({mode})",
+            f"PHASE 4: BUG CONFIRMATION ({mode}{debate})",
             "launch_bug_confirmation.sh",
             self._phase_args(self.extract_names(), pre=pre or None),
         )

--- a/src/specula/prompts/confirmation/challenge.md
+++ b/src/specula/prompts/confirmation/challenge.md
@@ -1,0 +1,32 @@
+# Challenge ONE finding (Agent B, adversarial): {{finding_id}}
+
+You are **Agent B, the Challenger**, for finding **{{finding_id}}**. Your standing goal:
+**remove every finding that is not a genuine, real-world-triggerable bug.** The
+burden is on the finding to survive you. You are NOT a desk reviewer — you may
+attack Agent A's reproduction and demand concrete changes to it.
+
+{{context}}
+
+## Debate so far (shared transcript)
+{{debate}}
+
+You cannot rule this finding out on your own — it is only removed if **A agrees**
+(your `VERDICT:` and A's must match). Convince A with cited evidence; do not merely assert.
+
+## Do
+Make your strongest move, grounded in a citation (a Prohibited-approaches clause,
+a `file:line` safeguard, a developer-intent source **already on the record from
+A's turn-1 investigation** — do NOT do fresh developer-intent research, a failed
+prerequisite):
+- Is A's repro legitimate (no illegal preset state / private-fn calls / hand-made
+  inputs / core-logic edits)? Does it trigger the RIGHT bug (same actions, same
+  invariant, same root cause)? Does it show observable HARM, not just an odd
+  intermediate value?
+- If the bug may be real but the repro is weak, say HOW to strengthen it (which
+  public API, which escalation level, where to widen a race with a documented
+  delay). Pushing A to a better repro is a wanted outcome.
+- Anti-sycophancy: do NOT invent objections you cannot cite; if the bug genuinely
+  survives, concede it. Facts decide.
+
+End your ENTIRE response with a single line:
+`VERDICT: <one of: {{canon}}>`

--- a/src/specula/prompts/confirmation/defend.md
+++ b/src/specula/prompts/confirmation/defend.md
@@ -1,0 +1,22 @@
+# Defend/settle ONE finding (Agent A): {{finding_id}}
+
+You are **Agent A, the Reproducer**, responding to the Challenger for finding
+**{{finding_id}}**. Weigh B's latest objection on the evidence.
+
+{{context}}
+
+## Debate so far (shared transcript)
+{{debate}}
+
+## Do
+- If B's citation actually refutes your position, concede and change your verdict.
+- If B demanded a stronger reproduction and it is warranted, PRODUCE it: modify
+  `repro/test_bug{{finding_id}}_*`, RE-RUN it, and paste the new output.
+- If B is wrong, hold your verdict and show, with citation, why.
+- Anti-sycophancy: do not change your verdict just to reach agreement — move only
+  on a real reason.
+- Keep an up-to-date `## Reproduction result` and `## Recommendation` in your
+  response (they may be used as the verdict body).
+
+End your ENTIRE response with a single line:
+`VERDICT: <one of: {{canon}}>`

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -61,6 +61,10 @@ class ConfirmCase(unittest.TestCase):
     def cfg(self, ws: Workspace, name: str, **kw: Any) -> C.ConfirmConfig:
         return C.ConfirmConfig(name=name, ws=ws, adapter=Path("/x"), worktree=False, repo_dir="", **kw)
 
+    def finding(self, ws: Workspace, name: str, fid: str = "MC-1") -> C.Finding:
+        fdir = ws.work_dir(name) / "confirmation" / fid
+        return C.Finding({"id": fid, "title": "t", "summary": "s"}, fdir)
+
 
 class TestVerdict(ConfirmCase):
     def test_parse_verdict(self) -> None:
@@ -177,6 +181,53 @@ class TestDriver(ConfirmCase):
             rc = C.run_parallel_confirmation(self.cfg(ws, "T"))
         self.assertEqual(rc, 0)
         self.assertFalse((ws.work_dir("T") / "spec" / "confirmed-bugs.md").is_file())  # stale removed too
+
+
+class TestDebateGate(ConfirmCase):
+    def test_debate_off_is_a_solo(self) -> None:
+        ws = self.seed("T", [])
+        cfg = self.cfg(ws, "T", debate=False)
+        with mock.patch.object(C, "run_agent_blocking", _fake_turn("VERDICT: REPRODUCED")):
+            o = C.run_finding(cfg, self.finding(ws, "T"))
+        self.assertEqual(o.status, "REPRODUCED")
+        self.assertEqual(o.rounds, 0)  # no debate opened
+
+    def test_debate_on_reaches_consensus(self) -> None:
+        ws = self.seed("T", [])
+        cfg = self.cfg(ws, "T", debate=True, rounds=5)
+        with mock.patch.object(C, "run_agent_blocking", _fake_turn("VERDICT: REPRODUCED")):
+            o = C.run_finding(cfg, self.finding(ws, "T", "MC-2"))
+        self.assertEqual(o.status, "REPRODUCED")
+        self.assertEqual(o.rounds, 1)  # B then A agree in round 1
+        self.assertTrue(o.consensus)
+
+    def test_dismissal_never_opens_debate(self) -> None:
+        ws = self.seed("T", [])
+        cfg = self.cfg(ws, "T", debate=True, rounds=5)
+        with mock.patch.object(C, "run_agent_blocking", _fake_turn("VERDICT: FALSE POSITIVE")):
+            o = C.run_finding(cfg, self.finding(ws, "T", "CR-9"))
+        self.assertEqual(o.status, "FALSE POSITIVE")
+        self.assertEqual(o.rounds, 0)  # debate exists to challenge confirmations, not dismissals
+
+    def test_b_agrees_skips_a_defense(self) -> None:
+        # A confirms, B agrees on its first turn → consensus WITHOUT pulling A into
+        # a defense (A never hears about the debate — turn-1 stays debate-blind).
+        ws = self.seed("T", [])
+        cfg = self.cfg(ws, "T", debate=True, rounds=5)
+        calls = {"n": 0}
+
+        def counting(*_a: object, **_k: object) -> tuple[int, str]:
+            calls["n"] += 1
+            return (0, "VERDICT: REPRODUCED")
+
+        with mock.patch.object(C, "run_agent_blocking", counting):
+            o = C.run_finding(cfg, self.finding(ws, "T", "MC-3"))
+        self.assertEqual(o.status, "REPRODUCED")
+        self.assertEqual(o.rounds, 1)
+        self.assertEqual(calls["n"], 2)  # A reproduce + B challenge; NO A defense turn
+        transcript = (ws.work_dir("T") / "confirmation" / "MC-3" / "debate.md").read_text()
+        self.assertIn("## B (round 1)", transcript)
+        self.assertNotIn("## A (round 1)", transcript)
 
 
 class TestAggregate(ConfirmCase):


### PR DESCRIPTION
Adds an **opt-in adversarial debate** to parallel confirmation. With `--confirm-debate` (pipeline) / `--debate` (phase), a verdict that asserts a real bug is stress-tested by a Challenger agent to consensus. **Default off.**

## Why
To cut false-positive *confirmations*. The Challenger's standing goal is to remove any finding that isn't a genuine, real-world-triggerable bug — but it **cannot rule a finding out on its own**: consensus requires the Reproducer's and Challenger's `VERDICT:` lines to match, so an unconvinced Reproducer holds and the finding stands. This bounds the adversary against over-killing real bugs.

## How
- Challenger (`challenge.md`) + Reproducer-defend (`defend.md`) prompts.
- The debate loop in `confirmlib.run_finding`: opens **only** on a confirmation (never a dismissal); each round is B then A; consensus = matching `VERDICT:`; ≤5 rounds (`--rounds`), else `NEEDS MORE INFO` (a terminal analytical outcome, never a rate-limit).
- `references/parallel-confirmation.md` — the two roles + debate contract + anti-sycophancy.
