### PR TITLE
workspace sandbox: wrap agent runs on macOS + Linux (issue #54 Point 1.1, 1.3, 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,8 +134,6 @@ docs/pipeline-cost-time.md
 experiments/
 # RQ2 baseline target lists: machine-specific paths; libspdm one is confidential
 scripts/exp/ablation/targets_rq2*.txt
-# §6.5 model-sensitivity "answer-mask" sandbox scaffolding
-scripts/launch/sandbox/
 # Generated output / caches
 .specula-output/
 # Per-run isolated workspaces (launch_pipeline.sh --isolate); experiment

--- a/scripts/launch/adapters/codex.sh
+++ b/scripts/launch/adapters/codex.sh
@@ -195,10 +195,21 @@ run_codex() {
   local marker_file
   marker_file="$(mktemp)"
 
-  codex exec \
-    --dangerously-bypass-approvals-and-sandbox \
-    "$PROMPT" \
-    > "$log_file" 2>&1 || true
+  # ── Optional outer srt sandbox (M1.3) ──
+  # Opt-in via SPECULA_SANDBOX=on; additive — off/unset leaves the codex argv
+  # byte-for-byte. One outer layer wraps codex and every descendant (TLC/MCP/
+  # build); the inner --dangerously-bypass-approvals-and-sandbox stays (YOLO,
+  # no nested second sandbox). Backend path repo-relative, overridable.
+  local -a cmd=()
+  if [[ "${SPECULA_SANDBOX:-}" == "on" ]]; then
+    local adapter_dir backend
+    adapter_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    backend="${SPECULA_SANDBOX_BACKEND:-$adapter_dir/../sandbox/backend.mjs}"
+    cmd+=(node "$backend" --workspace "${SPECULA_WORK_DIR:-$PWD}" --)
+  fi
+  cmd+=(codex exec --dangerously-bypass-approvals-and-sandbox "$PROMPT")
+
+  "${cmd[@]}" > "$log_file" 2>&1 || true
 
   write_usage_file "$log_file" "$marker_file"
   rm -f "$marker_file"

--- a/scripts/launch/sandbox/README.md
+++ b/scripts/launch/sandbox/README.md
@@ -74,3 +74,29 @@ With reads and network open by default, the only default protection is on writes
 A prompt-injected agent could read credentials or exfiltrate over the open
 network. To defend against that, set `read.deny` (credentials) and switch
 `network.mode` to `allowlist`.
+
+### Running the full pipeline (write paths)
+
+The default write allow-list is the run workspace + `${TMPDIR}` + `/tmp`. That
+covers **spec-only** phases (code analysis, spec generation, model checking over
+the specs in the workspace). The **full pipeline** — harness generation and trace
+validation — also writes *outside* the workspace: the artifact source tree it
+instruments and patches, and per-language build caches (`target/`, `~/.cargo`,
+`~/.cache`, …). Those are denied by default, so a full run in the default sandbox
+will fail until you grant them.
+
+Grant them without hand-editing the config by exporting
+`SPECULA_SANDBOX_EXTRA_WRITE` (a `:`-separated path list the launcher can set per
+run):
+
+```bash
+export SPECULA_SANDBOX_EXTRA_WRITE="/path/to/artifact:$HOME/.cargo:$HOME/.cache"
+```
+
+or add the same paths to `write.allow` in `sandbox.json`.
+
+**Usage stats note:** the agent's session transcript dir
+(`$CLAUDE_CONFIG_DIR/projects`, default `~/.claude/projects`) is read-only under
+the sandbox, so the per-turn / tool-use counts in `.usage.json` are not refined —
+cost and quota, taken from the agent's own JSON, are unaffected. Add that dir to
+`write.allow` if you need the full stats.

--- a/scripts/launch/sandbox/README.md
+++ b/scripts/launch/sandbox/README.md
@@ -1,0 +1,76 @@
+# Specula v0 sandbox
+
+A thin guardrail that wraps each agent run so a fully-automatic agent can work on
+a user's own machine without damaging their environment. It is a **guardrail, not
+a hard boundary**: it protects against mistakes and prompt injection, not a
+deliberately adversarial model (that needs a VM).
+
+Engine: [`@anthropic-ai/sandbox-runtime`](https://www.npmjs.com/package/@anthropic-ai/sandbox-runtime)
+(srt) — Linux = bubblewrap, macOS = Seatbelt. We drive it through its **library
+API** (`backend.mjs`), not the `srt` CLI, because the default "network fully open"
+posture cannot be expressed in srt's settings-file schema.
+
+## Files
+
+- `backend.mjs` — the shim. Reads `sandbox.json`, translates it to an srt runtime
+  config, runs the command inside the sandbox.
+- `sandbox.default.json` — the default config, copied to `~/.specula/sandbox.json`
+  on first run.
+
+## Requirements
+
+- Node ≥ 20, and `srt` installed: `npm i -g @anthropic-ai/sandbox-runtime`
+- Linux also needs `bubblewrap`, `socat`, `ripgrep`, and an unprivileged user
+  namespace (Ubuntu 24.04+: `kernel.apparmor_restrict_unprivileged_userns=0`).
+
+## Usage
+
+```bash
+backend.mjs --workspace DIR [--config PATH] -- CMD [ARGS...]
+```
+
+`--workspace` is the writable run directory (`${WORKSPACE}` in the config).
+Config is resolved in order: `--config PATH` → `<cwd>/.specula/sandbox.json` →
+`~/.specula/sandbox.json` (written from the default on first run).
+
+## Config (`sandbox.json`)
+
+**Default posture: only writes are restricted; reads and network are fully open.**
+Tighten by editing this one file — no code changes.
+
+```jsonc
+{
+  "enabled": true,                 // false = run WITHOUT sandbox (legacy behaviour)
+  "write": {                       // the ONLY dimension restricted by default
+    "allow": ["${WORKSPACE}", "${TMPDIR}"],  // placeholders expanded by Specula
+    "deny":  []                    // carve-outs inside allowed paths (deny wins)
+  },
+  "read": {                        // open by default
+    "deny":  [],                   // to protect credentials: ["~/.ssh","~/.aws","~/.config/gcloud","~/.netrc"]
+    "allow": []                    // re-allow inside a denied region (allow wins)
+  },
+  "network": {                     // open by default
+    "mode":  "open",               // "open" = no proxy, fully open; "allowlist" = deny-by-default, only `allow`
+    "allow": [],                   // allowlist mode: ["*.github.com","pypi.org","registry.npmjs.org", …]
+    "deny":  []                    // allowlist mode only (see constraint below)
+  }
+}
+```
+
+### Constraints (don't get surprised)
+
+- **`open` vs `allowlist` is either/or — there is no "open but block a few".** In
+  `open` mode srt runs no proxy, so there is no interception point; `network.deny`
+  only takes effect in `allowlist` mode.
+- **Linux paths are literal — no globs.** Use directories (e.g. `~/.ssh`), not
+  `~/.ssh/id_*`. `~` expands to the home directory.
+- srt always blocks writes to a built-in set (`.bashrc`, `.gitconfig`,
+  `.git/hooks/`, `.claude/commands/`, `.mcp.json`, …) — free defense, but it only
+  guards **writes**, not credential **reads**; protect reads via `read.deny`.
+
+### Consequence of the default
+
+With reads and network open by default, the only default protection is on writes.
+A prompt-injected agent could read credentials or exfiltrate over the open
+network. To defend against that, set `read.deny` (credentials) and switch
+`network.mode` to `allowlist`.

--- a/scripts/launch/sandbox/backend.mjs
+++ b/scripts/launch/sandbox/backend.mjs
@@ -24,6 +24,15 @@ const TEMPLATE_PATH = path.join(HERE, 'sandbox.default.json');
 const CAPABILITY = path.join(HERE, 'capability.mjs');
 const USER_CONFIG_PATH = path.join(os.homedir(), '.specula', 'sandbox.json');
 
+// Human-facing diagnostics — printed only when stderr is a real terminal. When
+// this backend wraps an agent whose stdout+stderr the caller captures and parses
+// (e.g. `claude --output-format json`, merged via 2>&1), a stray line here would
+// corrupt that stream, so stay silent unless a human is watching. Hard failures
+// (refuse / fatal) still write to stderr unconditionally.
+function diag(msg) {
+  if (process.stderr.isTTY) process.stderr.write(msg);
+}
+
 // ── Locate srt without hardcoding any machine path ──
 export async function loadSrt() {
   // 1) normal resolution — srt is a local dependency or already on NODE_PATH.
@@ -71,22 +80,31 @@ export function loadConfig(explicit, cwd) {
   const def = fs.readFileSync(TEMPLATE_PATH, 'utf8');
   fs.mkdirSync(path.dirname(USER_CONFIG_PATH), { recursive: true });
   fs.writeFileSync(USER_CONFIG_PATH, def);
-  process.stderr.write(`[specula-sandbox] wrote default config → ${USER_CONFIG_PATH} (edit it to tighten)\n`);
+  diag(`[specula-sandbox] wrote default config → ${USER_CONFIG_PATH} (edit it to tighten)\n`);
   return { cfg: JSON.parse(def), source: USER_CONFIG_PATH };
 }
 
-// Expand Specula placeholders in a config path.
+// Expand Specula placeholders (${WORKSPACE}, ${TMPDIR}) and a leading ~ in a
+// config path. We expand ~ ourselves so a credential deny does not depend on
+// srt's own tilde handling for this load-bearing path.
 export function expandPlaceholders(s, workspace) {
-  return String(s).replaceAll('${WORKSPACE}', workspace).replaceAll('${TMPDIR}', os.tmpdir());
+  let out = String(s).replaceAll('${WORKSPACE}', workspace).replaceAll('${TMPDIR}', os.tmpdir());
+  if (out === '~') out = os.homedir();
+  else if (out.startsWith('~/')) out = path.join(os.homedir(), out.slice(2));
+  return out;
 }
 
 // Specula sandbox.json → srt runtime config.
 export function translate(cfg, workspace) {
   const expand = s => expandPlaceholders(s, workspace);
   const arr = x => (Array.isArray(x) ? x : []);
+  // Run-specific write paths the launcher can inject without editing the config
+  // file (e.g. the artifact source tree + build caches a full pipeline writes to).
+  const extraWrite = (process.env.SPECULA_SANDBOX_EXTRA_WRITE || '')
+    .split(path.delimiter).filter(Boolean).map(expand);
   const runtime = {
     filesystem: {
-      allowWrite: arr(cfg.write?.allow).map(expand),
+      allowWrite: [...arr(cfg.write?.allow).map(expand), ...extraWrite],
       denyWrite: arr(cfg.write?.deny).map(expand),
       denyRead: arr(cfg.read?.deny).map(expand),
       allowRead: arr(cfg.read?.allow).map(expand),
@@ -146,7 +164,7 @@ async function main() {
   const command = args.cmd.map(shq).join(' ');
 
   if (cfg.enabled === false) {
-    process.stderr.write(`[specula-sandbox] enabled:false in ${source} → running WITHOUT sandbox\n`);
+    diag(`[specula-sandbox] enabled:false in ${source} → running WITHOUT sandbox\n`);
     runChild(command).on('exit', (code, signal) => process.exit(signal ? 1 : (code ?? 0)));
     return;
   }

--- a/scripts/launch/sandbox/backend.mjs
+++ b/scripts/launch/sandbox/backend.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// Specula v0 sandbox backend — a thin Node shim over @anthropic-ai/sandbox-runtime (srt).
+//
+// Reads a user-editable sandbox.json (Specula's own schema), translates it into an
+// srt runtime config, and runs the given command inside the srt sandbox.
+//
+// Why a Node shim and not the `srt` CLI: the default posture leaves the network
+// FULLY OPEN, which srt's settings-file schema cannot express (it requires
+// network.allowedDomains and rejects "*"). Only the library API can omit
+// allowedDomains, which makes srt skip network isolation entirely. So we drive
+// srt through SandboxManager here.
+//
+// Usage:
+//   backend.mjs --workspace DIR [--config PATH] -- CMD [ARGS...]
+
+import { spawn, spawnSync, execSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_PATH = path.join(HERE, 'sandbox.default.json');
+const CAPABILITY = path.join(HERE, 'capability.mjs');
+const USER_CONFIG_PATH = path.join(os.homedir(), '.specula', 'sandbox.json');
+
+// ── Locate srt without hardcoding any machine path ──
+export async function loadSrt() {
+  // 1) normal resolution — srt is a local dependency or already on NODE_PATH.
+  try { return await import('@anthropic-ai/sandbox-runtime'); } catch { /* fall through */ }
+  // 2) global install — ask npm where global modules live, then import by file URL.
+  let globalRoot;
+  try { globalRoot = execSync('npm root -g', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim(); } catch { /* ignore */ }
+  if (globalRoot) {
+    const entry = path.join(globalRoot, '@anthropic-ai', 'sandbox-runtime', 'dist', 'index.js');
+    if (fs.existsSync(entry)) return import(pathToFileURL(entry).href);
+  }
+  throw new Error(
+    'cannot find @anthropic-ai/sandbox-runtime — install it with:\n' +
+    '  npm i -g @anthropic-ai/sandbox-runtime');
+}
+
+function parseArgs(argv) {
+  const out = { workspace: null, config: null, cmd: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--') { out.cmd = argv.slice(i + 1); break; }
+    else if (a === '--workspace') out.workspace = argv[++i];
+    else if (a === '--config') out.config = argv[++i];
+    else throw new Error(`unknown argument: ${a}`);
+  }
+  if (!out.workspace) throw new Error('--workspace DIR is required');
+  if (out.cmd.length === 0) throw new Error('no command given (expected: … -- CMD [ARGS...])');
+  return out;
+}
+
+function readJson(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); }
+  catch (e) { throw new Error(`invalid JSON in ${p}: ${e.message}`); }
+}
+
+// Resolve the config file: explicit --config → repo-level .specula/ → user-level;
+// first run writes the tracked default to the user-level path so there is something to edit.
+export function loadConfig(explicit, cwd) {
+  const candidates = explicit
+    ? [explicit]
+    : [path.join(cwd, '.specula', 'sandbox.json'), USER_CONFIG_PATH];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return { cfg: readJson(p), source: p };
+  }
+  const def = fs.readFileSync(TEMPLATE_PATH, 'utf8');
+  fs.mkdirSync(path.dirname(USER_CONFIG_PATH), { recursive: true });
+  fs.writeFileSync(USER_CONFIG_PATH, def);
+  process.stderr.write(`[specula-sandbox] wrote default config → ${USER_CONFIG_PATH} (edit it to tighten)\n`);
+  return { cfg: JSON.parse(def), source: USER_CONFIG_PATH };
+}
+
+// Expand Specula placeholders in a config path.
+export function expandPlaceholders(s, workspace) {
+  return String(s).replaceAll('${WORKSPACE}', workspace).replaceAll('${TMPDIR}', os.tmpdir());
+}
+
+// Specula sandbox.json → srt runtime config.
+export function translate(cfg, workspace) {
+  const expand = s => expandPlaceholders(s, workspace);
+  const arr = x => (Array.isArray(x) ? x : []);
+  const runtime = {
+    filesystem: {
+      allowWrite: arr(cfg.write?.allow).map(expand),
+      denyWrite: arr(cfg.write?.deny).map(expand),
+      denyRead: arr(cfg.read?.deny).map(expand),
+      allowRead: arr(cfg.read?.allow).map(expand),
+    },
+    // network.mode:"open" (default) → leave allowedDomains UNDEFINED so srt skips
+    // network isolation entirely (host network untouched, no proxy). srt still
+    // needs a network object present (initialize reads network.parentProxy etc.).
+    network: {},
+  };
+  const net = cfg.network ?? {};
+  const mode = net.mode ?? 'open';
+  if (mode === 'allowlist') {
+    runtime.network.allowedDomains = arr(net.allow);
+    runtime.network.deniedDomains = arr(net.deny);
+  } else if (mode !== 'open') {
+    throw new Error(`network.mode must be "open" or "allowlist", got "${mode}"`);
+  }
+  return runtime;
+}
+
+// Shell-quote each arg: on Linux srt runs the command via `bash -c`, so the argv
+// must survive that re-parse.
+const shq = a => `'` + String(a).replaceAll(`'`, `'\\''`) + `'`;
+
+function runChild(command) {
+  const child = spawn(command, { shell: true, stdio: 'inherit' });
+  for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+    process.on(sig, () => { try { child.kill(sig); } catch { /* ignore */ } });
+  }
+  return child;
+}
+
+// Refuse to run unsandboxed unless the user explicitly asked (enabled:false).
+// Probes in a SEPARATE process so SandboxManager's global config is not pinned to
+// the probe run; the result is cached in SPECULA_SANDBOX_CAPABILITY so descendant
+// runs in the same session skip the (re-)probe.
+function ensureCapable(source) {
+  const cached = process.env.SPECULA_SANDBOX_CAPABILITY;
+  if (cached === 'ok') return;
+  if (cached !== 'fail') {
+    const r = spawnSync('node', [CAPABILITY], { encoding: 'utf8' });
+    if (r.status === 0) { process.env.SPECULA_SANDBOX_CAPABILITY = 'ok'; return; }
+    if (r.stderr) process.stderr.write(r.stderr);
+  }
+  process.env.SPECULA_SANDBOX_CAPABILITY = 'fail';
+  process.stderr.write(
+    `[specula-sandbox] refusing to run: the sandbox cannot start on this host and ` +
+    `"enabled" is not false in ${source}.\n` +
+    `[specula-sandbox]   → fix the cause above, or set "enabled": false to run WITHOUT the sandbox (no guardrail).\n`);
+  process.exit(3);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const workspace = path.resolve(args.workspace);
+  const { cfg, source } = loadConfig(args.config, process.cwd());
+  const command = args.cmd.map(shq).join(' ');
+
+  if (cfg.enabled === false) {
+    process.stderr.write(`[specula-sandbox] enabled:false in ${source} → running WITHOUT sandbox\n`);
+    runChild(command).on('exit', (code, signal) => process.exit(signal ? 1 : (code ?? 0)));
+    return;
+  }
+
+  ensureCapable(source);
+
+  const { SandboxManager } = await loadSrt();
+  const runtimeConfig = translate(cfg, workspace);
+  await SandboxManager.initialize(runtimeConfig);
+  const wrapped = await SandboxManager.wrapWithSandbox(command);
+  runChild(wrapped).on('exit', (code, signal) => {
+    try { SandboxManager.cleanupAfterCommand(); } catch { /* ignore */ }
+    process.exit(signal ? 1 : (code ?? 0));
+  });
+}
+
+// Only run as a CLI when invoked directly (so leak-probe.mjs can import the
+// helpers above without executing a sandbox run).
+const isCLI = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isCLI) {
+  main().catch(e => {
+    process.stderr.write(`[specula-sandbox] error: ${e.message}\n`);
+    process.exit(2);
+  });
+}

--- a/scripts/launch/sandbox/capability.mjs
+++ b/scripts/launch/sandbox/capability.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Specula v0 sandbox capability probe (M1.2).
+//
+// Decide whether srt can actually START a sandbox on THIS host. The ground truth
+// is running a trivial command through the sandbox — not just a static dependency
+// check — so it also catches missing unprivileged user namespaces and hardened
+// kernels, which a dependency list cannot see.
+//
+// Scope: macOS + Linux. Windows is out (Pial owns WSL2). On unsupported platforms
+// the probe reports "unsupported" so the caller can refuse rather than pretend.
+//
+// As a CLI: exit 0 and print "ok" when sandboxing works; exit 1 and print a
+// one-line reason on stderr otherwise. backend.mjs runs this in a SEPARATE process
+// (a probe would otherwise pin SandboxManager's global config to the probe run).
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadSrt } from './backend.mjs';
+
+// Returns { ok: true } | { ok: false, reason, hint? }.
+export async function checkCapability() {
+  let srt;
+  try { srt = await loadSrt(); }
+  catch (e) { return { ok: false, reason: e.message.split('\n')[0], hint: 'npm i -g @anthropic-ai/sandbox-runtime' }; }
+  const { SandboxManager } = srt;
+
+  if (SandboxManager.isSupportedPlatform && !SandboxManager.isSupportedPlatform()) {
+    return { ok: false, reason: `platform "${process.platform}" is not supported by srt`,
+      hint: 'on Windows, run Specula inside WSL2 (owned by Pial)' };
+  }
+
+  // Static dependency check (fast, precise reasons: bwrap / socat / ripgrep).
+  if (SandboxManager.checkDependencies) {
+    const { errors = [] } = SandboxManager.checkDependencies() || {};
+    if (errors.length) {
+      return { ok: false, reason: `missing sandbox dependencies: ${errors.join('; ')}`,
+        hint: 'Ubuntu/Debian: sudo apt-get install bubblewrap socat ripgrep' };
+    }
+  }
+
+  // Ground truth: run `true` through a minimal sandbox and see if it starts.
+  const ws = fs.mkdtempSync(path.join(os.tmpdir(), 'specula-cap-'));
+  try {
+    await SandboxManager.initialize({
+      network: {},
+      filesystem: { allowWrite: [ws], denyWrite: [], denyRead: [], allowRead: [] },
+    });
+    const wrapped = await SandboxManager.wrapWithSandbox('true');
+    const { code, stderr } = await new Promise(res => {
+      let err = '';
+      const c = spawn(wrapped, { shell: true, stdio: ['ignore', 'ignore', 'pipe'] });
+      c.stderr.on('data', d => { err += d; });
+      c.on('exit', (code, sig) => res({ code: sig ? 1 : (code ?? 1), stderr: err }));
+      c.on('error', e => res({ code: 1, stderr: e.message }));
+    });
+    try { SandboxManager.cleanupAfterCommand(); } catch { /* ignore */ }
+    if (code !== 0) {
+      const last = stderr.trim().split('\n').filter(Boolean).pop() || `exit ${code}`;
+      return { ok: false, reason: `sandbox failed to start: ${last}`,
+        hint: 'check unprivileged user namespaces (Ubuntu 24.04+: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0)' };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, reason: `sandbox failed to start: ${e.message.split('\n')[0]}` };
+  } finally {
+    fs.rmSync(ws, { recursive: true, force: true });
+  }
+}
+
+const isCLI = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isCLI) {
+  checkCapability().then(r => {
+    if (r.ok) { process.stdout.write('ok\n'); process.exit(0); }
+    process.stderr.write(`[specula-sandbox] capability check FAILED: ${r.reason}\n`);
+    if (r.hint) process.stderr.write(`[specula-sandbox]   fix: ${r.hint}\n`);
+    process.exit(1);
+  }).catch(e => {
+    process.stderr.write(`[specula-sandbox] capability check error: ${e.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/launch/sandbox/leak-probe.mjs
+++ b/scripts/launch/sandbox/leak-probe.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// Specula v0 sandbox self-test ("leak-probe").
+//
+// Given a sandbox.json, assert that everything the config claims to restrict
+// actually holds INSIDE the sandbox. It reads the SAME config the backend uses
+// (via loadConfig) and runs its checks THROUGH backend.mjs, so the probe and the
+// real run can never drift. On the default posture it verifies the one default
+// restriction (writes); it becomes load-bearing the moment a user tightens
+// read.deny or switches network to allowlist.
+//
+// Exit 0 = every restriction held. Exit 1 = at least one LEAK. Exit 2 = probe error.
+//
+// Usage: leak-probe.mjs --workspace DIR [--config PATH]
+
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadConfig, expandPlaceholders } from './backend.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const BACKEND = path.join(HERE, 'backend.mjs');
+const shq = a => `'` + String(a).replaceAll(`'`, `'\\''`) + `'`;
+
+function parseArgs(argv) {
+  const out = { workspace: null, config: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--workspace') out.workspace = argv[++i];
+    else if (a === '--config') out.config = argv[++i];
+    else throw new Error(`unknown argument: ${a}`);
+  }
+  if (!out.workspace) throw new Error('--workspace DIR is required');
+  return out;
+}
+
+const expandHome = p => (p.startsWith('~') ? path.join(os.homedir(), p.slice(1)) : p);
+
+// Up to `limit` real files under a host path, so we can test their content is masked.
+function sampleFiles(p, limit = 5) {
+  const out = [];
+  let st; try { st = fs.statSync(p); } catch { return out; }
+  if (st.isFile()) return [p];
+  if (!st.isDirectory()) return out;
+  const stack = [p];
+  while (stack.length && out.length < limit) {
+    let names; const d = stack.pop();
+    try { names = fs.readdirSync(d); } catch { continue; }
+    for (const name of names) {
+      if (out.length >= limit) break;
+      const f = path.join(d, name);
+      let s; try { s = fs.lstatSync(f); } catch { continue; }
+      if (s.isFile()) out.push(f);
+      else if (s.isDirectory()) stack.push(f);
+    }
+  }
+  return out;
+}
+
+// Is `domain` covered by an allowlist entry (exact or "*.base")?
+function domainCovered(domain, allow) {
+  return allow.some(pat => {
+    if (pat === domain) return true;
+    if (pat.startsWith('*.')) {
+      const base = pat.slice(2);
+      return domain === base || domain.endsWith('.' + base);
+    }
+    return false;
+  });
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const workspace = path.resolve(args.workspace);
+  const { cfg, source } = loadConfig(args.config, process.cwd());
+  const expand = s => expandHome(expandPlaceholders(s, workspace));
+
+  const lines = ['set -u'];
+  const notes = [];
+
+  // 1) read.deny — each denied path's file CONTENT must be unreadable inside the
+  //    sandbox. Test content (head -c1), NOT `ls`: srt masks with an empty tmpfs,
+  //    so `ls` on a denied directory succeeds with exit 0 (P0 lesson).
+  for (const raw of (cfg.read?.deny ?? [])) {
+    const files = sampleFiles(expand(raw));
+    if (files.length === 0) { notes.push(`read.deny "${raw}" — no real file on host to test`); continue; }
+    for (const f of files) {
+      lines.push(`if head -c1 ${shq(f)} >/dev/null 2>&1; then echo "LEAK read: ${f}"; else echo "ok read: ${f}"; fi`);
+    }
+  }
+
+  // 2) write — a canary OUTSIDE the allowed set must not be writable.
+  const canary = path.join(os.homedir(), '.specula-leakprobe-canary');
+  lines.push(`if touch ${shq(canary)} 2>/dev/null; then echo "LEAK write: ${canary}"; rm -f ${shq(canary)}; else echo "ok write-blocked: ${canary}"; fi`);
+
+  // 3) network allowlist — a reachable domain NOT covered by the allowlist must be blocked.
+  if ((cfg.network?.mode ?? 'open') === 'allowlist') {
+    const allow = cfg.network?.allow ?? [];
+    const canaryDomain = ['example.com', 'example.org', 'example.net'].find(d => !domainCovered(d, allow));
+    if (canaryDomain) {
+      lines.push(`code=$(curl -sS -o /dev/null -m 10 -w "%{http_code}" https://${canaryDomain} 2>/dev/null || true); ` +
+        `if [ "$code" = "200" ]; then echo "LEAK net: ${canaryDomain} reachable"; else echo "ok net-blocked: ${canaryDomain} ($code)"; fi`);
+    } else {
+      notes.push('network allowlist covers all canary domains — skipped net check');
+    }
+  } else {
+    notes.push('network mode=open — no network restriction to verify');
+  }
+
+  // Run the probe THROUGH backend.mjs against the SAME config. Keep the probe
+  // script inside the workspace (always writable + readable) so a tightened
+  // read.deny can't hide the probe itself.
+  fs.mkdirSync(workspace, { recursive: true });
+  const probePath = path.join(workspace, '.specula-leakprobe.sh');
+  fs.writeFileSync(probePath, lines.join('\n') + '\n');
+  const r = spawnSync('node', [BACKEND, '--workspace', workspace, '--config', source, '--', 'bash', probePath],
+    { encoding: 'utf8' });
+  fs.rmSync(probePath, { force: true });
+
+  const out = r.stdout || '';
+  process.stdout.write(out);
+  if (r.stderr) process.stderr.write(r.stderr);
+  for (const n of notes) process.stderr.write(`[leak-probe] note: ${n}\n`);
+
+  const leaks = out.split('\n').filter(l => l.startsWith('LEAK'));
+  const oks = out.split('\n').filter(l => l.startsWith('ok '));
+  if (leaks.length > 0) {
+    process.stderr.write(`[leak-probe] FAIL: ${leaks.length} leak(s) — config "${source}" does not hold\n`);
+    process.exit(1);
+  }
+  if (r.status !== 0 || oks.length === 0) {
+    process.stderr.write(`[leak-probe] ERROR: backend exited ${r.status} without producing checks\n`);
+    process.exit(2);
+  }
+  process.stderr.write(`[leak-probe] PASS: ${oks.length} check(s) held for config "${source}"\n`);
+  process.exit(0);
+}
+
+try { main(); }
+catch (e) { process.stderr.write(`[leak-probe] error: ${e.message}\n`); process.exit(2); }

--- a/scripts/launch/sandbox/sandbox.default.json
+++ b/scripts/launch/sandbox/sandbox.default.json
@@ -1,0 +1,16 @@
+{
+  "enabled": true,
+  "write": {
+    "allow": ["${WORKSPACE}", "${TMPDIR}"],
+    "deny": []
+  },
+  "read": {
+    "deny": [],
+    "allow": []
+  },
+  "network": {
+    "mode": "open",
+    "allow": [],
+    "deny": []
+  }
+}

--- a/scripts/launch/sandbox/sandbox.default.json
+++ b/scripts/launch/sandbox/sandbox.default.json
@@ -1,7 +1,7 @@
 {
   "enabled": true,
   "write": {
-    "allow": ["${WORKSPACE}", "${TMPDIR}"],
+    "allow": ["${WORKSPACE}", "${TMPDIR}", "/tmp"],
     "deny": []
   },
   "read": {

--- a/src/specula/adapters/claude_code.py
+++ b/src/specula/adapters/claude_code.py
@@ -41,6 +41,34 @@ def _derived_path(log_file: str, suffix: str) -> str:
     return stem + suffix
 
 
+def _maybe_wrap_sandbox(cmd: list[str], work_dir: str) -> list[str]:
+    """Optionally wrap the agent command in the outer srt sandbox (M1.3).
+
+    Opt-in via ``SPECULA_SANDBOX=on``; additive — when off/unset the command is
+    returned byte-for-byte (legacy). One outer srt layer wraps claude and every
+    descendant it spawns (TLC / MCP / build); the inner
+    ``--dangerously-skip-permissions`` stays, so the agent runs YOLO with no
+    nested second sandbox. Backend path is repo-relative but overridable via
+    ``SPECULA_SANDBOX_BACKEND`` (e.g. an installed layout).
+    """
+    if os.environ.get("SPECULA_SANDBOX", "").lower() != "on":
+        return cmd
+    backend = os.environ.get("SPECULA_SANDBOX_BACKEND") or os.path.normpath(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "..",
+            "..",
+            "..",
+            "scripts",
+            "launch",
+            "sandbox",
+            "backend.mjs",
+        )
+    )
+    workspace = work_dir or os.getcwd()
+    return ["node", backend, "--workspace", workspace, "--", *cmd]
+
+
 def _parse_result(raw_text: str) -> dict[str, Any] | None:
     """The claude result JSON, parsed once for both extractors below; None when
     the output isn't a JSON object (crash text, spawn error, truncation)."""
@@ -230,6 +258,7 @@ def main(argv: list[str]) -> int:
         if model:
             cmd += ["--model", model]
         cmd += settings_args
+        cmd = _maybe_wrap_sandbox(cmd, work_dir)
 
         # ── Run ──
         raw_json = _derived_path(log_file, ".raw.json")

--- a/tests/unit/test_sandbox_wrap.py
+++ b/tests/unit/test_sandbox_wrap.py
@@ -1,0 +1,46 @@
+"""Tests for the optional outer-sandbox wrapping in the claude-code adapter (M1.3).
+
+``_maybe_wrap_sandbox`` is the whole opt-in surface: off/unset must leave the
+agent argv byte-for-byte (legacy); on must prepend the srt backend while keeping
+the inner ``--dangerously-skip-permissions`` (YOLO) flag so the sandbox is one
+outer layer, never nested.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from specula.adapters.claude_code import _maybe_wrap_sandbox
+
+BASE = ["claude", "--print", "--dangerously-skip-permissions", "--output-format", "json"]
+
+
+class SandboxWrapTests(unittest.TestCase):
+    def test_unset_is_byte_for_byte_unchanged(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SPECULA_SANDBOX", None)
+            self.assertEqual(_maybe_wrap_sandbox(list(BASE), "/tmp/ws"), BASE)
+
+    def test_off_is_unchanged(self) -> None:
+        with mock.patch.dict(os.environ, {"SPECULA_SANDBOX": "off"}):
+            self.assertEqual(_maybe_wrap_sandbox(list(BASE), "/tmp/ws"), BASE)
+
+    def test_on_wraps_and_preserves_inner_flag(self) -> None:
+        with mock.patch.dict(os.environ, {"SPECULA_SANDBOX": "on", "SPECULA_SANDBOX_BACKEND": "/x/backend.mjs"}):
+            got = _maybe_wrap_sandbox(list(BASE), "/tmp/ws")
+        self.assertEqual(got, ["node", "/x/backend.mjs", "--workspace", "/tmp/ws", "--", *BASE])
+        self.assertIn("--dangerously-skip-permissions", got)  # inner YOLO preserved
+
+    def test_on_repo_relative_backend_resolves(self) -> None:
+        with mock.patch.dict(os.environ, {"SPECULA_SANDBOX": "on"}, clear=False):
+            os.environ.pop("SPECULA_SANDBOX_BACKEND", None)
+            got = _maybe_wrap_sandbox(list(BASE), "/tmp/ws")
+        backend = got[1]
+        self.assertTrue(backend.endswith(os.path.join("scripts", "launch", "sandbox", "backend.mjs")))
+        self.assertTrue(os.path.exists(backend))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds workspace. It wraps each agent run (and everything it spawns — TLC, MCP servers, build steps) in one outer sandbox based on Anthropic's [`sandbox-runtime` (https://www.npmjs.com/package/@anthropic-ai/sandbox-runtime) (srt: bubblewrap on Linux, Seatbelt on macOS). A single user-editable config file controls it.

## Design

- **srt via its library API, not the CLI** — the default "network open" posture can't be expressed in srt's settings file (requires `allowedDomains`, rejects `*`); only the library API omits it. `backend.mjs` is a thin Node shim.
- **One config `~/.specula/sandbox.json`** (written on first run); write / read / network translate to an srt config — single source of truth.
- **Default: only writes restricted; reads + network open.** Tightening credentials (`read.deny`) and egress (`network: allowlist`) is opt-in. *Consequence:* by default a prompt-injected agent can still read secrets and exfiltrate — the default guardrail only covers writes.
- **Additive + fail-closed** — opt-in via `SPECULA_SANDBOX=on`, off = byte-for-byte legacy; inner YOLO flags stay (one outer layer); can't-start + not `enabled:false` → refuse with a reason, never silently unguarded.

