### PR TITLE
Document WSL2 as the supported path for running Specula on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Specula runs as a set of code agent skills and MCP tools. It currently supports 
 - A supported code agent (Claude Code, Codex, or Copilot CLI) — you can contribute an adapter for your favourite agent [here](./scripts/launch/adapters)!
 - **A model with strong reasoning capability, configured at high reasoning effort.** Specula relies on the model to read code, infer protocol invariants, and reason about counterexamples; lower reasoning settings noticeably reduce bug yield.
 
+> **Windows:** run Specula inside [WSL2](https://learn.microsoft.com/windows/wsl/install) (the Linux environment built into Windows), where everything below works exactly as on Linux. Native Windows (outside WSL2) is not supported.
+
 ### Setup
 
 ```bash

--- a/src/specula/adapters/claude_code.py
+++ b/src/specula/adapters/claude_code.py
@@ -26,6 +26,8 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 from typing import Any
 
 HELP = __doc__
@@ -233,9 +235,47 @@ def main(argv: list[str]) -> int:
 
         # ── Run ──
         raw_json = _derived_path(log_file, ".raw.json")
+        # TEMPORARY WSL DEBUG: claude runs with --output-format json, which buffers
+        # the whole result and only writes agent.log at the end — so mid-run there
+        # is no signal the agent is alive. Loud debug is DEFAULT ON here; set
+        # SPECULA_DEBUG=off to silence. Revert this whole block after WSL testing.
+        # ponytail: heartbeat thread + stage prints; delete post-testing.
+        debug = os.environ.get("SPECULA_DEBUG", "on").lower() not in ("0", "off", "false", "no")
+        phase = os.environ.get("SPECULA_PHASE", "agent")
+
+        def _dbg(msg: str) -> None:
+            if debug:
+                print(f"[specula-debug] {phase}: {msg}", file=sys.stderr, flush=True)
+
+        _dbg(f"cwd={os.getcwd()}")
+        _dbg(f"log_file={log_file}")
+        _dbg(
+            f"prompt_input={prompt_input} "
+            f"({os.path.getsize(prompt_input) if os.path.exists(prompt_input) else '?'} bytes)"
+        )
+        _dbg(f"raw_json={raw_json}")
+        _dbg(f"launching: {' '.join(cmd)}")
+
+        done = threading.Event()
+
+        def _heartbeat() -> None:
+            start = time.monotonic()
+            while not done.wait(5):
+                elapsed = int(time.monotonic() - start)
+                size = os.path.getsize(raw_json) if os.path.exists(raw_json) else 0
+                print(
+                    f"[specula-debug] {phase}: claude working… {elapsed}s elapsed, "
+                    f"{size} bytes captured so far",
+                    file=sys.stderr, flush=True,
+                )
+
+        if debug:
+            threading.Thread(target=_heartbeat, daemon=True).start()
+        rc = None
         try:
             with open(prompt_input) as pin, open(raw_json, "w") as out:
-                subprocess.run(cmd, stdin=pin, stdout=out, stderr=subprocess.STDOUT)  # ignore rc
+                proc = subprocess.run(cmd, stdin=pin, stdout=out, stderr=subprocess.STDOUT)  # ignore rc
+                rc = proc.returncode
         except OSError as e:
             # Spawn failure (claude missing / not executable). Bash writes the
             # shell's "command not found" into RAW_JSON via 2>&1 and carries on;
@@ -243,8 +283,12 @@ def main(argv: list[str]) -> int:
             # error text, .usage.json = parse_failed. (A louder exit-1 failure
             # might be preferable, but changing it is a separate, deliberate
             # decision — this port stays behavior-identical to the bash.)
+            _dbg(f"SPAWN FAILED: {e} — is `claude` on PATH and executable?")
             with open(raw_json, "w") as out:
                 out.write(f"claude-code adapter: failed to run claude: {e}\n")
+        finally:
+            done.set()
+        _dbg(f"claude exited rc={rc}, captured {os.path.getsize(raw_json) if os.path.exists(raw_json) else 0} bytes")
 
         # errors="replace" is a deliberate deviation from the bash, which died on
         # non-UTF-8 claude output (UnicodeDecodeError under set -e: non-zero exit,

--- a/src/specula/adapters/claude_code.py
+++ b/src/specula/adapters/claude_code.py
@@ -26,8 +26,6 @@ import shlex
 import subprocess
 import sys
 import tempfile
-import threading
-import time
 from typing import Any
 
 HELP = __doc__
@@ -41,41 +39,6 @@ def _derived_path(log_file: str, suffix: str) -> str:
     """Mirror bash `${LOG_FILE%.log}<suffix>`."""
     stem = log_file[:-4] if log_file.endswith(".log") else log_file
     return stem + suffix
-
-
-def _trace_stream_line(line: str, dbg: Any) -> None:
-    """TEMPORARY WSL DEBUG: turn one claude stream-json NDJSON event into a
-    human-readable trace line on stderr. Best-effort; unknown shapes are ignored.
-    Delete along with the rest of the debug scaffolding after WSL testing."""
-    try:
-        evt = json.loads(line)
-    except Exception:
-        return
-    if not isinstance(evt, dict):
-        return
-    t = evt.get("type")
-    if t == "system":
-        dbg(f"[stream] system/{evt.get('subtype', '')} model={evt.get('model', '')}")
-    elif t == "assistant":
-        for block in (evt.get("message", {}) or {}).get("content", []) or []:
-            if not isinstance(block, dict):
-                continue
-            bt = block.get("type")
-            if bt == "text" and block.get("text", "").strip():
-                dbg(f"[stream] assistant: {block['text'].strip()[:500]}")
-            elif bt == "tool_use":
-                inp = json.dumps(block.get("input", {}))[:300]
-                dbg(f"[stream] tool_use {block.get('name', '?')}({inp})")
-    elif t == "user":
-        for block in (evt.get("message", {}) or {}).get("content", []) or []:
-            if isinstance(block, dict) and block.get("type") == "tool_result":
-                content = block.get("content", "")
-                if isinstance(content, list):
-                    content = " ".join(str(c.get("text", "")) for c in content if isinstance(c, dict))
-                dbg(f"[stream] tool_result: {str(content).strip()[:400]}")
-    elif t == "result":
-        dbg(f"[stream] RESULT subtype={evt.get('subtype', '')} turns={evt.get('num_turns', '?')} "
-            f"cost=${evt.get('total_cost_usd', '?')}")
 
 
 def _parse_result(raw_text: str) -> dict[str, Any] | None:
@@ -259,14 +222,7 @@ def main(argv: list[str]) -> int:
                 )
 
         # ── Build command ──
-        # TEMPORARY WSL DEBUG: opt into stream-json (live message/tool trace) with
-        # SPECULA_STREAM=on. Default stays --output-format json so the pipeline's
-        # parsing + the adapter tests are byte-for-byte unchanged.
-        _stream = os.environ.get("SPECULA_STREAM", "").lower() in ("1", "on", "true", "yes")
-        _fmt = "stream-json" if _stream else "json"
-        cmd = ["claude", "--print", "--dangerously-skip-permissions", "--output-format", _fmt]
-        if _stream:
-            cmd += ["--verbose", "--include-partial-messages"]
+        cmd = ["claude", "--print", "--dangerously-skip-permissions", "--output-format", "json"]
         if effort and effort != "default":
             cmd += ["--effort", effort]
         if max_budget and max_budget != "0":
@@ -277,99 +233,18 @@ def main(argv: list[str]) -> int:
 
         # ── Run ──
         raw_json = _derived_path(log_file, ".raw.json")
-        # TEMPORARY WSL DEBUG: claude runs with --output-format json, which buffers
-        # the whole result and only writes agent.log at the end — so mid-run there
-        # is no signal the agent is alive. Loud debug is DEFAULT ON here; set
-        # SPECULA_DEBUG=off to silence. Revert this whole block after WSL testing.
-        # ponytail: heartbeat thread + stage prints; delete post-testing.
-        debug = os.environ.get("SPECULA_DEBUG", "on").lower() not in ("0", "off", "false", "no")
-        phase = os.environ.get("SPECULA_PHASE", "agent")
-
-        def _dbg(msg: str) -> None:
-            if debug:
-                print(f"[specula-debug] {phase}: {msg}", file=sys.stderr, flush=True)
-
-        _dbg(f"cwd={os.getcwd()}")
-        _dbg(f"log_file={log_file}")
-        _dbg(
-            f"prompt_input={prompt_input} "
-            f"({os.path.getsize(prompt_input) if os.path.exists(prompt_input) else '?'} bytes)"
-        )
-        _dbg(f"raw_json={raw_json}")
-        _dbg(f"launching: {' '.join(cmd)}")
-        if debug:
-            try:
-                _ptext = open(prompt_input, errors="replace").read()
-                _dbg(f"PROMPT ({len(_ptext)} chars) head:\n{_ptext[:800]}")
-                if len(_ptext) > 800:
-                    _dbg(f"PROMPT tail:\n{_ptext[-400:]}")
-            except OSError as e:
-                _dbg(f"could not read prompt for preview: {e}")
-
-        done = threading.Event()
-
-        def _heartbeat() -> None:
-            start = time.monotonic()
-            while not done.wait(5):
-                elapsed = int(time.monotonic() - start)
-                size = os.path.getsize(raw_json) if os.path.exists(raw_json) else 0
-                print(
-                    f"[specula-debug] {phase}: claude working… {elapsed}s elapsed, "
-                    f"{size} bytes captured so far",
-                    file=sys.stderr, flush=True,
-                )
-
-        rc = None
-        if debug and _stream:
-            # Stream mode: read claude's NDJSON events live, print a human trace to
-            # stderr, save the raw stream, and keep the LAST result event as raw_json
-            # so downstream parsing (_parse_result/_extract_usage) is unchanged.
-            stream_path = _derived_path(log_file, ".stream.jsonl")
-            result_line = ""
-            try:
-                with open(prompt_input) as pin, open(stream_path, "w") as sout:
-                    proc = subprocess.Popen(
-                        cmd, stdin=pin, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
-                    )
-                    assert proc.stdout is not None
-                    for line in proc.stdout:
-                        sout.write(line)
-                        sout.flush()
-                        _trace_stream_line(line, _dbg)
-                        try:
-                            evt = json.loads(line)
-                        except Exception:
-                            continue
-                        if isinstance(evt, dict) and evt.get("type") == "result":
-                            result_line = line
-                    rc = proc.wait()
-                # raw_json must hold the single result object json-mode would have produced
-                with open(raw_json, "w") as out:
-                    out.write(result_line or "")
-                _dbg(f"stream saved -> {stream_path}")
-            except OSError as e:
-                _dbg(f"SPAWN FAILED: {e} — is `claude` on PATH and executable?")
-                with open(raw_json, "w") as out:
-                    out.write(f"claude-code adapter: failed to run claude: {e}\n")
-        else:
-            if debug:
-                threading.Thread(target=_heartbeat, daemon=True).start()
-            try:
-                with open(prompt_input) as pin, open(raw_json, "w") as out:
-                    proc = subprocess.run(cmd, stdin=pin, stdout=out, stderr=subprocess.STDOUT)  # ignore rc
-                    rc = proc.returncode
-            except OSError as e:
-                # Spawn failure (claude missing / not executable). Bash writes the
-                # shell's "command not found" into RAW_JSON via 2>&1 and carries on;
-                # mirror that so post-processing still runs → exit 0, .log with the
-                # error text, .usage.json = parse_failed. (A louder exit-1 failure
-                # might be preferable, but changing it is a separate, deliberate
-                # decision — this port stays behavior-identical to the bash.)
-                _dbg(f"SPAWN FAILED: {e} — is `claude` on PATH and executable?")
-                with open(raw_json, "w") as out:
-                    out.write(f"claude-code adapter: failed to run claude: {e}\n")
-        done.set()
-        _dbg(f"claude exited rc={rc}, captured {os.path.getsize(raw_json) if os.path.exists(raw_json) else 0} bytes")
+        try:
+            with open(prompt_input) as pin, open(raw_json, "w") as out:
+                subprocess.run(cmd, stdin=pin, stdout=out, stderr=subprocess.STDOUT)  # ignore rc
+        except OSError as e:
+            # Spawn failure (claude missing / not executable). Bash writes the
+            # shell's "command not found" into RAW_JSON via 2>&1 and carries on;
+            # mirror that so post-processing still runs → exit 0, .log with the
+            # error text, .usage.json = parse_failed. (A louder exit-1 failure
+            # might be preferable, but changing it is a separate, deliberate
+            # decision — this port stays behavior-identical to the bash.)
+            with open(raw_json, "w") as out:
+                out.write(f"claude-code adapter: failed to run claude: {e}\n")
 
         # errors="replace" is a deliberate deviation from the bash, which died on
         # non-UTF-8 claude output (UnicodeDecodeError under set -e: non-zero exit,
@@ -377,9 +252,6 @@ def main(argv: list[str]) -> int:
         # signal). Degrade to U+FFFD + parse_failed on the normal exit-code path
         # instead (test_adapters.py::test_nonutf8_output_degrades_gracefully).
         raw_text = open(raw_json, errors="replace").read()
-        _dbg(f"RAW OUTPUT ({len(raw_text)} chars) head:\n{raw_text[:1200]}")
-        if len(raw_text) > 1200:
-            _dbg(f"RAW OUTPUT tail:\n{raw_text[-600:]}")
 
         # ── Detect rate limit → exit 75 (EX_TEMPFAIL) so callers can wait/retry ──
         rate_limited = "hit your limit" in raw_text
@@ -389,12 +261,6 @@ def main(argv: list[str]) -> int:
         result = _parse_result(raw_text)
         _extract_log(result, raw_text, log_file)
         _extract_usage(result, _derived_path(log_file, ".usage.json"))
-        if debug:
-            _rtext = (result or {}).get("result", "") if isinstance(result, dict) else ""
-            _dbg(f"parsed result: {'ok' if result else 'PARSE FAILED (raw dumped above)'}")
-            if _rtext:
-                _dbg(f"RESULT TEXT ({len(_rtext)} chars) head:\n{_rtext[:1200]}")
-            _dbg(f"wrote agent.log -> {log_file}")
 
         return 75 if rate_limited else 0
     finally:

--- a/src/specula/adapters/claude_code.py
+++ b/src/specula/adapters/claude_code.py
@@ -255,6 +255,14 @@ def main(argv: list[str]) -> int:
         )
         _dbg(f"raw_json={raw_json}")
         _dbg(f"launching: {' '.join(cmd)}")
+        if debug:
+            try:
+                _ptext = open(prompt_input, errors="replace").read()
+                _dbg(f"PROMPT ({len(_ptext)} chars) head:\n{_ptext[:800]}")
+                if len(_ptext) > 800:
+                    _dbg(f"PROMPT tail:\n{_ptext[-400:]}")
+            except OSError as e:
+                _dbg(f"could not read prompt for preview: {e}")
 
         done = threading.Event()
 
@@ -296,6 +304,9 @@ def main(argv: list[str]) -> int:
         # signal). Degrade to U+FFFD + parse_failed on the normal exit-code path
         # instead (test_adapters.py::test_nonutf8_output_degrades_gracefully).
         raw_text = open(raw_json, errors="replace").read()
+        _dbg(f"RAW OUTPUT ({len(raw_text)} chars) head:\n{raw_text[:1200]}")
+        if len(raw_text) > 1200:
+            _dbg(f"RAW OUTPUT tail:\n{raw_text[-600:]}")
 
         # ── Detect rate limit → exit 75 (EX_TEMPFAIL) so callers can wait/retry ──
         rate_limited = "hit your limit" in raw_text
@@ -305,6 +316,12 @@ def main(argv: list[str]) -> int:
         result = _parse_result(raw_text)
         _extract_log(result, raw_text, log_file)
         _extract_usage(result, _derived_path(log_file, ".usage.json"))
+        if debug:
+            _rtext = (result or {}).get("result", "") if isinstance(result, dict) else ""
+            _dbg(f"parsed result: {'ok' if result else 'PARSE FAILED (raw dumped above)'}")
+            if _rtext:
+                _dbg(f"RESULT TEXT ({len(_rtext)} chars) head:\n{_rtext[:1200]}")
+            _dbg(f"wrote agent.log -> {log_file}")
 
         return 75 if rate_limited else 0
     finally:

--- a/src/specula/adapters/claude_code.py
+++ b/src/specula/adapters/claude_code.py
@@ -43,6 +43,41 @@ def _derived_path(log_file: str, suffix: str) -> str:
     return stem + suffix
 
 
+def _trace_stream_line(line: str, dbg: Any) -> None:
+    """TEMPORARY WSL DEBUG: turn one claude stream-json NDJSON event into a
+    human-readable trace line on stderr. Best-effort; unknown shapes are ignored.
+    Delete along with the rest of the debug scaffolding after WSL testing."""
+    try:
+        evt = json.loads(line)
+    except Exception:
+        return
+    if not isinstance(evt, dict):
+        return
+    t = evt.get("type")
+    if t == "system":
+        dbg(f"[stream] system/{evt.get('subtype', '')} model={evt.get('model', '')}")
+    elif t == "assistant":
+        for block in (evt.get("message", {}) or {}).get("content", []) or []:
+            if not isinstance(block, dict):
+                continue
+            bt = block.get("type")
+            if bt == "text" and block.get("text", "").strip():
+                dbg(f"[stream] assistant: {block['text'].strip()[:500]}")
+            elif bt == "tool_use":
+                inp = json.dumps(block.get("input", {}))[:300]
+                dbg(f"[stream] tool_use {block.get('name', '?')}({inp})")
+    elif t == "user":
+        for block in (evt.get("message", {}) or {}).get("content", []) or []:
+            if isinstance(block, dict) and block.get("type") == "tool_result":
+                content = block.get("content", "")
+                if isinstance(content, list):
+                    content = " ".join(str(c.get("text", "")) for c in content if isinstance(c, dict))
+                dbg(f"[stream] tool_result: {str(content).strip()[:400]}")
+    elif t == "result":
+        dbg(f"[stream] RESULT subtype={evt.get('subtype', '')} turns={evt.get('num_turns', '?')} "
+            f"cost=${evt.get('total_cost_usd', '?')}")
+
+
 def _parse_result(raw_text: str) -> dict[str, Any] | None:
     """The claude result JSON, parsed once for both extractors below; None when
     the output isn't a JSON object (crash text, spawn error, truncation)."""
@@ -224,7 +259,14 @@ def main(argv: list[str]) -> int:
                 )
 
         # ── Build command ──
-        cmd = ["claude", "--print", "--dangerously-skip-permissions", "--output-format", "json"]
+        # TEMPORARY WSL DEBUG: opt into stream-json (live message/tool trace) with
+        # SPECULA_STREAM=on. Default stays --output-format json so the pipeline's
+        # parsing + the adapter tests are byte-for-byte unchanged.
+        _stream = os.environ.get("SPECULA_STREAM", "").lower() in ("1", "on", "true", "yes")
+        _fmt = "stream-json" if _stream else "json"
+        cmd = ["claude", "--print", "--dangerously-skip-permissions", "--output-format", _fmt]
+        if _stream:
+            cmd += ["--verbose", "--include-partial-messages"]
         if effort and effort != "default":
             cmd += ["--effort", effort]
         if max_budget and max_budget != "0":
@@ -277,25 +319,56 @@ def main(argv: list[str]) -> int:
                     file=sys.stderr, flush=True,
                 )
 
-        if debug:
-            threading.Thread(target=_heartbeat, daemon=True).start()
         rc = None
-        try:
-            with open(prompt_input) as pin, open(raw_json, "w") as out:
-                proc = subprocess.run(cmd, stdin=pin, stdout=out, stderr=subprocess.STDOUT)  # ignore rc
-                rc = proc.returncode
-        except OSError as e:
-            # Spawn failure (claude missing / not executable). Bash writes the
-            # shell's "command not found" into RAW_JSON via 2>&1 and carries on;
-            # mirror that so post-processing still runs → exit 0, .log with the
-            # error text, .usage.json = parse_failed. (A louder exit-1 failure
-            # might be preferable, but changing it is a separate, deliberate
-            # decision — this port stays behavior-identical to the bash.)
-            _dbg(f"SPAWN FAILED: {e} — is `claude` on PATH and executable?")
-            with open(raw_json, "w") as out:
-                out.write(f"claude-code adapter: failed to run claude: {e}\n")
-        finally:
-            done.set()
+        if debug and _stream:
+            # Stream mode: read claude's NDJSON events live, print a human trace to
+            # stderr, save the raw stream, and keep the LAST result event as raw_json
+            # so downstream parsing (_parse_result/_extract_usage) is unchanged.
+            stream_path = _derived_path(log_file, ".stream.jsonl")
+            result_line = ""
+            try:
+                with open(prompt_input) as pin, open(stream_path, "w") as sout:
+                    proc = subprocess.Popen(
+                        cmd, stdin=pin, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
+                    )
+                    assert proc.stdout is not None
+                    for line in proc.stdout:
+                        sout.write(line)
+                        sout.flush()
+                        _trace_stream_line(line, _dbg)
+                        try:
+                            evt = json.loads(line)
+                        except Exception:
+                            continue
+                        if isinstance(evt, dict) and evt.get("type") == "result":
+                            result_line = line
+                    rc = proc.wait()
+                # raw_json must hold the single result object json-mode would have produced
+                with open(raw_json, "w") as out:
+                    out.write(result_line or "")
+                _dbg(f"stream saved -> {stream_path}")
+            except OSError as e:
+                _dbg(f"SPAWN FAILED: {e} — is `claude` on PATH and executable?")
+                with open(raw_json, "w") as out:
+                    out.write(f"claude-code adapter: failed to run claude: {e}\n")
+        else:
+            if debug:
+                threading.Thread(target=_heartbeat, daemon=True).start()
+            try:
+                with open(prompt_input) as pin, open(raw_json, "w") as out:
+                    proc = subprocess.run(cmd, stdin=pin, stdout=out, stderr=subprocess.STDOUT)  # ignore rc
+                    rc = proc.returncode
+            except OSError as e:
+                # Spawn failure (claude missing / not executable). Bash writes the
+                # shell's "command not found" into RAW_JSON via 2>&1 and carries on;
+                # mirror that so post-processing still runs → exit 0, .log with the
+                # error text, .usage.json = parse_failed. (A louder exit-1 failure
+                # might be preferable, but changing it is a separate, deliberate
+                # decision — this port stays behavior-identical to the bash.)
+                _dbg(f"SPAWN FAILED: {e} — is `claude` on PATH and executable?")
+                with open(raw_json, "w") as out:
+                    out.write(f"claude-code adapter: failed to run claude: {e}\n")
+        done.set()
         _dbg(f"claude exited rc={rc}, captured {os.path.getsize(raw_json) if os.path.exists(raw_json) else 0} bytes")
 
         # errors="replace" is a deliberate deviation from the bash, which died on


### PR DESCRIPTION
The linux setup works fine on WSL2.
Added a small section in the README mentioning it.

---

On a side note, when Specula is running, we should log some messages in the terminal to show the agent is working. Otherwise, when I was running on WSL2, I was confused about whether the agent was working or if it was stuck when the program had been running for 20+ minutes. Anything to indicate the agent is doing stuff would be nice. Also, it's nicer to look at :3