### PR TITLE
Uniform --model / --effort interface across agent adapters

### DIFF
--- a/scripts/launch/adapters/codex.sh
+++ b/scripts/launch/adapters/codex.sh
@@ -29,8 +29,10 @@ MAX_TURNS=""
 LOG_FILE=""
 BACKGROUND=false
 CLAUDE_ALIAS=""
-EFFORT=""
-MODEL=""
+# Read adapter-specific environment defaults before parsing so an explicit
+# empty flag can still win and clear them.
+EFFORT="${CODEX_EFFORT:-}"
+MODEL="${CODEX_MODEL:-}"
 
 for arg in "$@"; do
   case "$arg" in
@@ -50,9 +52,10 @@ for arg in "$@"; do
   esac
 done
 
-# Flag wins over env; empty (neither set) -> codex config.toml default.
-MODEL="${MODEL:-${CODEX_MODEL:-}}"
-EFFORT="${EFFORT:-${CODEX_EFFORT:-}}"
+# The resolved values are carried by argv below.  Do not leak the wrapper's
+# fallback variables into Codex itself: an explicit `--model=` / `--effort=`
+# must genuinely return to config.toml defaults.
+unset CODEX_MODEL CODEX_EFFORT
 
 # ── Validate arguments ──
 

--- a/scripts/launch/adapters/codex.sh
+++ b/scripts/launch/adapters/codex.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Adapter: codex
-# Capabilities: max-turns, auto-approve, background, stop-gate
+# Capabilities: max-turns, model-select, effort-select, auto-approve, background, stop-gate
 #
 # Unified interface for invoking Codex CLI.
 #
@@ -14,7 +14,11 @@
 #   --log output.log       Log file path (required)
 #   --background           Run in background, print PID to stdout (default: foreground)
 #   --claude-alias NAME    Accepted for launcher compatibility; ignored.
-#   --effort LEVEL         Accepted for launcher compatibility; ignored.
+#   --model NAME           Model to use; passed to codex as -m. Env: CODEX_MODEL.
+#                          Empty -> codex config.toml default.
+#   --effort LEVEL         Reasoning effort (e.g. minimal|low|medium|high|ultra);
+#                          passed as -c model_reasoning_effort. Env: CODEX_EFFORT.
+#                          Empty -> codex config.toml default.
 #   --help                 Show this help
 
 set -euo pipefail
@@ -26,6 +30,7 @@ LOG_FILE=""
 BACKGROUND=false
 CLAUDE_ALIAS=""
 EFFORT=""
+MODEL=""
 
 for arg in "$@"; do
   case "$arg" in
@@ -36,6 +41,7 @@ for arg in "$@"; do
     --background)    BACKGROUND=true ;;
     --claude-alias=*) CLAUDE_ALIAS="${arg#*=}" ;;
     --effort=*)      EFFORT="${arg#*=}" ;;
+    --model=*)       MODEL="${arg#*=}" ;;
     --help|-h)
       sed -n '2,/^$/{ s/^# //; s/^#//; p }' "$0"
       exit 0
@@ -43,6 +49,10 @@ for arg in "$@"; do
     *) echo "codex adapter: unknown option: $arg" >&2; exit 1 ;;
   esac
 done
+
+# Flag wins over env; empty (neither set) -> codex config.toml default.
+MODEL="${MODEL:-${CODEX_MODEL:-}}"
+EFFORT="${EFFORT:-${CODEX_EFFORT:-}}"
 
 # ── Validate arguments ──
 
@@ -218,6 +228,9 @@ run_codex() {
     cmd+=(node "$backend" --workspace "${SPECULA_WORK_DIR:-$PWD}" --)
   fi
   cmd+=(codex exec --dangerously-bypass-approvals-and-sandbox)
+  # Model / reasoning effort (additive — empty leaves codex config.toml default).
+  [[ -n "$MODEL" ]] && cmd+=(-m "$MODEL")
+  [[ -n "$EFFORT" ]] && cmd+=(-c "model_reasoning_effort=$EFFORT")
 
   local codex_rc=0
   set +e

--- a/scripts/launch/adapters/copilot-cli.sh
+++ b/scripts/launch/adapters/copilot-cli.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Adapter: copilot-cli
-# Capabilities: model-select, auto-approve, background
+# Capabilities: model-select, effort-select, auto-approve, background
 # stop-gate: NOT supported — Copilot CLI has no stop-hook mechanism. The
 # generic gate env vars (SPECULA_PHASE/SPECULA_WORK_DIR; see
 # src/specula/stop_gate.py) are simply never read here, so the execution
@@ -18,7 +18,8 @@
 #   --max-turns N          Mapped to --max-autopilot-continues (0=unlimited, omits flag)
 #   --model MODEL          AI model to use (default: $COPILOT_MODEL or Copilot CLI default)
 #   --claude-alias NAME    Accepted for adapter compatibility; ignored
-#   --effort LEVEL         Accepted for adapter compatibility; ignored
+#   --effort LEVEL         Reasoning effort; mapped to Copilot CLI's
+#                          --reasoning-effort (requires Copilot CLI 1.0.4+)
 #   --log output.log       Log file path (required)
 #   --background           Run in background, print PID to stdout (default: foreground)
 #   --help                 Show this help
@@ -29,6 +30,7 @@ PROMPT=""
 PROMPT_FILE=""
 MAX_TURNS=""
 MODEL="${COPILOT_MODEL:-}"
+EFFORT=""
 LOG_FILE=""
 BACKGROUND=false
 
@@ -39,7 +41,7 @@ for arg in "$@"; do
     --max-turns=*)   MAX_TURNS="${arg#*=}" ;;
     --model=*)       MODEL="${arg#*=}" ;;
     --claude-alias=*) : ;;
-    --effort=*)      : ;;
+    --effort=*)      EFFORT="${arg#*=}" ;;
     --log=*)         LOG_FILE="${arg#*=}" ;;
     --background)    BACKGROUND=true ;;
     --help|-h)
@@ -49,6 +51,11 @@ for arg in "$@"; do
     *) echo "copilot-cli adapter: unknown option: $arg" >&2; exit 1 ;;
   esac
 done
+
+# MODEL now carries the wrapper fallback or the explicit flag.  Always remove
+# the environment variable before spawning Copilot so `--model=` can genuinely
+# clear an inherited COPILOT_MODEL and return to settings.json / CLI defaults.
+unset COPILOT_MODEL
 
 # ── Validate arguments ──
 
@@ -77,6 +84,17 @@ if [[ -n "$PROMPT_FILE" ]]; then
   PROMPT="$(cat "$PROMPT_FILE")"
 fi
 
+# Probe optional CLI features once per adapter invocation.  Capability probing
+# is more robust than parsing version strings across stable/prerelease channels.
+COPILOT_HELP=""
+COPILOT_HELP_READY=false
+load_copilot_help() {
+  if [[ "$COPILOT_HELP_READY" != true ]]; then
+    COPILOT_HELP="$(copilot --help 2>&1 || true)"
+    COPILOT_HELP_READY=true
+  fi
+}
+
 # ── Build command ──
 #
 # Note: --background is handled by the caller (launch scripts use & directly).
@@ -87,6 +105,20 @@ CMD=(copilot -p "$PROMPT" --allow-all)
 
 if [[ -n "$MODEL" ]]; then
   CMD+=(--model "$MODEL")
+fi
+
+if [[ -n "$EFFORT" ]]; then
+  load_copilot_help
+  if grep -q -- '--reasoning-effort' <<< "$COPILOT_HELP"; then
+    CMD+=(--reasoning-effort "$EFFORT")
+  elif grep -q -- '--effort' <<< "$COPILOT_HELP"; then
+    # Short alias added after the canonical flag; retain this fallback for
+    # unusual prerelease builds that advertise only the alias.
+    CMD+=(--effort "$EFFORT")
+  else
+    echo "copilot-cli adapter: --effort requires Copilot CLI 1.0.4+ (installed client does not advertise --reasoning-effort)" >&2
+    exit 1
+  fi
 fi
 
 # Map --max-turns to --max-autopilot-continues (skip if 0 = unlimited)
@@ -103,11 +135,9 @@ fi
 ADAPTER_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EVENT_HELPER="$ADAPTER_DIR/../../../src/specula/adapters/event_stream.py"
 
-# JSON streaming arrived after the first Copilot CLI releases. Probe the
-# installed binary's help instead of imposing a minimum version: old clients
-# still stream their plain output through the helper, so activity logging stays
-# enabled without passing flags they do not understand.
-COPILOT_HELP="$(copilot --help 2>&1 || true)"
+# JSON streaming arrived after the first Copilot CLI releases. Old clients
+# still stream plain output through the helper without unsupported flags.
+load_copilot_help
 if grep -q -- '--output-format' <<< "$COPILOT_HELP"; then
   CMD+=(--output-format json)
 fi

--- a/src/specula/adapters/claude_code.py
+++ b/src/specula/adapters/claude_code.py
@@ -269,6 +269,12 @@ def main(argv: list[str]) -> int:
         else:
             return _die(f"claude-code adapter: unknown option: {arg}")
 
+    # Environment variables are wrapper fallbacks, not a second input channel
+    # for the child process.  The resolved values are expressed through argv;
+    # removing them here makes an explicit empty flag a real reset.
+    os.environ.pop("CLAUDE_MODEL", None)
+    os.environ.pop("CLAUDE_EFFORT", None)
+
     # ── Validate arguments ──
     if prompt and prompt_file:
         return _die("claude-code adapter: --prompt and --prompt-file are mutually exclusive")

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -110,6 +110,8 @@ class ConfirmConfig:
     repo_dir: str = ""
     max_parallel: int = 4
     claude_alias: str = "claude"
+    model: str = ""  # forwarded to the adapter (empty -> adapter default)
+    effort: str = ""  # reasoning effort forwarded to the adapter
     worktree: bool = True
     dry_run: bool = False
     prompt_extra: str = ""  # target's .prompt-extra.md, appended to every agent prompt
@@ -178,6 +180,8 @@ def run_turn(cfg: ConfirmConfig, f: Finding, role: str, turn_no: int, prompt: st
         phase_key=PHASE_KEY,
         work_dir=cfg.ws.work_dir(cfg.name),
         claude_alias=cfg.claude_alias,
+        model=cfg.model,
+        effort=cfg.effort,
     )
     if rc == 75:
         raise RateLimited(f"{f.id} turn {turn_no} {role}")
@@ -415,6 +419,8 @@ def consolidate(cfg: ConfirmConfig) -> None:
         phase_key=PHASE_KEY,
         work_dir=wd,
         claude_alias=cfg.claude_alias,
+        model=cfg.model,
+        effort=cfg.effort,
     )
     if rc == 75:
         raise RateLimited(f"{cfg.name} consolidate")

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -110,11 +110,13 @@ class ConfirmConfig:
     repo_dir: str = ""
     max_parallel: int = 4
     claude_alias: str = "claude"
-    model: str = ""  # forwarded to the adapter (empty -> adapter default)
-    effort: str = ""  # reasoning effort forwarded to the adapter
     worktree: bool = True
     dry_run: bool = False
     prompt_extra: str = ""  # target's .prompt-extra.md, appended to every agent prompt
+    # Appended after the original fields to preserve positional callers.
+    # None = no Specula override; "" = explicit reset to the CLI default.
+    model: str | None = None
+    effort: str | None = None
 
 
 @dataclass

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -213,6 +213,8 @@ class Phase:
     accepts_artifact = True  # bug_classification takes no --artifact (rejects it)
     dry_prompt_flag = "--prompt"  # bug_classification's dry-run line shows --prompt-file
     progress_config = progress.ProgressConfig()
+    _model = ""  # model / reasoning effort forwarded to the adapter; set in run()
+    _effort = ""
 
     # ── per-phase hooks ──
     def parse_flag(self, arg: str, extra: dict[str, str | bool]) -> bool:
@@ -380,6 +382,8 @@ class Phase:
         agent = "claude-code"
         # `or`: bash ${CLAUDE_ALIAS:-claude} treats an exported-but-empty var as unset
         claude_alias = os.environ.get("CLAUDE_ALIAS") or "claude"
+        model = ""
+        effort = ""
         artifact = ""
         targets: list[str] = []
         extra: dict[str, str | bool] = {}
@@ -411,6 +415,10 @@ class Phase:
                 agent = arg[len("--agent=") :]
             elif arg.startswith("--claude-alias="):
                 claude_alias = arg[len("--claude-alias=") :]
+            elif arg.startswith("--model="):
+                model = arg[len("--model=") :]
+            elif arg.startswith("--effort="):
+                effort = arg[len("--effort=") :]
             elif arg.startswith("--artifact=") and self.accepts_artifact:
                 artifact = arg[len("--artifact=") :]
             elif arg in ("--help", "-h"):
@@ -426,6 +434,12 @@ class Phase:
 
         if not targets:
             targets = [_logical_cwd().name]  # bash `basename "$PWD"` (logical under symlinks)
+
+        # Model / reasoning effort: flag wins, then a run-wide env, else empty —
+        # each adapter falls back to its own env / CLI default. Forwarded to the
+        # adapter (translated per-CLI) only when non-empty.
+        self._model = model or os.environ.get("SPECULA_MODEL") or ""
+        self._effort = effort or os.environ.get("SPECULA_EFFORT") or ""
 
         adapter = LAUNCH_DIR / "adapters" / f"{agent}.sh"
         if not adapter.is_file():
@@ -689,7 +703,7 @@ class Phase:
                     f"--prompt-file={files['prompt']}",
                     f"--max-turns={max_turns}",
                     f"--claude-alias={claude_alias}",
-                    "--effort=max",
+                    *_model_effort_argv(self._model, self._effort),
                     f"--log={files['log']}",
                     "--background",
                 ],
@@ -727,6 +741,21 @@ class Phase:
         return launched
 
 
+def _model_effort_argv(model: str, effort: str) -> list[str]:
+    """Adapter flags for model / reasoning effort, omitted when empty so the
+    adapter falls back to its own env (`CODEX_MODEL`, `CLAUDE_EFFORT`, …) or the
+    CLI default. Empty is the default on purpose: a hardcoded ``--effort=max`` is
+    a claude-ism the codex adapter rejects (codex has no ``max`` level). Each
+    adapter translates these to its native flags (codex ``-m`` / ``-c
+    model_reasoning_effort``, claude ``--model`` / ``--effort``)."""
+    argv: list[str] = []
+    if model:
+        argv.append(f"--model={model}")
+    if effort:
+        argv.append(f"--effort={effort}")
+    return argv
+
+
 def run_agent_blocking(
     adapter: Path,
     prompt: str,
@@ -738,12 +767,14 @@ def run_agent_blocking(
     claude_alias: str,
     max_turns: str = "0",
     stop_gate: bool = False,
+    model: str = "",
+    effort: str = "",
 ) -> tuple[int, str]:
     """Run ONE agent invocation, blocking, and return (returncode, log text).
 
     The blocking sibling of `Phase._launch`: it shares the same adapter path, the
     same flag set (`--prompt-file` / `--max-turns` / `--claude-alias` /
-    `--effort=max` / `--log`), and the same stop-gate env keys
+    `--model` / `--effort` / `--log`), and the same stop-gate env keys
     (`SPECULA_PHASE` / `SPECULA_WORK_DIR`) — but drops `--background` so the
     caller can read the result before issuing the next turn. That is the shape a
     per-finding confirmation debate needs (turn N+1 reads turn N's output),
@@ -767,7 +798,7 @@ def run_agent_blocking(
         f"--prompt-file={prompt_file}",
         f"--max-turns={max_turns}",
         f"--claude-alias={claude_alias}",
-        "--effort=max",
+        *_model_effort_argv(model, effort),
         f"--log={log_file}",
     ]
     rc = subprocess.run(cmd, env=env).returncode
@@ -1492,6 +1523,8 @@ Prerequisites:
                 repo_dir=ws.find_repo_dir(name),
                 max_parallel=findings_parallel,
                 claude_alias=claude_alias,
+                model=self._model,
+                effort=self._effort,
                 dry_run=dry_run,
                 prompt_extra=self._read_prompt_extra(ws, name),
             )
@@ -1646,17 +1679,26 @@ Output:
         phase = argv[0] if argv else ""
         agent = "claude-code"
         claude_alias = os.environ.get("CLAUDE_ALIAS") or "claude"
+        model = ""
+        effort = ""
         targets: list[str] = []
         for arg in argv[1:]:
             if arg.startswith("--agent="):
                 agent = arg[len("--agent=") :]
             elif arg.startswith("--claude-alias="):
                 claude_alias = arg[len("--claude-alias=") :]
+            elif arg.startswith("--model="):
+                model = arg[len("--model=") :]
+            elif arg.startswith("--effort="):
+                effort = arg[len("--effort=") :]
             elif arg in ("--help", "-h"):
                 sys.stdout.write(self.usage)
                 return 0
             else:
                 targets.append(arg)
+
+        self._model = model or os.environ.get("SPECULA_MODEL") or ""
+        self._effort = effort or os.environ.get("SPECULA_EFFORT") or ""
 
         if not phase or not targets:
             print(f"Usage: {SCRIPT_DIR}/phaselib.py review <analysis|specgen|validation> name [name ...]")
@@ -1766,7 +1808,7 @@ Output:
                     f"--prompt={prompt.rstrip(chr(10))}",
                     "--max-turns=30",
                     f"--claude-alias={claude_alias}",
-                    "--effort=max",
+                    *_model_effort_argv(self._model, self._effort),
                     f"--log={log_file}",
                     "--background",
                 ],

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -213,8 +213,10 @@ class Phase:
     accepts_artifact = True  # bug_classification takes no --artifact (rejects it)
     dry_prompt_flag = "--prompt"  # bug_classification's dry-run line shows --prompt-file
     progress_config = progress.ProgressConfig()
-    _model = ""  # model / reasoning effort forwarded to the adapter; set in run()
-    _effort = ""
+    # Tri-state tuning values set in run(): None = unspecified, "" = explicit
+    # reset to the adapter/CLI default, non-empty = explicit override.
+    _model: str | None = None
+    _effort: str | None = None
 
     # ── per-phase hooks ──
     def parse_flag(self, arg: str, extra: dict[str, str | bool]) -> bool:
@@ -382,8 +384,8 @@ class Phase:
         agent = "claude-code"
         # `or`: bash ${CLAUDE_ALIAS:-claude} treats an exported-but-empty var as unset
         claude_alias = os.environ.get("CLAUDE_ALIAS") or "claude"
-        model = ""
-        effort = ""
+        model: str | None = None
+        effort: str | None = None
         artifact = ""
         targets: list[str] = []
         extra: dict[str, str | bool] = {}
@@ -435,11 +437,13 @@ class Phase:
         if not targets:
             targets = [_logical_cwd().name]  # bash `basename "$PWD"` (logical under symlinks)
 
-        # Model / reasoning effort: flag wins, then a run-wide env, else empty —
-        # each adapter falls back to its own env / CLI default. Forwarded to the
-        # adapter (translated per-CLI) only when non-empty.
-        self._model = model or os.environ.get("SPECULA_MODEL") or ""
-        self._effort = effort or os.environ.get("SPECULA_EFFORT") or ""
+        # An explicit flag wins even when its value is empty.  Only an absent
+        # flag consults the run-wide environment; an empty environment value is
+        # treated as unset.  Keeping None distinct from "" is also what lets an
+        # unspecified Claude run retain its deliberate max-effort default while
+        # `--effort=` can still reset the underlying CLI to its own default.
+        self._model = model if model is not None else (os.environ.get("SPECULA_MODEL") or None)
+        self._effort = effort if effort is not None else (os.environ.get("SPECULA_EFFORT") or None)
 
         adapter = LAUNCH_DIR / "adapters" / f"{agent}.sh"
         if not adapter.is_file():
@@ -649,9 +653,12 @@ class Phase:
         files["prompt"].write_text(prompt)
         print(f"[{_ts()}] Launching agent: {name}")
         if dry_run:
+            tuning = _model_effort_argv(adapter, self._model, self._effort)
+            tuning_text = (" " + " ".join(tuning)) if tuning else ""
             print(
                 f"  [DRY RUN] {adapter} {self.dry_prompt_flag}=<prompt> "
-                f"--max-turns={max_turns} --log={files['log']} --background"
+                f"--max-turns={max_turns} --claude-alias={claude_alias}{tuning_text} "
+                f"--log={files['log']} --background"
             )
             print(f"  Prompt saved: {files['prompt']}")
             return None
@@ -703,7 +710,7 @@ class Phase:
                     f"--prompt-file={files['prompt']}",
                     f"--max-turns={max_turns}",
                     f"--claude-alias={claude_alias}",
-                    *_model_effort_argv(self._model, self._effort),
+                    *_model_effort_argv(adapter, self._model, self._effort),
                     f"--log={files['log']}",
                     "--background",
                 ],
@@ -741,18 +748,23 @@ class Phase:
         return launched
 
 
-def _model_effort_argv(model: str, effort: str) -> list[str]:
-    """Adapter flags for model / reasoning effort, omitted when empty so the
-    adapter falls back to its own env (`CODEX_MODEL`, `CLAUDE_EFFORT`, …) or the
-    CLI default. Empty is the default on purpose: a hardcoded ``--effort=max`` is
-    a claude-ism the codex adapter rejects (codex has no ``max`` level). Each
-    adapter translates these to its native flags (codex ``-m`` / ``-c
-    model_reasoning_effort``, claude ``--model`` / ``--effort``)."""
+def _model_effort_argv(adapter: Path, model: str | None, effort: str | None) -> list[str]:
+    """Build adapter tuning flags without collapsing "unset" and "empty".
+
+    Claude phase launches deliberately default to ``max`` so an ambient
+    ``CLAUDE_EFFORT`` injected by an IDE cannot silently downgrade a pipeline.
+    Codex and Copilot receive no effort flag when unspecified and therefore use
+    their own environment/config defaults.  An explicit empty value is always
+    forwarded so the adapter can clear its environment fallback and return to
+    the underlying CLI's configured default.
+    """
     argv: list[str] = []
-    if model:
+    if model is not None:
         argv.append(f"--model={model}")
-    if effort:
+    if effort is not None:
         argv.append(f"--effort={effort}")
+    elif adapter.stem == "claude-code":
+        argv.append("--effort=max")
     return argv
 
 
@@ -767,8 +779,8 @@ def run_agent_blocking(
     claude_alias: str,
     max_turns: str = "0",
     stop_gate: bool = False,
-    model: str = "",
-    effort: str = "",
+    model: str | None = None,
+    effort: str | None = None,
 ) -> tuple[int, str]:
     """Run ONE agent invocation, blocking, and return (returncode, log text).
 
@@ -798,7 +810,7 @@ def run_agent_blocking(
         f"--prompt-file={prompt_file}",
         f"--max-turns={max_turns}",
         f"--claude-alias={claude_alias}",
-        *_model_effort_argv(model, effort),
+        *_model_effort_argv(adapter, model, effort),
         f"--log={log_file}",
     ]
     rc = subprocess.run(cmd, env=env).returncode
@@ -833,6 +845,8 @@ Options:
   --max-turns=N       Max agent turns (default: 0 = unlimited)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
+  --model=NAME        Model forwarded to the selected adapter
+  --effort=LEVEL      Reasoning effort forwarded to the selected adapter
   --artifact=PATH     Source code path (default: $PWD for single target,
                       $PWD/<name>/artifact/<repo>/ for batch)
 
@@ -949,6 +963,8 @@ Options:
   --max-turns=N       Max agent turns (default: 0 = unlimited)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
+  --model=NAME        Model forwarded to the selected adapter
+  --effort=LEVEL      Reasoning effort forwarded to the selected adapter
   --artifact=PATH     Explicit path to the artifact repo (bypasses auto-detection)
 
 Prerequisites:
@@ -1080,6 +1096,8 @@ Options:
   --max-turns=N       Max agent turns (default: 0 = unlimited)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
+  --model=NAME        Model forwarded to the selected adapter
+  --effort=LEVEL      Reasoning effort forwarded to the selected adapter
   --artifact=PATH     Explicit path to artifact repo (overrides auto-detection)
 
 Prerequisites:
@@ -1207,6 +1225,8 @@ Options:
   --max-turns=N       Max agent turns (default: 0 = unlimited)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
+  --model=NAME        Model forwarded to the selected adapter
+  --effort=LEVEL      Reasoning effort forwarded to the selected adapter
 
 Prerequisites:
   - Confirmed bug report at <name>/spec/confirmed-bugs.md (from Phase 4a)
@@ -1313,6 +1333,8 @@ Options:
   --max-turns=N       Max agent turns (default: 0 = unlimited)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
+  --model=NAME        Model forwarded to the selected adapter
+  --effort=LEVEL      Reasoning effort forwarded to the selected adapter
   --artifact=PATH     Explicit path to the artifact repo (overrides auto-detection)
 
 Prerequisites:
@@ -1463,6 +1485,8 @@ Options:
   --max-turns=N       Max agent turns (default: 0 = unlimited)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
+  --model=NAME        Model forwarded to the selected adapter
+  --effort=LEVEL      Reasoning effort forwarded to the selected adapter
   --artifact=PATH     Explicit path to the artifact repo (overrides auto-detection)
 
 Prerequisites:
@@ -1665,6 +1689,12 @@ Used by launch_pipeline.sh between phases. Can also be used standalone.
 Usage:
   bash scripts/launch/launch_review.sh <phase> <name> [name ...]
 
+Options (after <phase>):
+  --agent=NAME        Agent adapter to use (default: claude-code)
+  --claude-alias=NAME Claude CLI profile (default: claude)
+  --model=NAME        Model forwarded to the selected adapter
+  --effort=LEVEL      Reasoning effort forwarded to the selected adapter
+
 Phases:
   analysis    — Review code analysis output (modeling-brief.md, analysis-report.md)
   specgen     — Review spec generation output (base.tla, MC.tla, Trace.tla)
@@ -1679,8 +1709,8 @@ Output:
         phase = argv[0] if argv else ""
         agent = "claude-code"
         claude_alias = os.environ.get("CLAUDE_ALIAS") or "claude"
-        model = ""
-        effort = ""
+        model: str | None = None
+        effort: str | None = None
         targets: list[str] = []
         for arg in argv[1:]:
             if arg.startswith("--agent="):
@@ -1697,8 +1727,8 @@ Output:
             else:
                 targets.append(arg)
 
-        self._model = model or os.environ.get("SPECULA_MODEL") or ""
-        self._effort = effort or os.environ.get("SPECULA_EFFORT") or ""
+        self._model = model if model is not None else (os.environ.get("SPECULA_MODEL") or None)
+        self._effort = effort if effort is not None else (os.environ.get("SPECULA_EFFORT") or None)
 
         if not phase or not targets:
             print(f"Usage: {SCRIPT_DIR}/phaselib.py review <analysis|specgen|validation> name [name ...]")
@@ -1808,7 +1838,7 @@ Output:
                     f"--prompt={prompt.rstrip(chr(10))}",
                     "--max-turns=30",
                     f"--claude-alias={claude_alias}",
-                    *_model_effort_argv(self._model, self._effort),
+                    *_model_effort_argv(adapter, self._model, self._effort),
                     f"--log={log_file}",
                     "--background",
                 ],

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -434,18 +434,59 @@ class Pipeline:
                 )
                 if r.returncode == 0:
                     artifact_sha = r.stdout.decode(errors="replace").strip()
+        model, effort = self._resolved_run_tuning()
         meta = {
             "run_id": self.run_id,
             "created": _date_iseconds(),
             "argv": self.argv,
             "targets": self.targets,
             "agent": self.agent,
+            "model": model,
+            "effort": effort,
             "claude_alias": self.claude_alias,
             "artifact": self.artifact,
             "artifact_git_sha": artifact_sha,
         }
         with contextlib.suppress(OSError):
             meta_file.write_text(json.dumps(meta, indent=2) + "\n")
+
+    def _resolved_run_tuning(self) -> tuple[str | None, str | None]:
+        """Return model/effort values that are knowable at run creation.
+
+        Pipeline flags win even when explicitly empty. An empty flag resets the
+        adapter to its own configuration, whose resulting value is unknown here
+        and therefore recorded as null. Otherwise mirror the phase and adapter
+        environment fallbacks; never guess values selected by CLI config files.
+        """
+        if self.model is not None:
+            model = self.model or None
+        else:
+            model = os.environ.get("SPECULA_MODEL") or None
+            if model is None:
+                adapter_model_env = {
+                    "claude-code": "CLAUDE_MODEL",
+                    "codex": "CODEX_MODEL",
+                    "copilot-cli": "COPILOT_MODEL",
+                }.get(self.agent)
+                if adapter_model_env is not None:
+                    model = os.environ.get(adapter_model_env) or None
+
+        if self.effort is not None:
+            effort = self.effort or None
+        else:
+            effort = os.environ.get("SPECULA_EFFORT") or None
+            if effort is None:
+                if self.agent == "claude-code":
+                    # Phase launchers explicitly pass max, overriding any
+                    # ambient CLAUDE_EFFORT value.
+                    effort = "max"
+                elif self.agent == "codex":
+                    effort = os.environ.get("CODEX_EFFORT") or None
+
+        # The Claude adapter omits --effort for this explicit reset sentinel.
+        if self.agent == "claude-code" and effort == "default":
+            effort = None
+        return model, effort
 
     # ── utilities ──
     def extract_names(self) -> list[str]:

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -95,6 +95,8 @@ Options:
   --max-turns=N          Max agent turns (default: 0 = unlimited)
   --agent=NAME           Agent adapter to use (default: claude-code; e.g., claude-code, codex, copilot-cli)
   --claude-alias=NAME    Claude CLI profile (default: claude)
+  --model=NAME           Model forwarded to every agent adapter
+  --effort=LEVEL         Reasoning effort forwarded to every agent adapter
   --artifact=PATH        Path to system artifact/source code
   --isolate              Isolated workspace (the default): all outputs go to
                          runs/<run-id>/ — parallel-safe, keeps case-studies/
@@ -265,6 +267,11 @@ class Pipeline:
         self.skip_reviews = True
         self.agent = "claude-code"
         self.claude_alias = os.environ.get("CLAUDE_ALIAS") or "claude"
+        # None means no pipeline CLI override: phase launchers may consult
+        # SPECULA_MODEL / SPECULA_EFFORT.  "" is an explicit empty flag and
+        # must survive into the child so it can clear those environment values.
+        self.model: str | None = None
+        self.effort: str | None = None
         self.artifact = ""
         self.targets: list[str] = []
         self.quota_5h = os.environ.get("QUOTA_5H") or "85"
@@ -328,6 +335,10 @@ class Pipeline:
                 self.agent = arg.split("=", 1)[1]
             elif arg.startswith("--claude-alias="):
                 self.claude_alias = arg.split("=", 1)[1]
+            elif arg.startswith("--model="):
+                self.model = arg.split("=", 1)[1]
+            elif arg.startswith("--effort="):
+                self.effort = arg.split("=", 1)[1]
             elif arg.startswith("--artifact="):
                 self.artifact = arg.split("=", 1)[1]
             elif arg in ("--help", "-h"):
@@ -553,6 +564,20 @@ class Pipeline:
             ledger.write_text("\n".join(rows) + "\n")
 
     # ── phase runners ──
+    def _model_effort_args(self) -> list[str]:
+        """Explicit pipeline tuning flags, preserving an explicit empty value.
+
+        An absent flag stays absent so phase launchers can apply their run-wide
+        SPECULA_* fallback and adapter-specific defaults.  An explicit empty
+        flag must be forwarded to override (and clear) those fallbacks.
+        """
+        args: list[str] = []
+        if self.model is not None:
+            args.append(f"--model={self.model}")
+        if self.effort is not None:
+            args.append(f"--effort={self.effort}")
+        return args
+
     def _phase_args(self, positional: list[str], pre: list[str] | None = None, with_artifact: bool = True) -> list[str]:
         args = list(pre or [])
         args += [
@@ -560,6 +585,7 @@ class Pipeline:
             f"--max-turns={self.max_turns}",
             f"--agent={self.agent}",
             f"--claude-alias={self.claude_alias}",
+            *self._model_effort_args(),
         ]
         if with_artifact and self.artifact:
             args.append(f"--artifact={self.artifact}")
@@ -665,7 +691,13 @@ class Pipeline:
         # died with "Unknown phase" — invisible under --dry-run, which only logs
         # the command without executing it. Phase goes first: a deliberate
         # divergence from the buggy bash order (git history has the original).
-        args = [phase, f"--agent={self.agent}", f"--claude-alias={self.claude_alias}", *names]
+        args = [
+            phase,
+            f"--agent={self.agent}",
+            f"--claude-alias={self.claude_alias}",
+            *self._model_effort_args(),
+            *names,
+        ]
         self._phase(f"REVIEW: {phase}", "launch_review.sh", args)
 
     def run_phase2_specgen(self) -> None:

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -19,6 +19,7 @@ stdlib unittest, collected natively by pytest:
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -49,6 +50,9 @@ _VOLATILE = (
     "CLAUDE_ALIAS",
     "CLAUDE_EFFORT",
     "CLAUDE_MODEL",
+    "CODEX_MODEL",
+    "CODEX_EFFORT",
+    "COPILOT_MODEL",
 )
 
 
@@ -164,10 +168,11 @@ class CliE2E(unittest.TestCase):
                     self.assertIn(f"--model={model}", line)
                     self.assertIn(f"--effort={effort}", line)
                 self.assertIn("launch_review.sh analysis --agent=codex", review_line)
+                meta = json.loads((self.sole_run_dir(root) / "run.json").read_text())
+                self.assertEqual(meta["model"], model or None)
+                self.assertEqual(meta["effort"], effort or None)
 
     def test_run_json_records_argv(self) -> None:
-        import json
-
         root = self.specroot()
         work = self.workdir()
         self.run_cli(root, ["run", "--dry-run", "footest"], cwd=work)

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -43,6 +43,8 @@ _VOLATILE = (
     "SPECULA_PHASE",
     "SPECULA_WORK_DIR",
     "SPECULA_STOP_GATE",
+    "SPECULA_MODEL",
+    "SPECULA_EFFORT",
     "CLAUDE_CONFIG_DIR",
     "CLAUDE_ALIAS",
     "CLAUDE_EFFORT",
@@ -136,6 +138,32 @@ class CliE2E(unittest.TestCase):
         self.assertIn("Specula", out)
         self.assertIn("[DRY RUN] bash scripts/launch/launch_code_analysis.sh", out)
         self.assertIn("Pipeline completed", out)
+
+    def test_run_model_effort_reach_phase_and_review_commands(self) -> None:
+        for model, effort in (("gpt-5.5", "high"), ("", "")):
+            with self.subTest(model=model, effort=effort):
+                root = self.specroot()
+                work = self.workdir()
+                proc = self.run_cli(
+                    root,
+                    [
+                        "run",
+                        "--dry-run",
+                        "--enable-reviews",
+                        "--agent=codex",
+                        f"--model={model}",
+                        f"--effort={effort}",
+                        "footest",
+                    ],
+                    cwd=work,
+                )
+                self.assertEqual(proc.returncode, 0, proc.stderr)
+                phase_line = next(line for line in proc.stdout.splitlines() if "launch_code_analysis.sh" in line)
+                review_line = next(line for line in proc.stdout.splitlines() if "launch_review.sh" in line)
+                for line in (phase_line, review_line):
+                    self.assertIn(f"--model={model}", line)
+                    self.assertIn(f"--effort={effort}", line)
+                self.assertIn("launch_review.sh analysis --agent=codex", review_line)
 
     def test_run_json_records_argv(self) -> None:
         import json

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -79,6 +79,8 @@ class AdapterRun(TypedDict):
     argv: list[str]
     configdir: str
     sessionenv: str
+    modelenv: str
+    effortenv: str
     stdin: str | None
     base: Path
 
@@ -115,6 +117,12 @@ class AdapterCase(unittest.TestCase):
                 "fi",
             ]
         lines.append('printf "%s\\n" "$@" > "${ADAPTER_ARGV_FILE:-/dev/null}"')
+        model_var = {"claude": "CLAUDE_MODEL", "codex": "CODEX_MODEL", "copilot": "COPILOT_MODEL"}.get(name)
+        effort_var = {"claude": "CLAUDE_EFFORT", "codex": "CODEX_EFFORT"}.get(name)
+        if model_var:
+            lines.append(f'printf "%s\\n" "${{{model_var}-<unset>}}" > "${{ADAPTER_MODEL_ENV_FILE:-/dev/null}}"')
+        if effort_var:
+            lines.append(f'printf "%s\\n" "${{{effort_var}-<unset>}}" > "${{ADAPTER_EFFORT_ENV_FILE:-/dev/null}}"')
         if record_extra:
             lines += [
                 'printf "%s\\n" "${CLAUDE_CONFIG_DIR:-<unset>}" > "${ADAPTER_CONFIGDIR_FILE:-/dev/null}"',
@@ -150,6 +158,8 @@ class AdapterCase(unittest.TestCase):
             "ADAPTER_ARGV_FILE": base / "argv.txt",
             "ADAPTER_CONFIGDIR_FILE": base / "configdir.txt",
             "ADAPTER_SESSIONENV_FILE": base / "sessionenv.txt",
+            "ADAPTER_MODEL_ENV_FILE": base / "modelenv.txt",
+            "ADAPTER_EFFORT_ENV_FILE": base / "effortenv.txt",
             "ADAPTER_STDIN_FILE": base / "stdin.txt",
         }
         env = {k: v for k, v in os.environ.items() if k not in _VOLATILE}
@@ -173,6 +183,8 @@ class AdapterCase(unittest.TestCase):
             "argv": (read(record["ADAPTER_ARGV_FILE"]) or "").splitlines(),
             "configdir": (read(record["ADAPTER_CONFIGDIR_FILE"]) or "").strip(),
             "sessionenv": (read(record["ADAPTER_SESSIONENV_FILE"]) or "").strip(),
+            "modelenv": (read(record["ADAPTER_MODEL_ENV_FILE"]) or "").strip(),
+            "effortenv": (read(record["ADAPTER_EFFORT_ENV_FILE"]) or "").strip(),
             "stdin": read(record["ADAPTER_STDIN_FILE"]),
             "base": base,
         }
@@ -231,6 +243,22 @@ class ClaudeCodeAdapter(AdapterCase):
         base = self.sandbox()
         r = self.invoke(self.base_flags(base), env_extra={"CLAUDE_EFFORT": ""})
         self.assertEqual(r["argv"][r["argv"].index("--effort") + 1], "max")
+
+    def test_explicit_max_wins_over_low_env(self) -> None:
+        base = self.sandbox()
+        r = self.invoke(self.base_flags(base) + ["--effort=max"], env_extra={"CLAUDE_EFFORT": "low"})
+        self.assertEqual(r["argv"][r["argv"].index("--effort") + 1], "max")
+
+    def test_explicit_empty_model_effort_clear_env(self) -> None:
+        base = self.sandbox()
+        r = self.invoke(
+            self.base_flags(base) + ["--model=", "--effort="],
+            env_extra={"CLAUDE_MODEL": "env-model", "CLAUDE_EFFORT": "low"},
+        )
+        self.assertNotIn("--model", r["argv"])
+        self.assertNotIn("--effort", r["argv"])
+        self.assertEqual(r["modelenv"], "<unset>")
+        self.assertEqual(r["effortenv"], "<unset>")
 
     def test_alias_sets_config_dir(self) -> None:
         # HOME is run_adapter's own sandbox (returned as r["base"]); the config
@@ -857,6 +885,8 @@ class CodexAdapter(AdapterCase):
         argv = r["argv"]
         self.assertEqual(argv[argv.index("-m") + 1], "gpt-5.6-sol")
         self.assertEqual(argv[argv.index("-c") + 1], "model_reasoning_effort=ultra")
+        self.assertEqual(r["modelenv"], "<unset>")
+        self.assertEqual(r["effortenv"], "<unset>")
 
     def test_flag_wins_over_env(self) -> None:
         base = self.sandbox()
@@ -866,6 +896,17 @@ class CodexAdapter(AdapterCase):
         )
         argv = r["argv"]
         self.assertEqual(argv[argv.index("-m") + 1], "flag-model")
+
+    def test_explicit_empty_model_effort_clear_env(self) -> None:
+        base = self.sandbox()
+        r = self.invoke(
+            self.base_flags(base) + ["--model=", "--effort="],
+            env_extra={"CODEX_MODEL": "env-model", "CODEX_EFFORT": "high"},
+        )
+        self.assertEqual(r["returncode"], 0, r["stderr"])
+        self.assertEqual(r["argv"], ["exec", "--dangerously-bypass-approvals-and-sandbox", "the prompt"])
+        self.assertEqual(r["modelenv"], "<unset>")
+        self.assertEqual(r["effortenv"], "<unset>")
 
     def test_max_turns_required(self) -> None:
         base = self.sandbox()
@@ -923,6 +964,13 @@ class CopilotAdapter(AdapterCase):
         base = self.sandbox()
         r = self.invoke(self.base_flags(base), env_extra={"COPILOT_MODEL": "envmodel"})
         self.assertEqual(r["argv"][-2:], ["--model", "envmodel"])
+        self.assertEqual(r["modelenv"], "<unset>")
+
+    def test_explicit_empty_model_clears_env(self) -> None:
+        base = self.sandbox()
+        r = self.invoke(self.base_flags(base) + ["--model="], env_extra={"COPILOT_MODEL": "envmodel"})
+        self.assertNotIn("--model", r["argv"])
+        self.assertEqual(r["modelenv"], "<unset>")
 
     def test_max_turns_maps_to_autopilot_continues(self) -> None:
         base = self.sandbox()
@@ -934,10 +982,38 @@ class CopilotAdapter(AdapterCase):
         r = self.invoke(self.base_flags(base) + ["--max-turns=0"])
         self.assertNotIn("--max-autopilot-continues", r["argv"])
 
-    def test_alias_and_effort_accepted_but_ignored(self) -> None:
+    def test_alias_ignored_and_effort_forwarded(self) -> None:
         base = self.sandbox()
-        r = self.invoke(self.base_flags(base) + ["--claude-alias=claude", "--effort=max"])
+        r = self.invoke(
+            self.base_flags(base) + ["--claude-alias=claude", "--effort=high"],
+            env_extra={"COPILOT_HELP_TEXT": "  --reasoning-effort <level>"},
+        )
         self.assertEqual(r["returncode"], 0)
+        self.assertEqual(
+            r["argv"],
+            ["-p", "the prompt", "--allow-all", "--reasoning-effort", "high"],
+        )
+
+    def test_effort_alias_fallback(self) -> None:
+        base = self.sandbox()
+        r = self.invoke(
+            self.base_flags(base) + ["--effort=max"],
+            env_extra={"COPILOT_HELP_TEXT": "  --effort <level>"},
+        )
+        self.assertEqual(r["returncode"], 0)
+        self.assertEqual(r["argv"][-2:], ["--effort", "max"])
+
+    def test_effort_requires_supported_cli(self) -> None:
+        base = self.sandbox()
+        r = self.invoke(self.base_flags(base) + ["--effort=high"])
+        self.assertEqual(r["returncode"], 1)
+        self.assertIn("requires Copilot CLI 1.0.4+", r["stderr"])
+        self.assertEqual(r["argv"], [])  # help probe only; task was never launched
+
+    def test_explicit_empty_effort_keeps_old_cli_compatible(self) -> None:
+        base = self.sandbox()
+        r = self.invoke(self.base_flags(base) + ["--effort="])
+        self.assertEqual(r["returncode"], 0, r["stderr"])
         self.assertEqual(r["argv"], ["-p", "the prompt", "--allow-all"])
 
     def test_output_redirected_to_log(self) -> None:
@@ -968,12 +1044,17 @@ class CopilotAdapter(AdapterCase):
         )
         r = self.run_adapter(
             self.CMD,
-            self.base_flags(base),
+            self.base_flags(base) + ["--effort=high"],
             fake_name="copilot",
             fixture_text=fixture,
-            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "COPILOT_HELP_TEXT": "--output-format\n--stream"},
+            env_extra={
+                "SPECULA_ACTIVITY_LOG": str(activity),
+                "COPILOT_HELP_TEXT": "--reasoning-effort\n--output-format\n--stream",
+            },
         )
         self.assertEqual(r["returncode"], 0, r["stderr"])
+        self.assertIn("--reasoning-effort", r["argv"])
+        self.assertEqual(r["argv"][r["argv"].index("--reasoning-effort") + 1], "high")
         self.assertEqual(r["argv"][-4:], ["--output-format", "json", "--stream", "on"])
         self.assertEqual(activity.read_text(), fixture)
         self.assertEqual(

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -57,6 +57,8 @@ _VOLATILE = (
     "CLAUDE_EFFORT",
     "CLAUDE_MODEL",
     "COPILOT_MODEL",
+    "CODEX_MODEL",
+    "CODEX_EFFORT",
     "CLAUDECODE",
     "CLAUDE_CODE_SSE_PORT",
     "CLAUDE_CODE_ENTRYPOINT",
@@ -827,11 +829,43 @@ class CodexAdapter(AdapterCase):
         self.invoke(self.base_flags(base))
         self.assertEqual(json.loads((base / "out.usage.json").read_text())["agent"], "codex")
 
-    def test_alias_and_effort_accepted_but_ignored(self) -> None:
+    def test_model_and_effort_forwarded_alias_ignored(self) -> None:
         base = self.sandbox()
-        r = self.invoke(self.base_flags(base) + ["--claude-alias=x", "--effort=high"])
+        r = self.invoke(self.base_flags(base) + ["--claude-alias=x", "--model=gpt-5.5", "--effort=high"])
         self.assertEqual(r["returncode"], 0)
-        self.assertEqual(r["argv"], ["exec", "--dangerously-bypass-approvals-and-sandbox", "the prompt"])
+        # --claude-alias is ignored; --model -> -m, --effort -> -c model_reasoning_effort
+        self.assertEqual(
+            r["argv"],
+            [
+                "exec",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "-m",
+                "gpt-5.5",
+                "-c",
+                "model_reasoning_effort=high",
+                "the prompt",
+            ],
+        )
+
+    def test_model_effort_from_env(self) -> None:
+        base = self.sandbox()
+        r = self.invoke(
+            self.base_flags(base),
+            env_extra={"CODEX_MODEL": "gpt-5.6-sol", "CODEX_EFFORT": "ultra"},
+        )
+        self.assertEqual(r["returncode"], 0)
+        argv = r["argv"]
+        self.assertEqual(argv[argv.index("-m") + 1], "gpt-5.6-sol")
+        self.assertEqual(argv[argv.index("-c") + 1], "model_reasoning_effort=ultra")
+
+    def test_flag_wins_over_env(self) -> None:
+        base = self.sandbox()
+        r = self.invoke(
+            self.base_flags(base) + ["--model=flag-model"],
+            env_extra={"CODEX_MODEL": "env-model"},
+        )
+        argv = r["argv"]
+        self.assertEqual(argv[argv.index("-m") + 1], "flag-model")
 
     def test_max_turns_required(self) -> None:
         base = self.sandbox()

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -72,6 +72,27 @@ class TestVerdict(ConfirmCase):
         self.assertEqual(C.parse_verdict("VERDICT: DROPPED\nVERDICT: FALSE POSITIVE"), "FALSE POSITIVE")
 
 
+class TestConfirmConfigCompatibility(ConfirmCase):
+    def test_legacy_positional_arguments_keep_their_meaning(self) -> None:
+        ws = Workspace(["T"])
+        cfg = C.ConfirmConfig("T", ws, Path("/adapter"), "/repo", 7, "alias", False, True, "EXTRA")
+        self.assertFalse(cfg.worktree)
+        self.assertTrue(cfg.dry_run)
+        self.assertEqual(cfg.prompt_extra, "EXTRA")
+        self.assertIsNone(cfg.model)
+        self.assertIsNone(cfg.effort)
+
+    def test_turn_threads_explicit_empty_tuning(self) -> None:
+        ws = Workspace(["T"])
+        cfg = C.ConfirmConfig("T", ws, Path("/adapter"), worktree=False, model="", effort="")
+        finding = C.Finding({"id": "MC-1"}, ws.work_dir("T") / "confirmation" / "MC-1")
+        with mock.patch.object(C, "run_agent_blocking", return_value=(0, "VERDICT: FALSE POSITIVE")) as run:
+            verdict, _ = C.run_turn(cfg, finding, "A", 1, "prompt")
+        self.assertEqual(verdict, "FALSE POSITIVE")
+        self.assertEqual(run.call_args.kwargs["model"], "")
+        self.assertEqual(run.call_args.kwargs["effort"], "")
+
+
 class TestMergeRR(ConfirmCase):
     AGENT_BODY = (
         "---\n"

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -40,6 +40,7 @@ import unittest
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, TypedDict, cast
+from unittest import mock
 
 SRC = Path(__file__).resolve().parents[2] / "src"
 if str(SRC) not in sys.path:  # test the tree this file lives in, installed or not
@@ -1139,6 +1140,54 @@ class TestReviewPhase(PhaseCase):
         self.assertEqual(len(spawned), 1)
         self.assertIsNotNone(spawned[0].poll())
         self.assertFalse(phaselib.Phase._group_exists(spawned[0].pid))
+
+
+class TestModelEffortForwarding(unittest.TestCase):
+    """Uniform model / reasoning-effort forwarding: phaselib hands --model /
+    --effort to the adapter only when set (empty -> the adapter's own default),
+    so a codex run is never given the claude-only 'max' effort level."""
+
+    def test_argv_helper(self) -> None:
+        self.assertEqual(phaselib._model_effort_argv("", ""), [])
+        self.assertEqual(phaselib._model_effort_argv("gpt-5.5", ""), ["--model=gpt-5.5"])
+        self.assertEqual(phaselib._model_effort_argv("", "ultra"), ["--effort=ultra"])
+        self.assertEqual(phaselib._model_effort_argv("m", "e"), ["--model=m", "--effort=e"])
+
+    def _blocking_cmd(self, model: str = "", effort: str = "") -> list[str]:
+        captured: list[list[str]] = []
+
+        class _Result:
+            returncode = 0
+
+        def fake_run(cmd: list[str], **_: Any) -> _Result:
+            captured.append(cmd)
+            return _Result()
+
+        with tempfile.TemporaryDirectory() as d, mock.patch("specula.phaselib.subprocess.run", fake_run):
+            dp = Path(d)
+            phaselib.run_agent_blocking(
+                Path("/x/adapter.sh"),
+                "prompt",
+                dp / "p.md",
+                dp / "o.log",
+                phase_key="k",
+                work_dir=dp,
+                claude_alias="claude",
+                model=model,
+                effort=effort,
+            )
+        return captured[0]
+
+    def test_forwarded_when_set(self) -> None:
+        cmd = self._blocking_cmd(model="gpt-5.5", effort="ultra")
+        self.assertIn("--model=gpt-5.5", cmd)
+        self.assertIn("--effort=ultra", cmd)
+        self.assertNotIn("--effort=max", cmd)  # the removed claude-ism
+
+    def test_omitted_when_empty(self) -> None:
+        cmd = self._blocking_cmd()
+        self.assertFalse(any(c.startswith("--model=") for c in cmd))
+        self.assertFalse(any(c.startswith("--effort=") for c in cmd))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -170,7 +170,10 @@ class PhaseCase(unittest.TestCase):
             "SPECULA_QUOTA_7D",
             "SPECULA_QUOTA_MAX_WAITS",
             "SPECULA_CLAUDE_ALIAS",
+            "SPECULA_MODEL",
+            "SPECULA_EFFORT",
             "CLAUDE_ALIAS",
+            "CLAUDE_EFFORT",
         ):
             self.set_env(var, str(self.run_dir) if var == "SPECULA_RUN_DIR" else None)
 
@@ -285,6 +288,7 @@ class TestDryRunCommand(PhaseCase):
                 self.assertIn(str(adapter), out)
                 self.assertIn(f"{spec['flag']}=<prompt>", out)  # --prompt vs --prompt-file quirk
                 self.assertIn("--max-turns=0", out)
+                self.assertIn("--effort=max", out)  # Claude phase safety default
                 self.assertIn(f"--log={log}", out)
                 self.assertIn("--background", out)
                 self.assertIn(f"Prompt saved: {prompt}", out)
@@ -315,6 +319,29 @@ class TestDryRunCommand(PhaseCase):
         rc, out = self.dry_run(BY_KEY["code_analysis"], extra=["--max-turns=7"])
         self.assertEqual(rc, 0, out)
         self.assertIn("--max-turns=7", out)
+
+    def test_model_effort_and_explicit_empty_visible_in_dry_run(self) -> None:
+        rc, out = self.dry_run(
+            BY_KEY["code_analysis"],
+            extra=["--model=gpt-5.5", "--effort=high"],
+        )
+        self.assertEqual(rc, 0, out)
+        self.assertIn("--model=gpt-5.5", out)
+        self.assertIn("--effort=high", out)
+        self.assertNotIn("--effort=max", out)
+
+        self.set_env("SPECULA_MODEL", "env-model")
+        self.set_env("SPECULA_EFFORT", "low")
+        rc, out = self.dry_run(
+            BY_KEY["code_analysis"],
+            extra=["--model=", "--effort="],
+        )
+        self.assertEqual(rc, 0, out)
+        self.assertIn("--model= ", out)
+        self.assertIn("--effort= ", out)
+        self.assertNotIn("env-model", out)
+        self.assertNotIn("--effort=low", out)
+        self.assertNotIn("--effort=max", out)
 
     def test_bug_classification_rejects_artifact(self) -> None:
         # accepts_artifact=False: --artifact is not a known option here.
@@ -376,6 +403,8 @@ class TestArgErrors(PhaseCase):
                 self.assertEqual(rc, 0)
                 self.assertIn("Usage:", out)
                 self.assertIn(f"launch_{spec['key']}.sh", out)
+                self.assertIn("--model=NAME", out)
+                self.assertIn("--effort=LEVEL", out)
 
 
 class TestProgressReporting(PhaseCase):
@@ -1017,6 +1046,55 @@ class TestSummarize(PhaseCase):
                     self.assertIn(want.replace(NAME, name), got)
 
 
+class TestModelEffortLiveLaunch(PhaseCase):
+    """Normal batch launch path (the non-blocking sibling of confirmation)."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.adapters = self.tmp() / "adapters"
+        self.adapters.mkdir()
+        self.patch_attr(phaselib, "LAUNCH_DIR", self.adapters.parent)
+        self.patch_attr(phaselib.Phase, "_acceptance", lambda _self, _ws, _names: None)
+        self.set_env("SPECULA_PROGRESS", "off")
+
+    def launch(self, adapter_name: str, extra: list[str] | None = None) -> list[str]:
+        record = self.tmp() / "argv"
+        adapter = self.adapters / f"{adapter_name}.sh"
+        adapter.write_text(f'#!/usr/bin/env sh\nprintf "%s\\n" "$@" > "{record}"\n')
+        adapter.chmod(0o755)
+        rc, out = self.run_phase(
+            "code_analysis",
+            [f"--agent={adapter_name}", *(extra or []), self.artifact_flag(), NAME],
+        )
+        self.assertEqual(rc, 0, out)
+        return record.read_text().splitlines()
+
+    def test_claude_default_max_blocks_ambient_downgrade(self) -> None:
+        self.set_env("CLAUDE_EFFORT", "low")
+        argv = self.launch("claude-code")
+        self.assertIn("--effort=max", argv)
+
+    def test_non_claude_adapters_have_no_forced_effort(self) -> None:
+        for adapter in ("codex", "copilot-cli"):
+            with self.subTest(adapter=adapter):
+                argv = self.launch(adapter)
+                self.assertFalse(any(a.startswith("--effort=") for a in argv))
+
+    def test_specula_env_and_explicit_empty_precedence(self) -> None:
+        self.set_env("SPECULA_MODEL", "env-model")
+        self.set_env("SPECULA_EFFORT", "high")
+        argv = self.launch("codex")
+        self.assertIn("--model=env-model", argv)
+        self.assertIn("--effort=high", argv)
+
+        argv = self.launch("claude-code", ["--model=", "--effort="])
+        self.assertIn("--model=", argv)
+        self.assertIn("--effort=", argv)
+        self.assertNotIn("--effort=max", argv)
+        self.assertNotIn("--model=env-model", argv)
+        self.assertNotIn("--effort=high", argv)
+
+
 class TestReviewPhase(PhaseCase):
     """The review agent overrides run() wholesale; its contract is the prompt it
     assembles (no --dry-run, so drive the pure builders directly to stay off the
@@ -1070,6 +1148,8 @@ class TestReviewPhase(PhaseCase):
         rc, out = self.run_phase("review", ["analysis", "--help"])
         self.assertEqual(rc, 0)
         self.assertIn("Run a Claude Code review agent", out)
+        self.assertIn("--model=NAME", out)
+        self.assertIn("--effort=LEVEL", out)
 
     def test_review_streams_activity_through_shared_monitor(self) -> None:
         event = json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "reviewing"}})
@@ -1094,6 +1174,30 @@ class TestReviewPhase(PhaseCase):
         self.assertEqual(rc, 0, out)
         self.assertEqual(seen.read_text().strip(), "<unset>")
         self.assertFalse((self.work_dir() / "review-analysis.activity.jsonl").exists())
+
+    def test_review_claude_default_max_blocks_ambient_downgrade(self) -> None:
+        seen = self.tmp() / "argv"
+        self.install_adapter("claude-code", f'printf "%s\\n" "$@" > "{seen}"\n')
+        self.set_env("SPECULA_PROGRESS", "off")
+        self.set_env("CLAUDE_EFFORT", "low")
+        rc, out = self.run_phase("review", ["analysis", NAME])
+        self.assertEqual(rc, 0, out)
+        self.assertIn("--effort=max", seen.read_text().splitlines())
+
+    def test_review_explicit_empty_clears_specula_env(self) -> None:
+        seen = self.tmp() / "argv"
+        self.install_adapter("claude-code", f'printf "%s\\n" "$@" > "{seen}"\n')
+        self.set_env("SPECULA_PROGRESS", "off")
+        self.set_env("SPECULA_MODEL", "env-model")
+        self.set_env("SPECULA_EFFORT", "high")
+        rc, out = self.run_phase("review", ["analysis", "--model=", "--effort=", NAME])
+        self.assertEqual(rc, 0, out)
+        argv = seen.read_text().splitlines()
+        self.assertIn("--model=", argv)
+        self.assertIn("--effort=", argv)
+        self.assertNotIn("--model=env-model", argv)
+        self.assertNotIn("--effort=high", argv)
+        self.assertNotIn("--effort=max", argv)
 
     def test_review_rate_limit_retries_only_current_target(self) -> None:
         count = self.tmp() / "count"
@@ -1143,17 +1247,27 @@ class TestReviewPhase(PhaseCase):
 
 
 class TestModelEffortForwarding(unittest.TestCase):
-    """Uniform model / reasoning-effort forwarding: phaselib hands --model /
-    --effort to the adapter only when set (empty -> the adapter's own default),
-    so a codex run is never given the claude-only 'max' effort level."""
+    """Agent-aware tuning for the blocking confirmation path."""
 
     def test_argv_helper(self) -> None:
-        self.assertEqual(phaselib._model_effort_argv("", ""), [])
-        self.assertEqual(phaselib._model_effort_argv("gpt-5.5", ""), ["--model=gpt-5.5"])
-        self.assertEqual(phaselib._model_effort_argv("", "ultra"), ["--effort=ultra"])
-        self.assertEqual(phaselib._model_effort_argv("m", "e"), ["--model=m", "--effort=e"])
+        codex = Path("/x/codex.sh")
+        claude = Path("/x/claude-code.sh")
+        self.assertEqual(phaselib._model_effort_argv(codex, None, None), [])
+        self.assertEqual(phaselib._model_effort_argv(claude, None, None), ["--effort=max"])
+        self.assertEqual(phaselib._model_effort_argv(codex, "gpt-5.5", None), ["--model=gpt-5.5"])
+        self.assertEqual(phaselib._model_effort_argv(codex, None, "ultra"), ["--effort=ultra"])
+        self.assertEqual(
+            phaselib._model_effort_argv(claude, "", ""),
+            ["--model=", "--effort="],
+        )
 
-    def _blocking_cmd(self, model: str = "", effort: str = "") -> list[str]:
+    def _blocking_cmd(
+        self,
+        *,
+        adapter_name: str = "codex",
+        model: str | None = None,
+        effort: str | None = None,
+    ) -> list[str]:
         captured: list[list[str]] = []
 
         class _Result:
@@ -1166,7 +1280,7 @@ class TestModelEffortForwarding(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d, mock.patch("specula.phaselib.subprocess.run", fake_run):
             dp = Path(d)
             phaselib.run_agent_blocking(
-                Path("/x/adapter.sh"),
+                Path(f"/x/{adapter_name}.sh"),
                 "prompt",
                 dp / "p.md",
                 dp / "o.log",
@@ -1182,12 +1296,20 @@ class TestModelEffortForwarding(unittest.TestCase):
         cmd = self._blocking_cmd(model="gpt-5.5", effort="ultra")
         self.assertIn("--model=gpt-5.5", cmd)
         self.assertIn("--effort=ultra", cmd)
-        self.assertNotIn("--effort=max", cmd)  # the removed claude-ism
 
-    def test_omitted_when_empty(self) -> None:
-        cmd = self._blocking_cmd()
-        self.assertFalse(any(c.startswith("--model=") for c in cmd))
-        self.assertFalse(any(c.startswith("--effort=") for c in cmd))
+    def test_unspecified_effort_is_agent_specific(self) -> None:
+        claude = self._blocking_cmd(adapter_name="claude-code")
+        self.assertIn("--effort=max", claude)
+        for adapter in ("codex", "copilot-cli"):
+            with self.subTest(adapter=adapter):
+                cmd = self._blocking_cmd(adapter_name=adapter)
+                self.assertFalse(any(c.startswith("--effort=") for c in cmd))
+
+    def test_explicit_empty_is_forwarded_not_defaulted(self) -> None:
+        cmd = self._blocking_cmd(adapter_name="claude-code", model="", effort="")
+        self.assertIn("--model=", cmd)
+        self.assertIn("--effort=", cmd)
+        self.assertNotIn("--effort=max", cmd)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -508,14 +508,41 @@ class TestParsing(TmpCwd):
     def test_parse_args_skips_and_values(self) -> None:
         p = pl.Pipeline()
         rc = p.parse_args(
-            ["--skip-analysis", "--skip-repair-loop", "--max-repair-rounds=2", "--max-parallel=4", "t|g|l|r"]
+            [
+                "--skip-analysis",
+                "--skip-repair-loop",
+                "--max-repair-rounds=2",
+                "--max-parallel=4",
+                "--model=gpt-5.5",
+                "--effort=high",
+                "t|g|l|r",
+            ]
         )
         self.assertIsNone(rc)
         self.assertTrue(p.skip_analysis)
         self.assertTrue(p.skip_repair_loop)
         self.assertEqual(p.max_repair_rounds, "2")
         self.assertEqual(p.max_parallel, "4")
+        self.assertEqual(p.model, "gpt-5.5")
+        self.assertEqual(p.effort, "high")
         self.assertEqual(p.targets, ["t|g|l|r"])
+
+    def test_model_effort_absent_and_explicit_empty_are_distinct(self) -> None:
+        absent = pl.Pipeline()
+        self.assertIsNone(absent.parse_args(["t"]))
+        self.assertIsNone(absent.model)
+        self.assertIsNone(absent.effort)
+        absent_args = absent._phase_args(["t"])
+        self.assertFalse(any(a.startswith("--model=") for a in absent_args))
+        self.assertFalse(any(a.startswith("--effort=") for a in absent_args))
+
+        empty = pl.Pipeline()
+        self.assertIsNone(empty.parse_args(["--model=", "--effort=", "t"]))
+        self.assertEqual(empty.model, "")
+        self.assertEqual(empty.effort, "")
+        empty_args = empty._phase_args(["t"])
+        self.assertIn("--model=", empty_args)
+        self.assertIn("--effort=", empty_args)
 
     def test_parse_args_unknown_option(self) -> None:
         p = pl.Pipeline()
@@ -528,6 +555,8 @@ class TestParsing(TmpCwd):
         rc, out = quiet(p.parse_args, ["--help"])
         self.assertEqual(rc, 0)
         self.assertIn("Full Specula pipeline", out)
+        self.assertIn("--model=NAME", out)
+        self.assertIn("--effort=LEVEL", out)
 
     def test_default_target_is_cwd_basename(self) -> None:
         p = pl.Pipeline()
@@ -554,8 +583,13 @@ class TestRunReview(TmpCwd):
     as "--agent=..." and abort with "Unknown phase"; --dry-run only logs the
     command, so the sequencing golden never caught it. Pin the arg order here."""
 
-    def _capture(self, phase: str) -> list[str]:
-        p = make_pipeline(["footest|foo/bar|Go|ref"], skip_reviews=False)
+    def _capture(self, phase: str, *, model: str | None = None, effort: str | None = None) -> list[str]:
+        p = make_pipeline(
+            ["footest|foo/bar|Go|ref"],
+            skip_reviews=False,
+            model=model,
+            effort=effort,
+        )
         seen: list[list[str]] = []
         p._phase = lambda banner, script, args: seen.append(args)  # type: ignore[method-assign]
         p.run_review(phase, ["footest"])
@@ -572,6 +606,19 @@ class TestRunReview(TmpCwd):
         args = self._capture("specgen")
         self.assertIn("--agent=claude-code", args)
         self.assertIn("--claude-alias=claude", args)
+        self.assertEqual(args[-1], "footest")
+
+    def test_model_effort_values_and_empty_are_forwarded(self) -> None:
+        args = self._capture("analysis", model="gpt-5.5", effort="high")
+        self.assertIn("--model=gpt-5.5", args)
+        self.assertIn("--effort=high", args)
+        self.assertEqual(args[0], "analysis")
+        self.assertEqual(args[-1], "footest")
+
+        args = self._capture("analysis", model="", effort="")
+        self.assertIn("--model=", args)
+        self.assertIn("--effort=", args)
+        self.assertEqual(args[0], "analysis")
         self.assertEqual(args[-1], "footest")
 
 

--- a/tests/unit/test_workspace_isolation.py
+++ b/tests/unit/test_workspace_isolation.py
@@ -232,6 +232,31 @@ class TestPromptExtra(EnvIsolatedCase):
 
 
 class TestRunMetaAndAttach(EnvIsolatedCase):
+    _TUNING_ENV = (
+        "SPECULA_MODEL",
+        "SPECULA_EFFORT",
+        "CLAUDE_MODEL",
+        "CLAUDE_EFFORT",
+        "CODEX_MODEL",
+        "CODEX_EFFORT",
+        "COPILOT_MODEL",
+    )
+
+    def setUp(self) -> None:
+        super().setUp()
+        original = {name: os.environ.get(name) for name in self._TUNING_ENV}
+
+        def restore() -> None:
+            for name, value in original.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+
+        self.addCleanup(restore)
+        for name in self._TUNING_ENV:
+            os.environ.pop(name, None)
+
     def _pipeline(self, argv: list[str], root: Path) -> pl.Pipeline:
         self.patch_root(pl, root)
         p = pl.Pipeline()
@@ -251,10 +276,98 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
         self.assertEqual(meta["argv"], argv)
         self.assertEqual(meta["targets"], ["foo|o/r|Go|ref"])
         self.assertEqual(meta["agent"], "claude-code")
+        self.assertIsNone(meta["model"])
+        self.assertEqual(meta["effort"], "max")
         self.assertIsNone(meta["artifact_git_sha"])  # no artifact given
         self.assertIn("created", meta)
         # env exported for the phase subprocesses
         self.assertEqual(os.environ["SPECULA_RUN_DIR"], str(p.run_dir))
+
+    def test_meta_records_cli_tuning_over_environment(self) -> None:
+        root = self.tmp()
+        os.environ["SPECULA_MODEL"] = "env-model"
+        os.environ["SPECULA_EFFORT"] = "low"
+        os.environ["CODEX_MODEL"] = "adapter-model"
+        os.environ["CODEX_EFFORT"] = "medium"
+        p = self._pipeline(
+            ["--agent=codex", "--model=gpt-5.5", "--effort=high", "foo|o/r|Go|ref"],
+            root,
+        )
+        assert p.run_dir is not None
+        meta = json.loads((p.run_dir / "run.json").read_text())
+        self.assertEqual(meta["model"], "gpt-5.5")
+        self.assertEqual(meta["effort"], "high")
+
+    def test_meta_records_specula_environment_tuning(self) -> None:
+        root = self.tmp()
+        os.environ["SPECULA_MODEL"] = "env-model"
+        os.environ["SPECULA_EFFORT"] = "low"
+        os.environ["CODEX_MODEL"] = "adapter-model"
+        os.environ["CODEX_EFFORT"] = "medium"
+        p = self._pipeline(["--agent=codex", "foo|o/r|Go|ref"], root)
+        assert p.run_dir is not None
+        meta = json.loads((p.run_dir / "run.json").read_text())
+        self.assertEqual(meta["model"], "env-model")
+        self.assertEqual(meta["effort"], "low")
+
+    def test_meta_records_adapter_environment_tuning(self) -> None:
+        cases = (
+            ("claude-code", {"CLAUDE_MODEL": "opus", "CLAUDE_EFFORT": "low"}, "opus", "max"),
+            (
+                "codex",
+                {
+                    "SPECULA_MODEL": "",
+                    "SPECULA_EFFORT": "",
+                    "CODEX_MODEL": "gpt-env",
+                    "CODEX_EFFORT": "high",
+                },
+                "gpt-env",
+                "high",
+            ),
+            ("copilot-cli", {"COPILOT_MODEL": "copilot-env"}, "copilot-env", None),
+        )
+        for agent, environment, expected_model, expected_effort in cases:
+            with self.subTest(agent=agent):
+                for name in self._TUNING_ENV:
+                    os.environ.pop(name, None)
+                os.environ.update(environment)
+                os.environ.pop("SPECULA_RUN_DIR", None)
+                p = self._pipeline([f"--agent={agent}", "foo|o/r|Go|ref"], self.tmp())
+                assert p.run_dir is not None
+                meta = json.loads((p.run_dir / "run.json").read_text())
+                self.assertEqual(meta["model"], expected_model)
+                self.assertEqual(meta["effort"], expected_effort)
+
+    def test_meta_records_unknown_defaults_as_null(self) -> None:
+        for agent in ("codex", "copilot-cli"):
+            with self.subTest(agent=agent):
+                os.environ.pop("SPECULA_RUN_DIR", None)
+                p = self._pipeline([f"--agent={agent}", "foo|o/r|Go|ref"], self.tmp())
+                assert p.run_dir is not None
+                meta = json.loads((p.run_dir / "run.json").read_text())
+                self.assertIsNone(meta["model"])
+                self.assertIsNone(meta["effort"])
+
+    def test_meta_records_explicit_resets_as_null(self) -> None:
+        root = self.tmp()
+        os.environ["SPECULA_MODEL"] = "env-model"
+        os.environ["SPECULA_EFFORT"] = "low"
+        os.environ["CLAUDE_MODEL"] = "opus"
+        os.environ["CLAUDE_EFFORT"] = "high"
+        argv = ["--agent=claude-code", "--model=", "--effort=", "foo|o/r|Go|ref"]
+        p = self._pipeline(argv, root)
+        assert p.run_dir is not None
+        meta = json.loads((p.run_dir / "run.json").read_text())
+        self.assertIsNone(meta["model"])
+        self.assertIsNone(meta["effort"])
+        self.assertEqual(meta["argv"], argv)
+
+    def test_meta_records_claude_default_effort_as_unknown(self) -> None:
+        root = self.tmp()
+        p = self._pipeline(["--agent=claude-code", "--effort=default", "foo|o/r|Go|ref"], root)
+        assert p.run_dir is not None
+        meta = json.loads((p.run_dir / "run.json").read_text())
+        self.assertIsNone(meta["effort"])
 
     def test_meta_records_artifact_sha(self) -> None:
         root = self.tmp()


### PR DESCRIPTION
Adds a uniform `--model` / `--effort` interface across the agent adapters and forwards it through the full pipeline, including review and parallel confirmation paths.

- **codex.sh** — `--model` maps to `-m`; `--effort` maps to `-c model_reasoning_effort=...`. `CODEX_MODEL` / `CODEX_EFFORT` remain adapter fallbacks, while explicit empty flags clear them and use `config.toml` defaults.
- **copilot-cli.sh** — non-empty `--effort` maps to the native `--reasoning-effort` flag. Capability detection preserves old clients when effort is unset and reports a clear upgrade error when an installed client cannot honor a requested effort.
- **pipelinelib / phaselib** — parse and forward `--model` / `--effort` across normal phases and reviews, with `SPECULA_MODEL` / `SPECULA_EFFORT` fallback. Tri-state handling distinguishes absent, explicit empty, and non-empty values.
- **Claude safety default** — when no Specula effort override is provided, every Claude normal phase, blocking confirmation turn, and review still receives explicit `--effort=max`, preventing ambient `CLAUDE_EFFORT` injection from silently lowering pipeline effort. Explicit `--effort=` remains a deliberate reset.
- **confirmlib** — threads tuning through parallel confirmation while preserving the original positional `ConfirmConfig` field order.

Pipeline, adapter, precedence, compatibility, and Claude-default behavior are covered by unit and end-to-end regression tests; unit, ruff, shell, mypy, and DCO checks are green.