### PR TITLE
Rewrite usage guide for current Specula workflow

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -229,7 +229,7 @@ uv run specula run [options] "name|owner/repository|language|reference"
 | `--model=NAME` | Override the configured model |
 | `--effort=LEVEL` | Override reasoning effort |
 | `--artifact=PATH` | Set the target source checkout |
-| `--max-parallel=N` | Run phase agents concurrently |
+| `--max-parallel=N` | Set a hard concurrency limit. If omitted, ordinary phases run 1 target agent at a time and per-finding Phase 4 confirmation runs up to 4 Reproducer agents at a time |
 | `--max-turns=N` | Set Copilot's autopilot continuation limit; accepted but ignored by Claude Code and Codex |
 | `--enable-reviews` | Enable inter-phase reviews |
 | `--legacy-confirm` | Use one confirmation agent instead of per-finding agents |

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -206,7 +206,7 @@ uv run specula specgen --agent=codex --artifact=/path/to/source name
 
 A single-target individual command uses `.specula-output/` in the current directory; a multi-target command uses `<name>/.specula-output/` for each target. When `SPECULA_RUN_DIR` is set, every target uses `$SPECULA_RUN_DIR/<name>/.specula-output/`. A downstream command stops if its required files from the preceding phase are missing.
 
-Use `--check` to validate a phase's prerequisites without starting an agent:
+Use `--check` to run a lightweight path-level preflight without starting an agent. It checks the paths currently gated by that phase, but does not validate file contents; warnings such as zero trace files remain non-fatal:
 
 ```bash
 uv run specula validate --check --artifact=/path/to/source name

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -265,6 +265,8 @@ uv run specula batch --queue /path/to/tasks.queue --workers 3
 
 The scheduler clones missing repositories under `case-studies/` and creates an isolated workspace for every task. See all scheduler options with `uv run specula batch --help`.
 
+The scheduler owns `--run-id`, `--isolate`, and `--no-isolate` so that each task keeps a separate workspace. Do not include these flags in a queue; Specula rejects the queue and reports the affected line and flag.
+
 ## Progress and Logs
 
 Agent activity is printed during each phase and written to its log. Set `SPECULA_PROGRESS=off` to disable live reporting. After a run, start with `pipeline-summary.md` for deliverable status and log locations.

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -32,7 +32,7 @@ Specula relies on the selected agent to analyze code and reason about counterexa
 
 The agent sandbox is **disabled by default** and its dependencies are **not installed** by `specula setup`. Normal runs do not need SRT or Bubblewrap.
 
-To enable the sandbox for Claude Code or Codex, install Node.js 20+ and SRT:
+To enable the sandbox for Claude Code or Codex, install Node.js 20.11+ and SRT:
 
 ```bash
 npm install -g @anthropic-ai/sandbox-runtime
@@ -113,7 +113,7 @@ Select an agent, model, and reasoning effort when needed:
 ```bash
 uv run specula run \
   --agent=codex \
-  --model=<model-name> \
+  --model=MODEL_NAME \
   --effort=high \
   --artifact=/absolute/path/to/source \
   "name|owner/repository|language|reference"
@@ -131,7 +131,7 @@ Supported adapters are `claude-code` (default), `codex`, and `copilot-cli`. Mode
 
 Specula launches the installed agent CLI directly and uses its existing credentials. Authenticate the CLI before starting a pipeline. Claude Code runs default to maximum reasoning effort; Codex and Copilot use their configured defaults unless `--effort` is supplied.
 
-Passing `--effort` to Copilot requires Copilot CLI 1.0.4 or newer. Codex currently accepts `--max-turns` for adapter compatibility but does not enforce it because `codex exec` has no corresponding limit.
+Passing `--effort` to Copilot requires Copilot CLI 1.0.4 or newer. `--max-turns` maps to Copilot's autopilot continuation limit. Claude Code and Codex accept the option for adapter compatibility but do not enforce it. Inter-phase reviews pass a fixed value of 30 instead of the pipeline option; Claude Code and Codex still ignore it.
 
 ## Output Structure
 
@@ -147,7 +147,7 @@ runs/<run-id>/
 
 The `.specula-output/` directory contains the modeling brief, specifications, harness, traces, reproduction tests, reports, and phase logs. `runs/latest` points to the newest run.
 
-The source supplied through `--artifact` is not copied into the isolated workspace. Harness and reproduction work may build or modify that checkout. Use `--no-isolate` to write `.specula-output/` in the current project instead.
+The source supplied through `--artifact` is not copied into the isolated workspace. Harness and reproduction work may build or modify that checkout. `--no-isolate` selects the legacy layout: a single target writes phase outputs under `$PWD/.specula-output/`, or under `case-studies/<name>/.specula-output/` when that canonical case study exists; multiple targets use `$PWD/<name>/.specula-output/`. For a canonical single target, `pipeline.log` remains under the launch directory's `.specula-output/` while the phase outputs and summary use the case-study directory.
 
 TLC can use substantial memory and temporary disk space during model checking. The bundled `scripts/tlc/run_model_check.sh` stores states under `TMPDIR` (or `/tmp`) by default; set `TLC_STATE_DIR` to a larger or faster filesystem when necessary.
 
@@ -198,13 +198,13 @@ uv run specula analyze \
   "name|owner/repository|language|reference"
 ```
 
-This writes `.specula-output/modeling-brief.md` and `.specula-output/analysis-report.md` in the current directory. By interface, downstream phase commands take only the target `name`; continue passing `--artifact` so they can access the source:
+This writes `.specula-output/modeling-brief.md` and `.specula-output/analysis-report.md` in the current directory. By interface, downstream phase commands take only the target `name`. Continue passing `--artifact` to `specgen`, `harness`, `validate`, and `confirm` so they can access the source; `classify` reads only the generated report and does not accept `--artifact`:
 
 ```bash
 uv run specula specgen --agent=codex --artifact=/path/to/source name
 ```
 
-Individual commands share `.specula-output/` in the current directory unless `SPECULA_RUN_DIR` is set. A downstream command stops if its required files from the preceding phase are missing.
+A single-target individual command uses `.specula-output/` in the current directory; a multi-target command uses `<name>/.specula-output/` for each target. When `SPECULA_RUN_DIR` is set, every target uses `$SPECULA_RUN_DIR/<name>/.specula-output/`. A downstream command stops if its required files from the preceding phase are missing.
 
 Use `--check` to validate a phase's prerequisites without starting an agent:
 
@@ -230,12 +230,13 @@ uv run specula run [options] "name|owner/repository|language|reference"
 | `--effort=LEVEL` | Override reasoning effort |
 | `--artifact=PATH` | Set the target source checkout |
 | `--max-parallel=N` | Run phase agents concurrently |
+| `--max-turns=N` | Set Copilot's autopilot continuation limit; accepted but ignored by Claude Code and Codex |
 | `--enable-reviews` | Enable inter-phase reviews |
 | `--legacy-confirm` | Use one confirmation agent instead of per-finding agents |
 | `--skip-analysis`, `--skip-specgen`, `--skip-harness` | Reuse early-phase outputs |
 | `--skip-validation`, `--skip-confirmation`, `--skip-classification` | Reuse later-phase outputs |
 | `--run-id=ID` | Create or attach to an isolated run |
-| `--no-isolate` | Write outputs in the current project |
+| `--no-isolate` | Use the legacy output layout described above |
 
 `--dry-run` still creates the isolated run metadata, log, and summary files. The confirmation repair loop is enabled by default; disable it with `--skip-repair-loop` or cap attempts per request with `--max-repair-rounds=N`.
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -1,16 +1,269 @@
-# Usage
+# Usage Guide
 
-## Skills
+## Getting Started
 
-| Skill | Purpose |
-|-------|---------|
-| `/code-analysis` | Analyze target codebase, mine git history and issues, produce a modeling brief |
-| `/spec-generation` | Generate TLA+ specifications (base, model-checking, trace validation, instrumentation mapping) |
-| `/harness-generation` | Instrument source code to emit NDJSON traces, write test scenarios, collect traces |
-| `/validation-workflow` | Iterative trace validation + model checking until convergence, then bug hunting |
-| `/tla-trace-workflow` | Validate a single trace against a TLA+ spec (used by validation-workflow) |
-| `/tla-checking-workflow` | Run TLC model checking and classify counterexamples (used by validation-workflow) |
-| `/bug-confirmation` | Validate TLA+ counterexamples against real code, reproduce bugs |
-| `/bug-recording` | Record confirmed bugs to the shared bug tracker |
+### Supported platforms
 
-Each skill has a detailed guide in `skills/<skill-name>/guide.md`.
+- **Linux:** supported directly.
+- **macOS:** supported. Specula's long-running-job helpers use GNU `timeout` and `tail --pid`; install GNU coreutils and put its `gnubin` directory on `PATH` (for Homebrew: `brew install coreutils`, then add `$(brew --prefix coreutils)/libexec/gnubin` to `PATH`).
+- **Windows:** use [WSL2](https://learn.microsoft.com/windows/wsl/install) and run Specula inside its Linux environment. Native Windows terminals are not supported because the launchers and setup use Bash and other POSIX tools.
+
+When using WSL2, install the prerequisites and agent CLI inside WSL2, then clone and run Specula there. The target repository must also be accessible from that environment.
+
+### Requirements
+
+| Dependency | Used for | Installed by `specula setup`? |
+|---|---|---|
+| [uv](https://docs.astral.sh/uv/) | Running the packaged `specula` command | No |
+| Python 3.10+ with `pip` and `venv` | CLI, launchers, MCP tool environments | No |
+| JDK 21+ and Maven | TLC, SANY, and building the CFA tool | No |
+| Git and Bash | Source/history analysis, worktrees, and launch scripts | No |
+| Standard POSIX utilities (`tee`, `tail`, `du`, and others) | Logging and process coordination | No |
+| `curl` or `wget` | Downloading TLA+ JARs during setup | No |
+| GitHub CLI (`gh`) | Issue and repository research | No |
+| Claude Code, Codex, or GitHub Copilot CLI | Agent execution | No |
+| Target language toolchain and test dependencies | Harness generation and bug reproduction | No |
+
+The first setup needs network access to GitHub, PyPI, and Maven Central. Agent runs also need access to the selected model provider and any remote repositories the analysis uses. Claude subscription quota monitoring specifically uses `curl`; if it is unavailable, the quota check warns and fails open rather than stopping the pipeline.
+
+Specula relies on the selected agent to analyze code and reason about counterexamples, so use a strong reasoning model at high effort. Harness generation builds and instruments the target project; verify that the target builds normally before starting a full pipeline.
+
+### Optional sandbox dependencies
+
+The agent sandbox is **disabled by default** and its dependencies are **not installed** by `specula setup`. Normal runs do not need SRT or Bubblewrap.
+
+To enable the sandbox for Claude Code or Codex, install Node.js 20+ and SRT:
+
+```bash
+npm install -g @anthropic-ai/sandbox-runtime
+```
+
+Linux and WSL2 also require:
+
+- `bubblewrap` (the executable is named `bwrap`)
+- `socat`
+- `ripgrep`
+- unprivileged user namespaces enabled
+
+macOS uses the built-in Seatbelt sandbox instead of Bubblewrap. The sandbox is a guardrail rather than a security boundary; its default policy restricts writes but leaves reads and network access open.
+
+Enable it per run with `SPECULA_SANDBOX=on`. A full pipeline also needs write access to the target checkout and its build caches, for example:
+
+```bash
+export SPECULA_SANDBOX=on
+export SPECULA_SANDBOX_EXTRA_WRITE="/path/to/source:$HOME/.cache"
+uv run specula run --artifact=/path/to/source "name|owner/repository|language|reference"
+```
+
+If neither `.specula/sandbox.json` in the launch directory nor `~/.specula/sandbox.json` exists, the first sandboxed run copies the default policy to `~/.specula/sandbox.json`. Review the [sandbox guide](../scripts/launch/sandbox/README.md) before enabling it or tightening read/network access.
+
+Clone Specula and run its interactive setup:
+
+```bash
+git clone https://github.com/specula-org/Specula.git
+cd Specula
+uv run specula setup
+```
+
+Setup downloads the TLA+ JARs, builds the CFA tool, prepares the MCP tool environments, and offers integration for each supported agent. It prompts for global or project-local skill installation. Codex users can choose the skills/MCP setup or the generated Specula plugin.
+
+More precisely, setup manages:
+
+| Component | Setup behavior |
+|---|---|
+| `tla2tools.jar` and Community Modules | Downloads them into `lib/` if missing |
+| CFA transformer | Builds it with Maven |
+| MCP Python packages | Creates tool-specific virtual environments and installs `mcp` and `jsonschema` where required |
+| Claude Code | Installs skills and registers all three MCP servers |
+| Codex | Installs skills and MCP servers, or generates/updates the Specula plugin |
+| GitHub Copilot CLI | Installs skills only; MCP servers must currently be configured manually |
+
+Setup does **not** install `uv`, Python, a JDK, Maven, Git, `gh`, an agent CLI, target-language dependencies, GNU coreutils, or the optional sandbox dependencies.
+
+The setup is safe to rerun when updating the checkout. Confirm the CLI afterward:
+
+```bash
+uv run specula --help
+```
+
+### First run
+
+From the Specula checkout, point Specula at the source repository to analyze:
+
+```bash
+uv run specula run \
+  --artifact=/absolute/path/to/source \
+  "name|github-owner/repository|language|reference"
+```
+
+For example:
+
+```bash
+uv run specula run \
+  --artifact=/work/cometbft \
+  "cometbft|cometbft/cometbft|Go|Tendermint BFT"
+```
+
+Quote the target descriptor because `|` has special meaning in the shell. Its fields identify the output name, GitHub repository, primary language, and reference algorithm or design document.
+
+With the default isolated workspace, an external source checkout must be supplied with `--artifact`. Alternatively, Specula finds canonical checkouts under `case-studies/<name>/artifact/`.
+
+Select an agent, model, and reasoning effort when needed:
+
+```bash
+uv run specula run \
+  --agent=codex \
+  --model=<model-name> \
+  --effort=high \
+  --artifact=/absolute/path/to/source \
+  "name|owner/repository|language|reference"
+```
+
+Supported adapters are `claude-code` (default), `codex`, and `copilot-cli`. Model names and effort values are interpreted by the selected agent.
+
+## Agents and Authentication
+
+| Agent | `--agent` value | Authentication |
+|---|---|---|
+| Claude Code | `claude-code` | Existing Claude CLI profile; select another with `--claude-alias=NAME` |
+| Codex | `codex` | Existing Codex CLI login or configuration |
+| GitHub Copilot CLI | `copilot-cli` | Existing Copilot CLI login or token configuration |
+
+Specula launches the installed agent CLI directly and uses its existing credentials. Authenticate the CLI before starting a pipeline. Claude Code runs default to maximum reasoning effort; Codex and Copilot use their configured defaults unless `--effort` is supplied.
+
+Passing `--effort` to Copilot requires Copilot CLI 1.0.4 or newer. Codex currently accepts `--max-turns` for adapter compatibility but does not enforce it because `codex exec` has no corresponding limit.
+
+## Output Structure
+
+Runs are isolated by default under:
+
+```text
+runs/<run-id>/
+├── run.json
+├── pipeline.log
+├── pipeline-summary.md
+└── <name>/.specula-output/
+```
+
+The `.specula-output/` directory contains the modeling brief, specifications, harness, traces, reproduction tests, reports, and phase logs. `runs/latest` points to the newest run.
+
+The source supplied through `--artifact` is not copied into the isolated workspace. Harness and reproduction work may build or modify that checkout. Use `--no-isolate` to write `.specula-output/` in the current project instead.
+
+TLC can use substantial memory and temporary disk space during model checking. The bundled `scripts/tlc/run_model_check.sh` stores states under `TMPDIR` (or `/tmp`) by default; set `TLC_STATE_DIR` to a larger or faster filesystem when necessary.
+
+## Resuming a Run
+
+Use a stable ID when a run may need to be resumed:
+
+```bash
+uv run specula run \
+  --run-id=my-run \
+  --artifact=/path/to/source \
+  "name|owner/repository|language|reference"
+```
+
+Attach to the same run and skip completed phases. This resumes at validation:
+
+```bash
+uv run specula run \
+  --run-id=my-run \
+  --skip-analysis \
+  --skip-specgen \
+  --skip-harness \
+  --artifact=/path/to/source \
+  "name|owner/repository|language|reference"
+```
+
+Specula reuses `runs/<run-id>/<name>/.specula-output/`. Pass the target, artifact, agent, model, and effort again when resuming; `run.json` is an audit record, not a source of arguments for the new invocation.
+
+## Individual Phases
+
+Most users should run `uv run specula run`, which executes every phase in order. The commands below are for running or debugging one phase at a time.
+
+| Command | What it does | Required input | Main output |
+|---|---|---|---|
+| `analyze` | Launches an agent to inspect the source, mine Git history and issues, identify bug families, and decide what should be modeled | Target source and the four-field target descriptor | `modeling-brief.md`, `analysis-report.md` |
+| `specgen` | Converts the modeling brief into code-faithful TLA+ specifications | Source and `modeling-brief.md` | `spec/base.tla`, `spec/MC.tla`, `spec/Trace.tla`, configs, and `instrumentation-spec.md` |
+| `harness` | Instruments the implementation and runs scenarios to collect execution traces | Source and generated specifications | `harness/` and `traces/*.ndjson` |
+| `validate` | Checks real traces against the specification, runs TLC, and investigates counterexamples | Source, specifications, harness, and traces | `spec/bug-report.md`, `spec/findings.json`, TLC output, and `spec/changelog.md` |
+| `confirm` | Audits and reproduces each candidate bug against the real implementation | Source, modeling brief, and bug report | `spec/confirmed-bugs.md`, reproduction tests, and any repair requests |
+| `classify` | Assigns a severity to confirmed bugs | `spec/confirmed-bugs.md` | `spec/bug-severity.md` |
+
+For example, run only Phase 1 with Codex:
+
+```bash
+uv run specula analyze \
+  --agent=codex \
+  --artifact=/path/to/source \
+  "name|owner/repository|language|reference"
+```
+
+This writes `.specula-output/modeling-brief.md` and `.specula-output/analysis-report.md` in the current directory. By interface, downstream phase commands take only the target `name`; continue passing `--artifact` so they can access the source:
+
+```bash
+uv run specula specgen --agent=codex --artifact=/path/to/source name
+```
+
+Individual commands share `.specula-output/` in the current directory unless `SPECULA_RUN_DIR` is set. A downstream command stops if its required files from the preceding phase are missing.
+
+Use `--check` to validate a phase's prerequisites without starting an agent:
+
+```bash
+uv run specula validate --check --artifact=/path/to/source name
+```
+
+## CLI Reference
+
+### `specula run`
+
+Run the complete analysis-to-classification pipeline:
+
+```bash
+uv run specula run [options] "name|owner/repository|language|reference"
+```
+
+| Option | Purpose |
+|---|---|
+| `--dry-run` | Print phase commands without starting agents |
+| `--agent=NAME` | Select `claude-code`, `codex`, or `copilot-cli` |
+| `--model=NAME` | Override the configured model |
+| `--effort=LEVEL` | Override reasoning effort |
+| `--artifact=PATH` | Set the target source checkout |
+| `--max-parallel=N` | Run phase agents concurrently |
+| `--enable-reviews` | Enable inter-phase reviews |
+| `--legacy-confirm` | Use one confirmation agent instead of per-finding agents |
+| `--skip-analysis`, `--skip-specgen`, `--skip-harness` | Reuse early-phase outputs |
+| `--skip-validation`, `--skip-confirmation`, `--skip-classification` | Reuse later-phase outputs |
+| `--run-id=ID` | Create or attach to an isolated run |
+| `--no-isolate` | Write outputs in the current project |
+
+`--dry-run` still creates the isolated run metadata, log, and summary files. The confirmation repair loop is enabled by default; disable it with `--skip-repair-loop` or cap attempts per request with `--max-repair-rounds=N`.
+
+Use command-specific help for the authoritative option list:
+
+```bash
+uv run specula run --help
+uv run specula validate --help
+uv run specula confirm --help
+```
+
+## Batch Runs
+
+Create a tab-separated queue with one target per line and optional pipeline flags after a literal tab:
+
+```text
+alpha|owner/alpha|Go|Raft
+beta|owner/beta|Rust|Concurrent queue<TAB>--agent=codex --effort=high
+```
+
+Run it with:
+
+```bash
+uv run specula batch --queue /path/to/tasks.queue --workers 3
+```
+
+The scheduler clones missing repositories under `case-studies/` and creates an isolated workspace for every task. See all scheduler options with `uv run specula batch --help`.
+
+## Progress and Logs
+
+Agent activity is printed during each phase and written to its log. Set `SPECULA_PROGRESS=off` to disable live reporting. After a run, start with `pipeline-summary.md` for deliverable status and log locations.

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -392,6 +392,7 @@ class Phase:
         model: str | None = None
         effort: str | None = None
         artifact = ""
+        artifact_provided = False
         targets: list[str] = []
         extra: dict[str, str | bool] = {}
 
@@ -430,6 +431,7 @@ class Phase:
                 if not self.accepts_artifact:
                     print(self.artifact_rejection_message or f"Unknown option: {arg}")
                     return 1
+                artifact_provided = True
                 artifact = arg[len("--artifact=") :]
             elif arg in ("--help", "-h"):
                 sys.stdout.write(self.usage)
@@ -441,6 +443,10 @@ class Phase:
                 return 1
             else:
                 targets.append(arg)
+
+        if artifact_provided and (not artifact or not Path(artifact).is_dir()):
+            print(f"ERROR: --artifact must be an existing directory: {artifact}")
+            return 1
 
         if max_parallel is None:
             max_parallel = self.default_max_parallel(extra)
@@ -877,9 +883,9 @@ Options:
         for name in names:
             repo_dir = ws.find_repo_dir(name)
             if repo_dir:
-                # --artifact is returned verbatim (may not exist); mirror bash
-                # `cd "$repo_dir" && git ... || echo "?"` — degrade to "?" on a
-                # bad/unreadable path instead of crashing on subprocess cwd.
+                # An explicit --artifact has already been validated as a
+                # directory, but it need not be a Git checkout. Degrade the
+                # optional commit count to "?" when git cannot inspect it.
                 commits = "?"
                 if Path(repo_dir).is_dir():
                     r = subprocess.run(
@@ -1342,7 +1348,7 @@ Example:
 
 Options:
   --dry-run           Print commands without executing
-  --check             Only verify prerequisites exist
+  --check             Run a lightweight prerequisite path check
   --repair            Repair mode: process OPEN/REOPENED repair requests (confirmation back-edge)
   --max-parallel=N    Max concurrent agents (default: 1)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
@@ -1359,6 +1365,7 @@ Prerequisites:
 """
     check_header = "Checking prerequisites..."
     check_fail_msg = "ERROR: Missing prerequisites. Run spec generation first."
+    check_ok_msg = "Required path checks passed; review any warnings above."
 
     def parse_flag(self, arg: str, extra: dict[str, str | bool]) -> bool:
         if arg == "--repair":

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -211,6 +211,7 @@ class Phase:
     check_fail_msg = "ERROR: Missing prerequisites."
     check_ok_msg = "All prerequisites OK."  # code_analysis says "All repos OK."
     accepts_artifact = True  # bug_classification takes no --artifact (rejects it)
+    artifact_rejection_message: str | None = None
     dry_prompt_flag = "--prompt"  # bug_classification's dry-run line shows --prompt-file
     progress_config = progress.ProgressConfig()
     # Tri-state tuning values set in run(): None = unspecified, "" = explicit
@@ -421,7 +422,10 @@ class Phase:
                 model = arg[len("--model=") :]
             elif arg.startswith("--effort="):
                 effort = arg[len("--effort=") :]
-            elif arg.startswith("--artifact=") and self.accepts_artifact:
+            elif arg.startswith("--artifact="):
+                if not self.accepts_artifact:
+                    print(self.artifact_rejection_message or f"Unknown option: {arg}")
+                    return 1
                 artifact = arg[len("--artifact=") :]
             elif arg in ("--help", "-h"):
                 sys.stdout.write(self.usage)
@@ -1235,6 +1239,10 @@ Prerequisites:
     check_header = "Checking prerequisites..."
     check_fail_msg = "ERROR: Missing prerequisites. Run Phase 4a (launch_bug_confirmation.sh) first."
     accepts_artifact = False  # this launcher takes no --artifact
+    artifact_rejection_message = (
+        "ERROR: classify does not accept --artifact; this phase reads the existing "
+        ".specula-output/spec/confirmed-bugs.md and does not inspect source code."
+    )
     dry_prompt_flag = "--prompt-file"  # its dry-run line shows --prompt-file=<prompt>
 
     def check(self, ws: Workspace, names: list[str]) -> bool:

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -226,6 +226,10 @@ class Phase:
         --max-repair-rounds). `extra` is exposed to hooks as `ws.opts`."""
         return False
 
+    def default_max_parallel(self, extra: dict[str, str | bool]) -> int:
+        """Concurrent-agent default when ``--max-parallel`` is omitted."""
+        return 1
+
     def target_name(self, target: str) -> str:
         """Extract the display/work name from a target string. Downstream phases
         get name-only targets, so the whole (trimmed) string is the name;
@@ -378,7 +382,7 @@ class Phase:
 
     # ── shared driver ──
     def run(self, argv: list[str]) -> int:
-        max_parallel = 1
+        max_parallel: int | None = None
         max_turns = "0"
         dry_run = False
         check_only = False
@@ -437,6 +441,9 @@ class Phase:
                 return 1
             else:
                 targets.append(arg)
+
+        if max_parallel is None:
+            max_parallel = self.default_max_parallel(extra)
 
         if not targets:
             targets = [_logical_cwd().name]  # bash `basename "$PWD"` (logical under symlinks)
@@ -1489,7 +1496,8 @@ Options:
   --legacy-confirm    Single-agent confirmation (one agent, all findings) instead of parallel
   --recheck           Re-check mode: settle RECHECK repair requests (confirmation back-edge; single-agent)
   --max-repair-rounds=N  Per-request repair cap honored in --recheck (default: 0 = unlimited)
-  --max-parallel=N    Concurrent findings in parallel mode / concurrent agents in --legacy-confirm (default: 1)
+  --max-parallel=N    Hard limit for concurrent findings in parallel mode, or concurrent target agents in
+                      --legacy-confirm/--recheck (defaults: 4 in parallel mode, 1 otherwise)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
@@ -1518,6 +1526,9 @@ Prerequisites:
             return True
         return False
 
+    def default_max_parallel(self, extra: dict[str, str | bool]) -> int:
+        return 1 if extra.get("legacy") or extra.get("recheck") else 4
+
     def run_alternate(
         self,
         ws: Workspace,
@@ -1538,12 +1549,6 @@ Prerequisites:
         # would be circular.
         from specula.confirmlib import ConfirmConfig, run_parallel_confirmation
 
-        # `max_parallel` here is the per-finding concurrency. The pipeline default
-        # is 1 — it means "concurrent targets" for the other phases, but that is
-        # degenerate for per-finding fan-out (findings would run one at a time, so
-        # "parallel" would not actually be parallel). Use a real concurrency
-        # default; an explicit --max-parallel=N>1 still wins.
-        findings_parallel = max_parallel if max_parallel > 1 else 4
         rc = 0
         for name in names:
             if not dry_run:
@@ -1553,7 +1558,7 @@ Prerequisites:
                 ws=ws,
                 adapter=adapter,
                 repo_dir=ws.find_repo_dir(name),
-                max_parallel=findings_parallel,
+                max_parallel=max_parallel,
                 claude_alias=claude_alias,
                 model=self._model,
                 effort=self._effort,

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -91,7 +91,8 @@ Options:
   --legacy-confirm       Phase 4a: single-agent confirmation instead of the default parallel per-finding
   --max-repair-rounds=N  Per-request repair cap, enforced by re-check (default: 0 = unlimited)
   --enable-reviews        Enable review steps (disabled by default)
-  --max-parallel=N       Max concurrent agents per phase (default: 1)
+  --max-parallel=N       Hard limit for concurrent agents. When omitted, ordinary phases run 1 target
+                         agent at a time and per-finding bug confirmation runs up to 4 at a time
   --max-turns=N          Max agent turns (default: 0 = unlimited)
   --agent=NAME           Agent adapter to use (default: claude-code; e.g., claude-code, codex, copilot-cli)
   --claude-alias=NAME    Claude CLI profile (default: claude)
@@ -251,7 +252,10 @@ class Pipeline:
     """Parsed configuration + the phase sequencing of the bash `main`."""
 
     def __init__(self) -> None:
-        self.max_parallel = "1"  # verbatim passthrough; the launchers validate
+        # None means the user omitted the flag, so each phase applies its own
+        # default (1 normally; 4 for per-finding bug confirmation). A string,
+        # including "", is an explicit value forwarded for launcher validation.
+        self.max_parallel: str | None = None
         self.max_turns = "0"  # deprecated verbatim passthrough
         self.dry_run = False
         self.skip_analysis = False
@@ -621,8 +625,9 @@ class Pipeline:
 
     def _phase_args(self, positional: list[str], pre: list[str] | None = None, with_artifact: bool = True) -> list[str]:
         args = list(pre or [])
+        if self.max_parallel is not None:
+            args.append(f"--max-parallel={self.max_parallel}")
         args += [
-            f"--max-parallel={self.max_parallel}",
             f"--max-turns={self.max_turns}",
             f"--agent={self.agent}",
             f"--claude-alias={self.claude_alias}",
@@ -984,7 +989,8 @@ class Pipeline:
         print("╚══════════════════════════════════════════════════════════╝")
         print()
         print(f"Targets:      {len(self.targets)}")
-        print(f"Max parallel: {self.max_parallel}")
+        max_parallel = self.max_parallel if self.max_parallel is not None else "phase defaults (1; confirmation 4)"
+        print(f"Max parallel: {max_parallel}")
         print(f"Max turns:    {self.max_turns}")
         print(f"Agent:        {self.agent}  (claude-alias={self.claude_alias})")
         if self.run_dir:

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -623,6 +623,14 @@ class Pipeline:
             args.append(f"--effort={self.effort}")
         return args
 
+    def _max_parallel_summary(self) -> str:
+        if self.max_parallel is not None:
+            return self.max_parallel
+        confirmation_default = (
+            "legacy confirmation 1 at a time" if self.confirm_legacy else "per-finding confirmation 4 at a time"
+        )
+        return f"phase defaults (ordinary phases 1 at a time; {confirmation_default})"
+
     def _phase_args(self, positional: list[str], pre: list[str] | None = None, with_artifact: bool = True) -> list[str]:
         args = list(pre or [])
         if self.max_parallel is not None:
@@ -989,8 +997,7 @@ class Pipeline:
         print("╚══════════════════════════════════════════════════════════╝")
         print()
         print(f"Targets:      {len(self.targets)}")
-        max_parallel = self.max_parallel if self.max_parallel is not None else "phase defaults (1; confirmation 4)"
-        print(f"Max parallel: {max_parallel}")
+        print(f"Max parallel: {self._max_parallel_summary()}")
         print(f"Max turns:    {self.max_turns}")
         print(f"Agent:        {self.agent}  (claude-alias={self.claude_alias})")
         if self.run_dir:

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -277,6 +277,7 @@ class Pipeline:
         self.model: str | None = None
         self.effort: str | None = None
         self.artifact = ""
+        self._artifact_given = False
         self.targets: list[str] = []
         self.quota_5h = os.environ.get("QUOTA_5H") or "85"
         self.quota_7d = os.environ.get("QUOTA_7D") or "95"
@@ -345,6 +346,7 @@ class Pipeline:
                 self.effort = arg.split("=", 1)[1]
             elif arg.startswith("--artifact="):
                 self.artifact = arg.split("=", 1)[1]
+                self._artifact_given = True
             elif arg in ("--help", "-h"):
                 sys.stdout.write(USAGE)
                 return 0
@@ -360,6 +362,13 @@ class Pipeline:
         if self._run_id_given and self._no_isolate_given:
             print("ERROR: --no-isolate conflicts with --run-id", file=sys.stderr)
             return 1
+        if self._artifact_given:
+            if not self.artifact or not Path(self.artifact).is_dir():
+                print(f"ERROR: --artifact must be an existing directory: {self.artifact}", file=sys.stderr)
+                return 1
+            # The legacy single-target flow may chdir before launching phases.
+            # Stabilize a relative CLI path while it still refers to the caller's cwd.
+            self.artifact = str(Path(self.artifact).resolve())
         # wart fix (step 7): garbage quota config fails fast (pre-tee, like the
         # option errors). The bash pushed the values into the gate's arithmetic,
         # where a bad threshold read as "usage parse failed" and silently
@@ -641,7 +650,7 @@ class Pipeline:
             f"--claude-alias={self.claude_alias}",
             *self._model_effort_args(),
         ]
-        if with_artifact and self.artifact:
+        if with_artifact and self._artifact_given:
             args.append(f"--artifact={self.artifact}")
         args += positional
         return args

--- a/src/specula/schedulerlib.py
+++ b/src/specula/schedulerlib.py
@@ -110,6 +110,7 @@ Queue format (tab-separated):
   name|github|lang|reference[TAB]flags
 
   - flags: optional launch_pipeline.sh flags (e.g. --skip-analysis)
+  - --run-id, --isolate, and --no-isolate are reserved for the scheduler
 
 Workspace: every task's pipeline runs isolated under runs/<run>-<n>-<name>/
 (scheduler passes --run-id; canonical inputs stay in case-studies/<name>/).
@@ -319,7 +320,7 @@ class Scheduler:
         # final line is kept (bash silently dropped the task), and a
         # whitespace-only line is blank (bash stripped spaces only, so a
         # tabs-only line became a phantom task with an empty name)
-        for line in text.split("\n"):
+        for line_number, line in enumerate(text.split("\n"), start=1):
             if not line.strip() or re.match(r"^\s*#", line):
                 continue
             if "\t" in line:
@@ -327,6 +328,10 @@ class Scheduler:
                 flags = flags.lstrip("\t")
             else:
                 target, flags = line, ""
+            for flag in flags.split():
+                if flag in {"--run-id", "--isolate", "--no-isolate"} or flag.startswith("--run-id="):
+                    self.log(f"Queue line {line_number}: scheduler-reserved flag {flag}")
+                    raise SystemExit(1)
             self.task_targets.append(target)
             self.task_flags.append(flags)
         self.log(f"Loaded {len(self.task_targets)} tasks from {self.queue_file}")
@@ -393,11 +398,11 @@ class Scheduler:
         self.log(f"START #{idx + 1} {name}")
         self._write_status(idx, "running")
 
-        # every task runs in an isolated per-task workspace: runs/<run-id>/.
-        # --run-id implies --isolate; queue flags come later, so they can still
-        # override. One run dir per TASK (not per scheduler run): the run-scoped
-        # artifacts (pipeline.log, run.json, pipeline-summary.md) live at the
-        # run root and would collide across parallel workers.
+        # Every task runs in an isolated per-task workspace: runs/<run-id>/.
+        # load_queue rejects isolation flags before dispatch, so this generated
+        # ID cannot be overridden. One run dir per TASK (not per scheduler run):
+        # the run-scoped artifacts (pipeline.log, run.json,
+        # pipeline-summary.md) would otherwise collide across workers.
         task_run_id = self.task_run_id(idx)
         cmd = [
             "bash",
@@ -437,8 +442,7 @@ class Scheduler:
             # per task, not per attempt), so an attempt that dies before phase 1
             # truncates agent.log can read the previous attempt's API error and
             # misclassify a real failure as transient — costs at most the
-            # remaining bounded backoffs. And a queue-flag --run-id override
-            # moves the run dir, degrading the probe to the task-log grep above.
+            # remaining bounded backoffs.
             agent_log = f"{SPECULA_ROOT}/runs/{task_run_id}/{name}/.specula-output/agent.log"
             if os.path.isfile(agent_log) and _grep(agent_log, "API Error:"):
                 is_transient = True

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -16,6 +16,7 @@ import shutil
 import tempfile
 import unittest
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 from unittest import mock
@@ -158,6 +159,24 @@ class TestDriver(ConfirmCase):
         self.assertEqual(rc, 0)
         cb = ws.work_dir("T") / "spec" / "confirmed-bugs.md"
         self.assertTrue(cb.is_file() and cb.stat().st_size > 0)
+
+    def test_configured_max_parallel_reaches_executor(self) -> None:
+        ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
+        real_executor = ThreadPoolExecutor
+        worker_counts: list[int] = []
+
+        def executor(*args: Any, **kwargs: Any) -> ThreadPoolExecutor:
+            worker_counts.append(kwargs["max_workers"])
+            return real_executor(*args, **kwargs)
+
+        with (
+            mock.patch.object(C, "ThreadPoolExecutor", side_effect=executor),
+            mock.patch.object(C, "run_agent_blocking", _fake_turn("VERDICT: FALSE POSITIVE")),
+        ):
+            rc = C.run_parallel_confirmation(self.cfg(ws, "T", max_parallel=1))
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(worker_counts, [1])
 
     def test_rate_limit_withholds_deliverable(self) -> None:
         ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -112,7 +112,7 @@ PHASES: list[PhaseSpec] = [
         "artifact": True,
         "inputs": ["spec/base.tla", "spec/MC.tla", "spec/Trace.tla", "spec/instrumentation-spec.md"],
         "fail": "Run spec generation first.",
-        "ok": "All prerequisites OK.",
+        "ok": "Required path checks passed; review any warnings above.",
         "log": "spec-validation.log",
         "prompt": ".spec-validation-prompt.md",
         "flag": "--prompt",
@@ -216,9 +216,9 @@ class PhaseCase(unittest.TestCase):
             p.write_text("seeded\n")  # non-empty: some gates check st_size > 0
 
     def artifact_flag(self) -> str:
-        # A path find_repo_dir returns verbatim (need not exist), so the repo
-        # prerequisite is satisfied without a real checkout or a git call.
-        return f"--artifact={self.tmp() / 'repo'}"
+        repo = self.tmp() / "repo"
+        repo.mkdir()
+        return f"--artifact={repo}"
 
     def run_phase(self, key: str, args: list[str]) -> tuple[int, str]:
         buf = io.StringIO()
@@ -263,6 +263,19 @@ class TestCheckOnly(PhaseCase):
                 self.assertEqual(rc, 0, out)
                 self.assertIn(spec["ok"], out)
                 self.assertNotIn("[DRY RUN]", out)
+
+    def test_validation_check_remains_a_shallow_preflight(self) -> None:
+        spec_dir = self.work_dir() / "spec"
+        spec_dir.mkdir(parents=True)
+        for name in ("base.tla", "MC.tla", "Trace.tla", "instrumentation-spec.md"):
+            (spec_dir / name).touch()
+
+        rc, out = self.run_phase("spec_validation", ["--check", self.artifact_flag(), NAME])
+
+        self.assertEqual(rc, 0, out)
+        self.assertIn("specs OK (0L)", out)
+        self.assertIn("traces WARN (0 ndjson files)", out)
+        self.assertIn("Required path checks passed; review any warnings above.", out)
 
 
 class TestDryRunCommand(PhaseCase):
@@ -419,6 +432,17 @@ class TestArgErrors(PhaseCase):
                 self.assertEqual(rc, 1)
                 self.assertIn("expected an integer >= 1", out)
 
+    def test_missing_artifact_directory_is_rejected(self) -> None:
+        missing = self.tmp() / "missing"
+        rc, out = self.run_phase("code_analysis", ["--check", f"--artifact={missing}", NAME])
+        self.assertEqual(rc, 1)
+        self.assertIn("--artifact must be an existing directory", out)
+
+    def test_empty_artifact_value_is_rejected(self) -> None:
+        rc, out = self.run_phase("code_analysis", ["--check", "--artifact=", NAME])
+        self.assertEqual(rc, 1)
+        self.assertIn("--artifact must be an existing directory", out)
+
     def test_help_prints_usage(self) -> None:
         for spec in PHASES:
             with self.subTest(phase=spec["key"]):
@@ -439,6 +463,9 @@ class TestProgressReporting(PhaseCase):
         adapters.mkdir()
         self.patch_attr(phaselib, "LAUNCH_DIR", adapters.parent)
         self.patch_attr(phaselib.Phase, "_acceptance", lambda _self, _ws, _names: None)
+        # These tests exercise process/progress handling, not the analysis gate.
+        # Keep its optional `git rev-list` probe out of subprocess accounting.
+        self.patch_attr(phaselib.CodeAnalysisPhase, "check", lambda _self, _ws, _names: True)
         self.config = ProgressConfig(
             poll_seconds=0.005,
             change_report_seconds=0.0,

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -304,16 +304,36 @@ class TestDryRunCommand(PhaseCase):
         # (confirmlib), NOT the single-agent adapter launch.
         rc, out = self.dry_run(BY_KEY["bug_confirmation"])
         self.assertEqual(rc, 0, out)
+        self.assertIn("Max parallel: 4", out)
         self.assertIn("Parallel confirmation", out)
-        self.assertIn("max_parallel=4", out)  # real concurrency default, not the target-concurrency 1
+        self.assertIn("max_parallel=4", out)
         self.assertNotIn("--background", out)  # not the single-agent _launch command
+
+    def test_bug_confirmation_explicit_one_is_a_hard_limit(self) -> None:
+        rc, out = self.dry_run(BY_KEY["bug_confirmation"], extra=["--max-parallel=1"])
+        self.assertEqual(rc, 0, out)
+        self.assertIn("Max parallel: 1", out)
+        self.assertIn("Parallel confirmation", out)
+        self.assertIn("max_parallel=1", out)
+
+    def test_bug_confirmation_legacy_default_stays_one(self) -> None:
+        rc, out = self.dry_run(BY_KEY["bug_confirmation"], extra=["--legacy-confirm"])
+        self.assertEqual(rc, 0, out)
+        self.assertIn("Max parallel: 1", out)
+        self.assertNotIn("Parallel confirmation", out)
 
     def test_bug_confirmation_recheck_stays_single_agent(self) -> None:
         # --recheck always uses the single-agent path, even without --legacy-confirm.
         rc, out = self.dry_run(BY_KEY["bug_confirmation"], extra=["--recheck"])
         self.assertEqual(rc, 0, out)
+        self.assertIn("Max parallel: 1", out)
         self.assertIn("[DRY RUN]", out)  # single-agent adapter launch
         self.assertNotIn("Parallel confirmation", out)
+
+    def test_ordinary_phase_default_max_parallel_stays_one(self) -> None:
+        rc, out = self.dry_run(BY_KEY["code_analysis"])
+        self.assertEqual(rc, 0, out)
+        self.assertIn("Max parallel: 1", out)
 
     def test_max_turns_forwarded_verbatim(self) -> None:
         rc, out = self.dry_run(BY_KEY["code_analysis"], extra=["--max-turns=7"])

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -344,10 +344,13 @@ class TestDryRunCommand(PhaseCase):
         self.assertNotIn("--effort=max", out)
 
     def test_bug_classification_rejects_artifact(self) -> None:
-        # accepts_artifact=False: --artifact is not a known option here.
         rc, out = self.run_phase("bug_classification", ["--artifact=/x", NAME])
         self.assertEqual(rc, 1)
-        self.assertIn("Unknown option", out)
+        self.assertEqual(
+            out,
+            "ERROR: classify does not accept --artifact; this phase reads the existing "
+            ".specula-output/spec/confirmed-bugs.md and does not inspect source code.\n",
+        )
 
 
 class TestRepairAndRecheckModes(PhaseCase):

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -538,6 +538,23 @@ class TestParsing(TmpCwd):
         self.assertIsNone(p.parse_args(["--max-parallel=1", "t|g|l|r"]))
         self.assertEqual(p.max_parallel, "1")
         self.assertIn("--max-parallel=1", p._phase_args(["t"]))
+        self.assertEqual(p._max_parallel_summary(), "1")
+
+    def test_max_parallel_summary_reports_per_finding_default(self) -> None:
+        p = pl.Pipeline()
+        self.assertIsNone(p.parse_args(["t|g|l|r"]))
+        self.assertEqual(
+            p._max_parallel_summary(),
+            "phase defaults (ordinary phases 1 at a time; per-finding confirmation 4 at a time)",
+        )
+
+    def test_max_parallel_summary_reports_legacy_confirmation_default(self) -> None:
+        p = pl.Pipeline()
+        self.assertIsNone(p.parse_args(["--legacy-confirm", "t|g|l|r"]))
+        self.assertEqual(
+            p._max_parallel_summary(),
+            "phase defaults (ordinary phases 1 at a time; legacy confirmation 1 at a time)",
+        )
 
     def test_model_effort_absent_and_explicit_empty_are_distinct(self) -> None:
         absent = pl.Pipeline()

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -527,6 +527,50 @@ class TestParsing(TmpCwd):
         self.assertEqual(p.effort, "high")
         self.assertEqual(p.targets, ["t|g|l|r"])
 
+    def test_artifact_omitted_preserves_auto_discovery(self) -> None:
+        p = pl.Pipeline()
+        self.assertIsNone(p.parse_args(["t|g|l|r"]))
+        self.assertFalse(p._artifact_given)
+        self.assertFalse(any(arg.startswith("--artifact=") for arg in p._phase_args(["t"])))
+
+    def test_valid_artifact_directory_is_forwarded(self) -> None:
+        repo = self.tmp / "repo"
+        repo.mkdir()
+        p = pl.Pipeline()
+
+        self.assertIsNone(p.parse_args([f"--artifact={repo}", "t|g|l|r"]))
+
+        self.assertTrue(p._artifact_given)
+        self.assertEqual(p.artifact, str(repo))
+        self.assertIn(f"--artifact={repo}", p._phase_args(["t"]))
+        self.assertNotIn(f"--artifact={repo}", p._phase_args(["t"], with_artifact=False))
+
+    def test_relative_artifact_is_stable_after_working_directory_changes(self) -> None:
+        repo = self.tmp / "repo"
+        repo.mkdir()
+        p = pl.Pipeline()
+        self.assertIsNone(p.parse_args(["--artifact=repo", "t|g|l|r"]))
+
+        later_cwd = self.tmp / "case-studies" / "t"
+        later_cwd.mkdir(parents=True)
+        os.chdir(later_cwd)
+
+        self.assertEqual(p.artifact, str(repo))
+        self.assertEqual(p.argv, ["--artifact=repo", "t|g|l|r"])
+        self.assertIn(f"--artifact={repo}", p._phase_args(["t"]))
+
+    def test_invalid_artifact_path_is_rejected(self) -> None:
+        file_path = self.tmp / "artifact.txt"
+        file_path.write_text("not a directory\n")
+        for value in ("", str(self.tmp / "missing"), str(file_path)):
+            with self.subTest(value=value):
+                p = pl.Pipeline()
+                err = io.StringIO()
+                with contextlib.redirect_stderr(err):
+                    rc = p.parse_args([f"--artifact={value}", "t|g|l|r"])
+                self.assertEqual(rc, 1)
+                self.assertIn("--artifact must be an existing directory", err.getvalue())
+
     def test_max_parallel_omitted_preserves_phase_defaults(self) -> None:
         p = pl.Pipeline()
         self.assertIsNone(p.parse_args(["t|g|l|r"]))

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -527,6 +527,18 @@ class TestParsing(TmpCwd):
         self.assertEqual(p.effort, "high")
         self.assertEqual(p.targets, ["t|g|l|r"])
 
+    def test_max_parallel_omitted_preserves_phase_defaults(self) -> None:
+        p = pl.Pipeline()
+        self.assertIsNone(p.parse_args(["t|g|l|r"]))
+        self.assertIsNone(p.max_parallel)
+        self.assertFalse(any(a.startswith("--max-parallel=") for a in p._phase_args(["t"])))
+
+    def test_explicit_max_parallel_one_is_forwarded(self) -> None:
+        p = pl.Pipeline()
+        self.assertIsNone(p.parse_args(["--max-parallel=1", "t|g|l|r"]))
+        self.assertEqual(p.max_parallel, "1")
+        self.assertIn("--max-parallel=1", p._phase_args(["t"]))
+
     def test_model_effort_absent_and_explicit_empty_are_distinct(self) -> None:
         absent = pl.Pipeline()
         self.assertIsNone(absent.parse_args(["t"]))

--- a/tests/unit/test_schedulerlib.py
+++ b/tests/unit/test_schedulerlib.py
@@ -221,6 +221,22 @@ class TestLoadQueue(Base):
         s = self.load("a|g/h|Go|r\nb|i/j|Rust|r2")
         self.assertEqual(s.task_targets, ["a|g/h|Go|r", "b|i/j|Rust|r2"])
 
+    def test_scheduler_owned_isolation_flags_rejected(self) -> None:
+        for flag in ("--run-id", "--run-id=shared", "--isolate", "--no-isolate"):
+            with self.subTest(flag=flag):
+                s = self.sched()
+                qf = self.tmp() / "tasks.queue"
+                qf.write_text(f"# comment\n\na|g/h|Go|r\t--agent=codex {flag}\n")
+                s.queue_file = str(qf)
+                with self.assertRaises(SystemExit) as cm:
+                    s.load_queue()
+                self.assertEqual(cm.exception.code, 1)
+                self.assertEqual(s.lines[-1], f"Queue line 3: scheduler-reserved flag {flag}")
+
+    def test_similar_queue_flag_is_not_reserved(self) -> None:
+        s = self.load("a|g/h|Go|r\t--run-id-suffix=shared\n")
+        self.assertEqual(s.task_flags, ["--run-id-suffix=shared"])
+
     def test_missing_queue_file(self) -> None:
         s = self.sched()
         s.queue_file = "/nonexistent/tasks.queue"


### PR DESCRIPTION
Replace the minimal skills-only Usage page with a self-contained guide for the current Specula workflow.

- Document setup through `uv run specula setup`
- Cover Linux, macOS, and WSL2 platform requirements
- Clarify mandatory, setup-installed, and optional sandbox dependencies
- Document supported agents, authentication, model, and effort behavior
- Explain full-pipeline and individual-phase commands
- Cover isolated workspaces, outputs, resuming, and batch runs
- Document SRT/Bubblewrap requirements and sandbox write permissions
- Describe current CLI flags, progress reporting, and logs