### PR TITLE
small things fixed before release

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ codex mcp add tracedebugger \
 
 ## Auto Mode
 
-Point Specula to the target software repo, with a name (`$mysys`) for the run:
+Give the target a name and point Specula to its local repository:
 
 ```bash
-specula run --artifact=/path/to/repo mysys
+specula run mysys --artifact=/path/to/repo
 ```
 
 Outputs are stored in `runs/<run-id>`. 

--- a/README.md
+++ b/README.md
@@ -47,19 +47,20 @@ cd tools/trace_debugger
 python3 -m venv .venv
 . .venv/bin/activate
 pip install -r requirements.txt
+cd ../..  # return to the Specula repository root
 
 # for Claude Code
 claude mcp add --transport stdio --scope project \
-    --env SPECULA_ROOT=$PWD \
-    tracedebugger -- \
-    $PWD/tools/trace_debugger/.venv/bin/python \
-    $PWD/tools/trace_debugger/mcp_server.py
+    tracedebugger \
+    --env "SPECULA_ROOT=$PWD" -- \
+    "$PWD/tools/trace_debugger/.venv/bin/python" \
+    "$PWD/tools/trace_debugger/mcp_server.py"
 
 # for Codex
 codex mcp add tracedebugger \
-	--env SPECULA_ROOT=$PWD -- \
-	$PWD/tools/trace_debugger/.venv/bin/python \
-	$PWD/tools/trace_debugger/mcp_server.py
+	--env "SPECULA_ROOT=$PWD" -- \
+	"$PWD/tools/trace_debugger/.venv/bin/python" \
+	"$PWD/tools/trace_debugger/mcp_server.py"
 ```
 
 </details>

--- a/src/specula/stop_gate.py
+++ b/src/specula/stop_gate.py
@@ -216,6 +216,10 @@ def _registered_pid_files(state_dir: Path) -> tuple[list[Path], bool]:
         return [], True
 
 
+def _is_registered_pid_file(pid_file: Path) -> bool:
+    return pid_file.parent.name == BACKGROUND_PID_DIRNAME and pid_file.parent.parent.name == STATE_DIRNAME
+
+
 def _find_pid_files(work_dir: Path) -> tuple[list[Path], bool]:
     """Find registered and ordinary PID files without topology false blocks.
 
@@ -260,7 +264,7 @@ def _live_pid_files(work_dir: Path) -> tuple[list[tuple[Path, int]], bool]:
     live: list[tuple[Path, int]] = []
     pid_files, incomplete = _find_pid_files(work_dir)
     for pf in pid_files:
-        registered = pf.parent.name == BACKGROUND_PID_DIRNAME and pf.parent.parent.name == STATE_DIRNAME
+        registered = _is_registered_pid_file(pf)
         try:
             text = pf.read_text().strip().splitlines()[0].strip()
         except (OSError, IndexError):
@@ -317,11 +321,18 @@ def decide(phase: str, work_dir: Path) -> tuple[bool, str]:
     if live:
         jobs = ", ".join(f"{pf} (pid {pid})" for pf, pid in live)
         waiter = SPECULA_ROOT / "scripts" / "infra" / "wait_for_pid.sh"
+        waiter_arg = shlex.quote(str(waiter))
+        first_pid_file, first_pid = live[0]
+        wait_target = (
+            f"--pid {first_pid}"
+            if _is_registered_pid_file(first_pid_file)
+            else f"--pid-file {shlex.quote(str(first_pid_file))}"
+        )
         return False, (
             f"Background job(s) you started are still running: {jobs}. "
             f"Do NOT stop while they run unobserved — nothing re-invokes you when they finish. "
             f"Wait on each in the foreground now, e.g. "
-            f"`bash {waiter} --pid-file {shlex.quote(str(live[0][0]))} --timeout 45m`, "
+            f"`bash {waiter_arg} {wait_target} --timeout 45m`, "
             f"then harvest the results and finish the phase deliverables. "
             f"If you are genuinely unable to proceed, kill the jobs and write "
             f"{work_dir / BLOCKED_LOCATIONS[0]} describing what you tried and why — "

--- a/tests/unit/test_stop_gate.py
+++ b/tests/unit/test_stop_gate.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import shlex
 import subprocess
 import sys
 import unittest
@@ -195,6 +196,7 @@ class TestLivePids(GateCase):
         self.assertFalse(allow)
         self.assertIn("MC_run1.out.pid", reason)
         self.assertIn("wait_for_pid.sh", reason)
+        self.assertIn(f"--pid-file {self.wd / 'spec' / 'output' / 'MC_run1.out.pid'}", reason)
 
     def test_live_background_job_at_finding_root_blocks(self) -> None:
         self.deliver()
@@ -295,6 +297,40 @@ class TestLivePids(GateCase):
 
         self.assertFalse(allow)
         self.assertIn(f"{proc.pid}.pid", reason)
+        self.assertIn(f"--pid {proc.pid}", reason)
+        self.assertNotIn("--pid-file", reason)
+
+    def test_registered_job_wait_command_is_executable(self) -> None:
+        self.deliver()
+        proc = subprocess.Popen(["sleep", "300"])
+        self.addCleanup(proc.wait)
+        self.addCleanup(proc.kill)
+        outside = self.wd / "states" / "external-log"
+        outside.mkdir(parents=True)
+        original_pid_file = outside / "job.out.pid"
+        original_pid_file.write_text(f"{proc.pid}\n")
+        registry = self.wd / sg.STATE_DIRNAME / sg.BACKGROUND_PID_DIRNAME
+        registry.mkdir(parents=True)
+        (registry / f"{proc.pid}.pid").write_text(f"{proc.pid}\n{original_pid_file}\n")
+
+        allow, reason = sg.decide("spec_validation", self.wd)
+
+        self.assertFalse(allow)
+        command = reason.split("`", 2)[1]
+        waiter = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        try:
+            assert waiter.stdout is not None
+            first_line = waiter.stdout.readline()
+            self.assertIn(f"waiting on pid {proc.pid}", first_line)
+            proc.terminate()
+            proc.wait(timeout=5)
+            stdout, stderr = waiter.communicate(timeout=5)
+        finally:
+            if waiter.poll() is None:
+                waiter.kill()
+                waiter.wait()
+        self.assertEqual(waiter.returncode, 0, stderr)
+        self.assertIn(f"pid {proc.pid} exited", stdout)
 
     def test_malformed_managed_registry_blocks_instead_of_hiding_job(self) -> None:
         self.deliver()


### PR DESCRIPTION
## Summary

- fix stop-gate wait instructions for registered background jobs while preserving ordinary PID-file behavior
- fix manual trace debugger MCP setup paths and Claude/Codex command syntax
- add regression coverage that executes the printed wait command