### PR TITLE
Make CLI help safe and consistent

### DIFF
--- a/scripts/infra/setup.sh
+++ b/scripts/infra/setup.sh
@@ -4,6 +4,32 @@
 
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage:
+  specula setup
+
+Install Specula's TLA+ tools, Python environments, agent skills, and MCP integrations.
+
+This interactive command may download dependencies, build local tools, and
+update agent configuration.
+
+Options:
+  -h, --help  Show this help and exit
+EOF
+}
+
+if (( $# == 0 )); then
+  :
+elif (( $# == 1 )) && [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  usage
+  exit 0
+else
+  printf "specula setup: unexpected argument '%s'\n\n" "$1" >&2
+  usage >&2
+  exit 2
+fi
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'

--- a/scripts/infra/setup.sh
+++ b/scripts/infra/setup.sh
@@ -25,7 +25,11 @@ elif (( $# == 1 )) && [[ "$1" == "-h" || "$1" == "--help" ]]; then
   usage
   exit 0
 else
-  printf "specula setup: unexpected argument '%s'\n\n" "$1" >&2
+  unexpected="$1"
+  if [[ "$unexpected" == "-h" || "$unexpected" == "--help" ]]; then
+    unexpected="$2"
+  fi
+  printf "specula setup: unexpected argument '%s'\n\n" "$unexpected" >&2
   usage >&2
   exit 2
 fi

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -983,15 +983,15 @@ Batch launcher: spawn one agent per target system for code analysis.
 Each agent follows the code-analysis skill methodology and produces a modeling brief.
 
 Usage:
-  bash scripts/launch/launch_code_analysis.sh [options] "name|github|lang|reference" [...]
+  specula analyze [options] "name|github|lang|reference" [...]
 
 Single-target (run from your project directory):
   cd my-project
-  bash ~/Specula/scripts/launch/launch_code_analysis.sh "myproject|me/myproject|Go|Raft"
+  specula analyze "myproject|me/myproject|Go|Raft"
 
 Batch (run from a directory containing multiple targets):
   cd case-studies
-  bash ../scripts/launch/launch_code_analysis.sh \
+  specula analyze \
     "braft|brpc/braft|C++|Raft (Ongaro 2014)" \
     "sofa-jraft|sofastack/sofa-jraft|Java|Raft (Ongaro 2014)"
 
@@ -1102,15 +1102,15 @@ class SpecGenerationPhase(Phase):
     key = "spec_generation"
     title = "Specula — Spec Generation Batch Runner"
     usage = r"""
-Batch launcher: spawn one Claude Code agent per target system for TLA+ spec generation.
+Batch launcher: spawn one agent per target system for TLA+ spec generation.
 Each agent follows the spec-generation skill methodology and produces base/MC/Trace specs.
 
 Usage:
-  bash scripts/launch/launch_spec_generation.sh [options] "name" [...]
+  specula specgen [options] "name" [...]
 
 Example:
-  bash scripts/launch/launch_spec_generation.sh cometbft
-  bash scripts/launch/launch_spec_generation.sh braft sofa-jraft dragonboat
+  specula specgen cometbft
+  specula specgen braft sofa-jraft dragonboat
 
 Options:
   --dry-run           Print commands without executing
@@ -1124,7 +1124,7 @@ Options:
   --artifact=PATH     Explicit path to the artifact repo (bypasses auto-detection)
 
 Prerequisites:
-  - claude CLI installed and authenticated
+  - Selected agent CLI installed and authenticated
   - modeling-brief.md exists at <name>/.specula-output/modeling-brief.md
   - Source repo cloned at <name>/artifact/<repo>/ (or supplied via --artifact)
 
@@ -1233,16 +1233,16 @@ class HarnessGenerationPhase(Phase):
     key = "harness_generation"
     title = "Specula — Harness Generation (Phase 2.5)"
     usage = r"""
-Batch launcher: spawn one Claude Code agent per target system for harness generation (Phase 2.5).
+Batch launcher: spawn one agent per target system for harness generation (Phase 2.5).
 Each agent instruments the source code and collects NDJSON traces for spec validation.
 
 Usage:
-  bash scripts/launch/launch_harness_generation.sh [options] "name" [...]
+  specula harness [options] "name" [...]
 
 Example:
-  bash scripts/launch/launch_harness_generation.sh cometbft
-  bash scripts/launch/launch_harness_generation.sh braft sofa-jraft dragonboat
-  bash scripts/launch/launch_harness_generation.sh --artifact=/path/to/repo myproject
+  specula harness cometbft
+  specula harness braft sofa-jraft dragonboat
+  specula harness --artifact=/path/to/repo myproject
 
 Options:
   --dry-run           Print commands without executing
@@ -1256,7 +1256,7 @@ Options:
   --artifact=PATH     Explicit path to artifact repo (overrides auto-detection)
 
 Prerequisites:
-  - claude CLI installed and authenticated
+  - Selected agent CLI installed and authenticated
   - Phase 2 complete: spec/base.tla, spec/Trace.tla, spec/instrumentation-spec.md
   - Source repo at <name>/artifact/<repo>/ or specified via --artifact
 
@@ -1368,10 +1368,10 @@ dispositions receive no severity. No new analysis, no repro work, no
 modification to confirmed-bugs.md.
 
 Usage:
-  bash scripts/launch/launch_bug_classification.sh [options] "name" [...]
+  specula classify [options] "name" [...]
 
 Example:
-  bash scripts/launch/launch_bug_classification.sh libgomp_3 autobahn_3
+  specula classify libgomp_3 autobahn_3
 
 Options:
   --dry-run           Print commands without executing
@@ -1388,7 +1388,7 @@ Prerequisites:
 
 """
     check_header = "Checking prerequisites..."
-    check_fail_msg = "ERROR: Missing prerequisites. Run Phase 4a (launch_bug_confirmation.sh) first."
+    check_fail_msg = "ERROR: Missing prerequisites. Run Phase 4a ('specula confirm') first."
     accepts_artifact = False  # this launcher takes no --artifact
     artifact_rejection_message = (
         "ERROR: classify does not accept --artifact; this phase reads the existing "
@@ -1476,17 +1476,17 @@ class SpecValidationPhase(Phase):
     key = "spec_validation"
     title = "Specula — Spec Validation Batch Runner"
     usage = r"""
-Batch launcher: spawn one Claude Code agent per target system for spec validation.
+Batch launcher: spawn one agent per target system for spec validation.
 Each agent iteratively runs trace validation and invariant checking using existing
 skills until both pass. Harness and traces must already exist (Phase 2.5).
 
 Usage:
-  bash scripts/launch/launch_spec_validation.sh [options] "name" [...]
+  specula validate [options] "name" [...]
 
 Example:
-  bash scripts/launch/launch_spec_validation.sh cometbft
-  bash scripts/launch/launch_spec_validation.sh braft sofa-jraft dragonboat
-  bash scripts/launch/launch_spec_validation.sh --artifact=/path/to/repo myproject
+  specula validate cometbft
+  specula validate braft sofa-jraft dragonboat
+  specula validate --artifact=/path/to/repo myproject
 
 Options:
   --dry-run           Print commands without executing
@@ -1633,10 +1633,10 @@ per finding, in parallel — see confirmlib.py). `--legacy-confirm` reverts to t
 single agent that consolidates and reproduces every finding in one context.
 
 Usage:
-  bash scripts/launch/launch_bug_confirmation.sh [options] "name" [...]
+  specula confirm [options] "name" [...]
 
 Example:
-  bash scripts/launch/launch_bug_confirmation.sh hashicorp-raft nuraft
+  specula confirm hashicorp-raft nuraft
 
 Options:
   --dry-run           Print commands without executing
@@ -1965,11 +1965,11 @@ class ReviewPhase(Phase):
 
     key = "review"
     usage = r"""
-Run a Claude Code review agent on phase outputs.
-Used by launch_pipeline.sh between phases. Can also be used standalone.
+Run a review agent on phase outputs.
+Used by specula run between phases. Can also be used standalone.
 
 Usage:
-  bash scripts/launch/launch_review.sh <phase> <name> [name ...]
+  specula review <phase> <name> [name ...]
 
 Options (after <phase>):
   --agent=NAME        Agent adapter to use (default: claude-code)
@@ -1983,12 +1983,17 @@ Phases:
   validation  — Review validation results (validation-report.md)
 
 Output:
-  .specula-output/review-<phase>.md
+  analysis:    .specula-output/review-analysis.md
+  specgen:     .specula-output/spec/review-specgen.md
+  validation:  .specula-output/spec/review-validation.md
 
 """
 
     def run(self, argv: list[str]) -> int:
         phase = argv[0] if argv else ""
+        if phase in ("--help", "-h"):
+            sys.stdout.write(self.usage)
+            return 0
         agent = "claude-code"
         claude_alias = os.environ.get("CLAUDE_ALIAS") or "claude"
         model: str | None = None

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -69,13 +69,13 @@ Runs all phases with optional review agents between each phase.
 All agent logs and review results are saved for inspection.
 
 Usage:
-  bash scripts/launch/launch_pipeline.sh [options] "name|github|lang|reference" [...]
+  specula run [options] "name|github|lang|reference" [...]
 
 Example (single system):
-  bash scripts/launch/launch_pipeline.sh "cometbft|cometbft/cometbft|Go|Tendermint BFT"
+  specula run "cometbft|cometbft/cometbft|Go|Tendermint BFT"
 
 Example (multiple systems):
-  bash scripts/launch/launch_pipeline.sh \\
+  specula run \\
     "braft|brpc/braft|C++|Raft (Ongaro 2014)" \\
     "sofa-jraft|sofastack/sofa-jraft|Java|Raft (Ongaro 2014)"
 

--- a/src/specula/schedulerlib.py
+++ b/src/specula/schedulerlib.py
@@ -91,7 +91,7 @@ Pauses when usage exceeds threshold, waits for 5-hour window reset, resumes.
 Stops after exhausting MAX_WINDOWS resets.
 
 Usage:
-  bash scripts/exp/scheduler.sh [options]
+  specula batch [options]
 
 Options:
   --workers N         Parallel workers (default: 3)
@@ -100,16 +100,17 @@ Options:
   --windows N         Max resets to wait through (default: 3)
   --queue FILE     Task queue file (default: scripts/exp/tasks.queue)
   --max-turns N    Max agent turns per task (default: 0 = unlimited)
+  --prompt FILE     Copy extra instructions into every task workspace
   --setup-only     Only clone repos and write prompts, don't run pipeline
   --dry-run        Print commands without executing
   --claude-alias NAME  Claude CLI profile (default: claude).
-                       Forwarded to launch_pipeline.sh and used by usage.sh
-                       so quota checks target the same account.
+                       Forwarded to specula run so quota checks target the
+                       same account.
 
 Queue format (tab-separated):
   name|github|lang|reference[TAB]flags
 
-  - flags: optional launch_pipeline.sh flags (e.g. --skip-analysis)
+  - flags: optional specula run flags (e.g. --skip-analysis)
   - --run-id, --isolate, and --no-isolate are reserved for the scheduler
 
 Workspace: every task's pipeline runs isolated under runs/<run>-<n>-<name>/

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -120,3 +120,21 @@ class TestShim(unittest.TestCase):
             text=True,
         )
         self.assertEqual((r.returncode, r.stdout, r.stderr), (0, BASH_HELP, ""))
+
+    def test_subcommand_help_uses_public_cli_and_succeeds(self) -> None:
+        for command, _, _ in cli.COMMANDS:
+            if command == "setup":
+                continue  # setup's full public path is exercised hermetically in test_setup_security.py
+            with self.subTest(command=command):
+                r = subprocess.run(
+                    ["bash", str(REPO_ROOT / "specula"), command, "--help"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                self.assertEqual((r.returncode, r.stderr), (0, ""), r.stdout)
+                self.assertIn(f"specula {command}", r.stdout)
+                self.assertNotIn("bash scripts/", r.stdout)
+                self.assertNotIn("launch_", r.stdout)
+                self.assertNotIn("Claude Code agent", r.stdout)
+                self.assertNotIn("claude CLI installed", r.stdout)

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -138,7 +138,7 @@ PHASES: list[PhaseSpec] = [
         "key": "bug_classification",
         "artifact": False,
         "inputs": ["spec/confirmed-bugs.md"],
-        "fail": "Run Phase 4a (launch_bug_confirmation.sh) first.",
+        "fail": "Run Phase 4a ('specula confirm') first.",
         "ok": "All prerequisites OK.",
         "log": "bug-classification.log",
         "prompt": ".bug-classification-prompt.md",
@@ -148,6 +148,14 @@ PHASES: list[PhaseSpec] = [
     },
 ]
 BY_KEY = {p["key"]: p for p in PHASES}
+PUBLIC_COMMANDS = {
+    "code_analysis": "analyze",
+    "spec_generation": "specgen",
+    "harness_generation": "harness",
+    "spec_validation": "validate",
+    "bug_confirmation": "confirm",
+    "bug_classification": "classify",
+}
 
 
 class PhaseCase(unittest.TestCase):
@@ -563,7 +571,9 @@ class TestArgErrors(PhaseCase):
                 rc, out = self.run_phase(spec["key"], ["--help"])
                 self.assertEqual(rc, 0)
                 self.assertIn("Usage:", out)
-                self.assertIn(f"launch_{spec['key']}.sh", out)
+                self.assertIn(f"specula {PUBLIC_COMMANDS[spec['key']]}", out)
+                self.assertNotIn("bash scripts/", out)
+                self.assertNotIn("launch_", out)
                 self.assertIn("--model=NAME", out)
                 self.assertIn("--effort=LEVEL", out)
 
@@ -1904,11 +1914,17 @@ class TestReviewPhase(PhaseCase):
         self.assertIn("Unknown agent 'bogus'", out)
 
     def test_help(self) -> None:
-        rc, out = self.run_phase("review", ["analysis", "--help"])
-        self.assertEqual(rc, 0)
-        self.assertIn("Run a Claude Code review agent", out)
-        self.assertIn("--model=NAME", out)
-        self.assertIn("--effort=LEVEL", out)
+        for argv in (["--help"], ["-h"], ["analysis", "--help"], ["analysis", "-h"]):
+            with self.subTest(argv=argv):
+                rc, out = self.run_phase("review", argv)
+                self.assertEqual(rc, 0)
+                self.assertIn("Run a review agent", out)
+                self.assertIn("specula review <phase>", out)
+                self.assertIn("--model=NAME", out)
+                self.assertIn("--effort=LEVEL", out)
+                self.assertIn(".specula-output/review-analysis.md", out)
+                self.assertIn(".specula-output/spec/review-specgen.md", out)
+                self.assertIn(".specula-output/spec/review-validation.md", out)
 
     def test_review_streams_activity_through_shared_monitor(self) -> None:
         event = json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "reviewing"}})

--- a/tests/unit/test_schedulerlib.py
+++ b/tests/unit/test_schedulerlib.py
@@ -136,6 +136,7 @@ class TestParseArgs(Base):
             rc = s.parse_args(["--help", "--bogus"])  # --bogus never reached
         self.assertEqual(rc, 0)
         self.assertIn("Overnight batch scheduler", out.getvalue())
+        self.assertIn("--prompt FILE", out.getvalue())
         self.assertIn("Queue format (tab-separated):", out.getvalue())
 
     def test_unknown_flag(self) -> None:

--- a/tests/unit/test_setup_security.py
+++ b/tests/unit/test_setup_security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -12,6 +13,111 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SETUP_SCRIPT = REPO_ROOT / "scripts" / "infra" / "setup.sh"
 SKILL_INSTALLER = REPO_ROOT / "src" / "specula" / "skill_install.py"
+SETUP_HELP = """\
+Usage:
+  specula setup
+
+Install Specula's TLA+ tools, Python environments, agent skills, and MCP integrations.
+
+This interactive command may download dependencies, build local tools, and
+update agent configuration.
+
+Options:
+  -h, --help  Show this help and exit
+"""
+
+
+class TestSetupHelp(unittest.TestCase):
+    def make_checkout(self, root: Path) -> tuple[Path, Path, dict[str, str], Path]:
+        for relative in (
+            Path("specula"),
+            Path("src/specula/cli.py"),
+            Path("scripts/infra/setup.sh"),
+        ):
+            destination = root / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(REPO_ROOT / relative, destination)
+
+        home = root / "home"
+        home.mkdir()
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        sentinel = root / "setup-command-ran"
+        stub = bin_dir / "stub"
+        stub.write_text('#!/usr/bin/env bash\nprintf "called: %s\\n" "$0" >> "$SETUP_SENTINEL"\n')
+        stub.chmod(0o755)
+        for command in ("java", "pip3", "wget", "curl", "mvn", "claude", "codex"):
+            (bin_dir / command).symlink_to(stub.name)
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["PATH"] = f"{bin_dir}:{env['PATH']}"
+        env["SETUP_SENTINEL"] = str(sentinel)
+        return root / "specula", root / "scripts/infra/setup.sh", env, sentinel
+
+    def assert_no_setup_side_effects(self, root: Path, env: dict[str, str], sentinel: Path) -> None:
+        self.assertFalse(sentinel.exists())
+        self.assertEqual(list(Path(env["HOME"]).iterdir()), [])
+        for path in (
+            root / "lib",
+            root / "tools/trace_debugger/.venv",
+            root / "tools/spec_analyzer/.venv",
+            root / "tools/inv_checking_tool/.venv",
+            root / "tools/cfa/target",
+            root / ".specula-codex",
+            root / ".claude",
+            root / ".agents",
+            root / ".github",
+        ):
+            self.assertFalse(path.exists(), path)
+
+    def test_help_exits_before_any_setup_side_effect(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            launcher, setup, env, sentinel = self.make_checkout(root)
+
+            for command in (
+                ["/bin/bash", str(setup), "--help"],
+                ["/bin/bash", str(setup), "-h"],
+                ["/bin/bash", str(launcher), "setup", "--help"],
+                ["/bin/bash", str(launcher), "setup", "-h"],
+            ):
+                with self.subTest(command=command):
+                    result = subprocess.run(
+                        command,
+                        cwd=root,
+                        env=env,
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
+                        check=False,
+                    )
+                    self.assertEqual((result.returncode, result.stdout, result.stderr), (0, SETUP_HELP, ""))
+                    self.assert_no_setup_side_effects(root, env, sentinel)
+
+    def test_unknown_argument_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            launcher, setup, env, sentinel = self.make_checkout(root)
+
+            for arguments in (["--hlep"], [""], ["--help", "extra"], ["", "--hlep"]):
+                expected_error = f"specula setup: unexpected argument '{arguments[0]}'\n\n" + SETUP_HELP
+                for command in (
+                    ["/bin/bash", str(setup), *arguments],
+                    ["/bin/bash", str(launcher), "setup", *arguments],
+                ):
+                    with self.subTest(command=command):
+                        result = subprocess.run(
+                            command,
+                            cwd=root,
+                            env=env,
+                            capture_output=True,
+                            text=True,
+                            timeout=5,
+                            check=False,
+                        )
+                        self.assertEqual((result.returncode, result.stdout, result.stderr), (2, "", expected_error))
+                        self.assert_no_setup_side_effects(root, env, sentinel)
 
 
 class TestSetupPythonIsolation(unittest.TestCase):

--- a/tests/unit/test_setup_security.py
+++ b/tests/unit/test_setup_security.py
@@ -77,10 +77,10 @@ class TestSetupHelp(unittest.TestCase):
             launcher, setup, env, sentinel = self.make_checkout(root)
 
             for command in (
-                ["/bin/bash", str(setup), "--help"],
-                ["/bin/bash", str(setup), "-h"],
-                ["/bin/bash", str(launcher), "setup", "--help"],
-                ["/bin/bash", str(launcher), "setup", "-h"],
+                ["bash", str(setup), "--help"],
+                ["bash", str(setup), "-h"],
+                ["bash", str(launcher), "setup", "--help"],
+                ["bash", str(launcher), "setup", "-h"],
             ):
                 with self.subTest(command=command):
                     result = subprocess.run(
@@ -100,11 +100,17 @@ class TestSetupHelp(unittest.TestCase):
             root = Path(tmp)
             launcher, setup, env, sentinel = self.make_checkout(root)
 
-            for arguments in (["--hlep"], [""], ["--help", "extra"], ["", "--hlep"]):
-                expected_error = f"specula setup: unexpected argument '{arguments[0]}'\n\n" + SETUP_HELP
+            for arguments, unexpected in (
+                (["--hlep"], "--hlep"),
+                ([""], ""),
+                (["--help", "extra"], "extra"),
+                (["-h", "extra"], "extra"),
+                (["", "--hlep"], ""),
+            ):
+                expected_error = f"specula setup: unexpected argument '{unexpected}'\n\n" + SETUP_HELP
                 for command in (
-                    ["/bin/bash", str(setup), *arguments],
-                    ["/bin/bash", str(launcher), "setup", *arguments],
+                    ["bash", str(setup), *arguments],
+                    ["bash", str(launcher), "setup", *arguments],
                 ):
                     with self.subTest(command=command):
                         result = subprocess.run(


### PR DESCRIPTION
## Summary

- make `specula setup -h/--help` side-effect-free and reject unexpected arguments
- make `specula review -h/--help` work from the public CLI
- align subcommand help examples and output paths with the public commands
- add hermetic setup and CLI help contract tests