### PR TITLE
Fix setup agent detection and artifact paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Open your coding agent in the Specula directory. The workflow is a sequence of s
 
 `code-analysis` → `spec-generation` → `harness-generation` → `validation-workflow` → `bug-confirmation`
 
-(Codex will use `$code-analysis`, `$spec-generation`, etc.)
+(Codex uses `$code-analysis`, `$spec-generation`, etc. after choosing `y` in `specula setup`, or `$specula-codex:code-analysis`, `$specula-codex:spec-generation`, etc. in plugin mode.)
 
 To start, tell the agent your target and invoke the first skill:
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -68,7 +68,9 @@ specula setup
 
 Install with `-e` (editable): the `specula` command dispatches to scripts inside the checkout, so it must stay linked to it.
 
-Setup downloads the TLA+ JARs, builds the CFA tool, prepares the MCP tool environments, and offers integration for each supported agent. It prompts for global or project-local skill installation. Codex users can choose the skills/MCP setup or the generated Specula plugin.
+Setup downloads the TLA+ JARs, builds the CFA tool, prepares the MCP tool environments, and offers integration for each supported agent CLI found on `PATH`. It reports and skips any missing agent CLI instead of prompting for it. Setup prompts for global or project-local skill installation when that choice applies.
+
+For Codex, choose `y` to install skills and register MCP servers separately. Choose `plugin` to bundle the skills and MCP tools as `specula-codex@specula`, with cleaner namespacing and easier removal. Rerun `specula setup` and choose `plugin` again to update it.
 
 More precisely, setup manages:
 
@@ -78,7 +80,7 @@ More precisely, setup manages:
 | CFA transformer | Builds it with Maven |
 | MCP Python packages | Creates tool-specific virtual environments and installs `mcp` and `jsonschema` where required |
 | Claude Code | Installs skills and registers all three MCP servers |
-| Codex | Installs skills and MCP servers, or generates/updates the Specula plugin |
+| Codex | `y` installs skills and MCP servers separately; `plugin` generates or updates `specula-codex@specula` |
 | GitHub Copilot CLI | Installs skills and, with Copilot CLI 1.0.21+, registers all three MCP servers |
 
 Copilot MCP registration is user-level and follows `COPILOT_HOME`; the global/local setup choice controls only where skills are installed. Setup leaves an existing same-named MCP server unchanged and reports the conflict instead of overwriting it. Older Copilot CLI versions still install the skills, but MCP registration is skipped with an upgrade warning.

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -12,17 +12,19 @@ When using WSL2, install the prerequisites and agent CLI inside WSL2, then clone
 
 ### Requirements
 
-| Dependency | Used for | Installed by `specula setup`? |
-|---|---|---|
-| [uv](https://docs.astral.sh/uv/) | Installing the `specula` command | No |
-| Python 3.10+ with `pip` and `venv` | CLI, launchers, MCP tool environments | No |
-| JDK 21+ and Maven | TLC, SANY, and building the CFA tool | No |
-| Git and Bash | Source/history analysis, worktrees, and launch scripts | No |
-| Standard POSIX utilities (`tee`, `tail`, `du`, and others) | Logging and process coordination | No |
-| `curl` or `wget` | Downloading TLA+ JARs during setup | No |
-| GitHub CLI (`gh`) | Issue and repository research | No |
-| Claude Code, Codex, or GitHub Copilot CLI | Agent execution | No |
-| Target language toolchain and test dependencies | Harness generation and bug reproduction | No |
+The dependencies below are not installed by `specula setup`; install them separately as needed.
+
+| Dependency | Used for |
+|---|---|
+| [uv](https://docs.astral.sh/uv/) | Installing the `specula` command |
+| Python 3.10+ with `pip` and `venv` | CLI, launchers, MCP tool environments |
+| JDK 21+ and Maven | TLC, SANY, and building the CFA tool |
+| Git and Bash | Source/history analysis, worktrees, and launch scripts |
+| Standard POSIX utilities (`tee`, `tail`, `du`, and others) | Logging and process coordination |
+| `curl` or `wget` | Downloading TLA+ JARs during setup |
+| GitHub CLI (`gh`) | Issue and repository research |
+| Claude Code, Codex, or GitHub Copilot CLI | Agent execution |
+| Target language toolchain and test dependencies | Harness generation and bug reproduction |
 
 The first setup needs network access to GitHub, PyPI, and Maven Central. Agent runs also need access to the selected model provider and any remote repositories the analysis uses. Claude subscription quota monitoring specifically uses `curl`; if it is unavailable, the quota check warns and fails open rather than stopping the pipeline.
 

--- a/scripts/infra/setup.sh
+++ b/scripts/infra/setup.sh
@@ -91,10 +91,13 @@ ask_scope() {
 
 ask_codex_install() {
   local answer
+  echo "  y: install skills and register MCP servers separately." >&2
+  echo "  plugin: bundle skills and MCP tools as specula-codex@specula for cleaner namespacing and easier removal." >&2
+  echo "          Rerun specula setup and choose plugin again to update it." >&2
   while true; do
     read -rp "$(echo -e "${BLUE}[?]${NC} Install Specula for Codex? (y/n/plugin): ")" answer
     case "$answer" in
-      [Yy]|[Yy][Ee][Ss]) echo "legacy"; return 0 ;;
+      [Yy]|[Yy][Ee][Ss]) echo "separate"; return 0 ;;
       [Nn]|[Nn][Oo]) echo "skip"; return 0 ;;
       [Pp]|[Pp][Ll][Uu][Gg][Ii][Nn]) echo "plugin"; return 0 ;;
       *) echo "  Please answer y, n, or plugin." >&2 ;;
@@ -185,7 +188,7 @@ setup_codex_plugin() {
     --project-root "$project_root" \
     --plugin-root "$plugin_root"
   print_success "Codex plugin configured: specula-codex@specula"
-  print_status "Rerun this setup script and choose 'plugin' to update the Codex plugin."
+  print_status "Rerun specula setup and choose 'plugin' again to update the Codex plugin."
 }
 
 setup_python_tool_env() {
@@ -374,7 +377,9 @@ MCP_SERVERS=(
 
 # --- Claude Code ---
 echo -e "${BLUE}[1/3] Claude Code${NC}"
-if ask_yn "Install Specula for Claude Code?"; then
+if ! command_exists claude; then
+  print_status "Claude Code CLI not found on PATH; skipping."
+elif ask_yn "Install Specula for Claude Code?"; then
   scope="$(ask_scope "Claude Code")"
   if [[ "$scope" == "global" ]]; then
     setup_skills "$CLAUDE_USER_CONFIG_DIR/skills" "$SKILLS_SOURCE"
@@ -400,9 +405,13 @@ echo ""
 
 # --- Codex ---
 echo -e "${BLUE}[2/3] Codex${NC}"
-codex_install="$(ask_codex_install)"
+if command_exists codex; then
+  codex_install="$(ask_codex_install)"
+else
+  codex_install="missing"
+fi
 case "$codex_install" in
-  legacy)
+  separate)
     scope="$(ask_scope "Codex")"
     if [[ "$scope" == "global" ]]; then
       setup_skills "$HOME/.agents/skills" "$SKILLS_SOURCE" --legacy-root "$HOME/.codex/skills"
@@ -421,12 +430,17 @@ case "$codex_install" in
   skip)
     print_status "Skipped Codex."
     ;;
+  missing)
+    print_status "Codex CLI not found on PATH; skipping."
+    ;;
 esac
 echo ""
 
 # --- Copilot CLI ---
 echo -e "${BLUE}[3/3] GitHub Copilot CLI${NC}"
-if ask_yn "Install Specula for GitHub Copilot CLI?"; then
+if ! command_exists copilot; then
+  print_status "GitHub Copilot CLI not found on PATH; skipping."
+elif ask_yn "Install Specula for GitHub Copilot CLI?"; then
   scope="$(ask_scope "Copilot CLI")"
   if [[ "$scope" == "global" ]]; then
     setup_skills \

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -110,6 +110,26 @@ def _logical_cwd() -> Path:
     return Path.cwd()
 
 
+def _normalize_artifact_dir(raw: str) -> str | None:
+    """Expand and stabilize an explicit ``--artifact`` directory.
+
+    ``~`` after ``--artifact=`` is passed through literally by the shell, so
+    expand it here before validation.  ``Path.expanduser()`` raises
+    ``RuntimeError`` when a home directory cannot be resolved; path inspection
+    can also fail with ``OSError``.  Both mean the CLI should report its usual
+    invalid-directory error instead of exposing a traceback.
+    """
+    if not raw:
+        return None
+    try:
+        path = Path(raw).expanduser()
+        if not path.is_dir():
+            return None
+        return str(path.resolve())
+    except (OSError, RuntimeError):
+        return None
+
+
 def _grep_num(text: str, prefix: str) -> str:
     """First integer on the first line starting with `prefix`, else '?' — mirrors
     bash `grep -E "^prefix" | grep -oE '[0-9]+' | head -1`."""
@@ -450,9 +470,12 @@ class Phase:
             else:
                 targets.append(arg)
 
-        if artifact_provided and (not artifact or not Path(artifact).is_dir()):
-            print(f"ERROR: --artifact must be an existing directory: {artifact}")
-            return 1
+        if artifact_provided:
+            normalized_artifact = _normalize_artifact_dir(artifact)
+            if normalized_artifact is None:
+                print(f"ERROR: --artifact must be an existing directory: {artifact}")
+                return 1
+            artifact = normalized_artifact
 
         option_error = self.validate_options(extra)
         if option_error is not None:

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -39,7 +39,7 @@ from typing import Any
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from specula import quota as _quota
-from specula.phaselib import _logical_cwd, _wc_l
+from specula.phaselib import _logical_cwd, _normalize_artifact_dir, _wc_l
 
 RATE_LIMIT_FALLBACK_SECONDS = _quota.RATE_LIMIT_FALLBACK_SECONDS
 RATE_LIMIT_RC = _quota.RATE_LIMIT_RC
@@ -370,12 +370,13 @@ class Pipeline:
             print("ERROR: --no-isolate conflicts with --run-id", file=sys.stderr)
             return 1
         if self._artifact_given:
-            if not self.artifact or not Path(self.artifact).is_dir():
+            normalized_artifact = _normalize_artifact_dir(self.artifact)
+            if normalized_artifact is None:
                 print(f"ERROR: --artifact must be an existing directory: {self.artifact}", file=sys.stderr)
                 return 1
             # The legacy single-target flow may chdir before launching phases.
             # Stabilize a relative CLI path while it still refers to the caller's cwd.
-            self.artifact = str(Path(self.artifact).resolve())
+            self.artifact = normalized_artifact
 
         # Validate the repair budget before any phase starts.  int() in
         # run_repair_loop used to make malformed values fail only after the

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -294,6 +294,21 @@ class TestCheckOnly(PhaseCase):
                 self.assertIn(spec["ok"], out)
                 self.assertNotIn("[DRY RUN]", out)
 
+    def test_each_artifact_phase_expands_home_directory(self) -> None:
+        home = self.tmp()
+        repo = home / "cass-operator"
+        repo.mkdir()
+        self.set_env("HOME", str(home))
+
+        for spec in PHASES:
+            if not spec["artifact"]:
+                continue
+            with self.subTest(phase=spec["key"]):
+                self.seed(spec["inputs"])
+                rc, out = self.run_phase(spec["key"], ["--check", "--artifact=~/cass-operator", NAME])
+                self.assertEqual(rc, 0, out)
+                self.assertIn(spec["ok"], out)
+
     def test_validation_check_remains_a_shallow_preflight(self) -> None:
         spec_dir = self.work_dir() / "spec"
         spec_dir.mkdir(parents=True)
@@ -547,6 +562,13 @@ class TestArgErrors(PhaseCase):
         rc, out = self.run_phase("code_analysis", ["--check", "--artifact=", NAME])
         self.assertEqual(rc, 1)
         self.assertIn("--artifact must be an existing directory", out)
+
+    def test_artifact_expansion_failure_uses_existing_error_contract(self) -> None:
+        with mock.patch.object(Path, "expanduser", side_effect=RuntimeError("home unavailable")):
+            rc, out = self.run_phase("code_analysis", ["--check", "--artifact=~/repo", NAME])
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(out, "ERROR: --artifact must be an existing directory: ~/repo\n")
 
     def test_bug_confirmation_rejects_invalid_rounds(self) -> None:
         for value in ("abc", "0", "-1", "6"):

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -585,6 +585,31 @@ class TestParsing(TmpCwd):
         self.assertEqual(p.argv, ["--artifact=repo", "t|g|l|r"])
         self.assertIn(f"--artifact={repo}", p._phase_args(["t"]))
 
+    def test_home_relative_artifact_is_expanded_and_forwarded(self) -> None:
+        home = self.tmp / "home"
+        repo = home / "cass-operator"
+        repo.mkdir(parents=True)
+        p = pl.Pipeline()
+
+        with mock.patch.dict(os.environ, {"HOME": str(home)}):
+            self.assertIsNone(p.parse_args(["--artifact=~/cass-operator", "t|g|l|r"]))
+
+        self.assertEqual(p.artifact, str(repo))
+        self.assertEqual(p.argv, ["--artifact=~/cass-operator", "t|g|l|r"])
+        self.assertIn(f"--artifact={repo}", p._phase_args(["t"]))
+
+    def test_artifact_expansion_failure_uses_existing_error_contract(self) -> None:
+        p = pl.Pipeline()
+        err = io.StringIO()
+        with (
+            mock.patch.object(Path, "expanduser", side_effect=RuntimeError("home unavailable")),
+            contextlib.redirect_stderr(err),
+        ):
+            rc = p.parse_args(["--artifact=~/repo", "t|g|l|r"])
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(err.getvalue(), "ERROR: --artifact must be an existing directory: ~/repo\n")
+
     def test_invalid_artifact_path_is_rejected(self) -> None:
         file_path = self.tmp / "artifact.txt"
         file_path.write_text("not a directory\n")

--- a/tests/unit/test_setup_security.py
+++ b/tests/unit/test_setup_security.py
@@ -127,6 +127,190 @@ class TestSetupHelp(unittest.TestCase):
                         self.assert_no_setup_side_effects(root, env, sentinel)
 
 
+class TestSetupAgentDetection(unittest.TestCase):
+    AGENT_PROMPTS = {
+        "claude": "Install Specula for Claude Code?",
+        "codex": "Install Specula for Codex?",
+        "copilot": "Install Specula for GitHub Copilot CLI?",
+    }
+    AGENT_MISSING_MESSAGES = {
+        "claude": "Claude Code CLI not found on PATH; skipping.",
+        "codex": "Codex CLI not found on PATH; skipping.",
+        "copilot": "GitHub Copilot CLI not found on PATH; skipping.",
+    }
+    AGENT_USER_SKIP_MESSAGES = {
+        "claude": "Skipped Claude Code.",
+        "codex": "Skipped Codex.",
+        "copilot": "Skipped Copilot CLI.",
+    }
+
+    def make_checkout(self, root: Path, agents: set[str]) -> tuple[Path, dict[str, str], Path]:
+        for relative in (
+            Path("scripts/infra/setup.sh"),
+            Path("scripts/infra/copilot_mcp.sh"),
+        ):
+            destination = root / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(REPO_ROOT / relative, destination)
+
+        for relative in (
+            Path("tools/trace_debugger"),
+            Path("tools/cfa"),
+            Path("tools/spec_analyzer"),
+            Path("tools/inv_checking_tool"),
+            Path("skills"),
+            Path("lib"),
+        ):
+            (root / relative).mkdir(parents=True)
+        (root / "lib/tla2tools.jar").touch()
+        (root / "lib/CommunityModules-deps.jar").touch()
+
+        home = root / "home"
+        home.mkdir()
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        command_log = root / "commands.log"
+
+        for command in ("dirname", "grep", "head", "mkdir"):
+            executable = shutil.which(command)
+            if executable is None:
+                self.fail(f"required test utility is missing: {command}")
+            (bin_dir / command).symlink_to(executable)
+
+        fake_python = bin_dir / "python3"
+        fake_python.write_text(
+            """#!/bin/bash
+printf 'python3' >> "$FAKE_COMMAND_LOG"
+printf '\\t%s' "$@" >> "$FAKE_COMMAND_LOG"
+printf '\\n' >> "$FAKE_COMMAND_LOG"
+if [[ "${1:-}" == "--version" ]]; then
+  echo "Python 3.13.0"
+elif [[ "${1:-}" == "-I" && "${2:-}" == "-m" && "${3:-}" == "venv" ]]; then
+  /bin/mkdir -p "$4/bin"
+  /bin/ln -s "$0" "$4/bin/python"
+fi
+"""
+        )
+        fake_python.chmod(0o755)
+
+        fake_java = bin_dir / "java"
+        fake_java.write_text(
+            """#!/bin/bash
+if [[ "${1:-}" == "-version" ]]; then
+  echo 'openjdk version "21"' >&2
+else
+  echo "TLA+ fake help"
+fi
+"""
+        )
+        fake_java.chmod(0o755)
+
+        for command in ("pip3", "mvn"):
+            stub = bin_dir / command
+            stub.write_text(
+                """#!/bin/bash
+printf '%s' "${0##*/}" >> "$FAKE_COMMAND_LOG"
+printf '\\t%s' "$@" >> "$FAKE_COMMAND_LOG"
+printf '\\n' >> "$FAKE_COMMAND_LOG"
+"""
+            )
+            stub.chmod(0o755)
+
+        for agent in agents:
+            stub = bin_dir / agent
+            stub.write_text(
+                """#!/bin/bash
+printf '%s' "${0##*/}" >> "$FAKE_COMMAND_LOG"
+printf '\\t%s' "$@" >> "$FAKE_COMMAND_LOG"
+printf '\\n' >> "$FAKE_COMMAND_LOG"
+"""
+            )
+            stub.chmod(0o755)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "FAKE_COMMAND_LOG": str(command_log),
+                "HOME": str(home),
+                "PATH": str(bin_dir),
+            }
+        )
+        return root / "scripts/infra/setup.sh", env, command_log
+
+    def run_setup(
+        self,
+        root: Path,
+        agents: set[str],
+        user_input: str,
+    ) -> tuple[subprocess.CompletedProcess[str], str]:
+        setup, env, command_log = self.make_checkout(root, agents)
+        result = subprocess.run(
+            ["/bin/bash", str(setup)],
+            cwd=root,
+            env=env,
+            input=user_input,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        commands = command_log.read_text() if command_log.exists() else ""
+        return result, commands
+
+    def test_missing_agents_are_reported_without_prompting(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result, commands = self.run_setup(Path(tmp), set(), "")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for agent in self.AGENT_PROMPTS:
+            self.assertNotIn(self.AGENT_PROMPTS[agent], result.stdout + result.stderr)
+            self.assertIn(self.AGENT_MISSING_MESSAGES[agent], result.stdout)
+            self.assertNotIn(self.AGENT_USER_SKIP_MESSAGES[agent], result.stdout)
+        self.assertNotIn("src/specula/skill_install.py", commands)
+        self.assertNotIn("setup_codex_plugin.py", commands)
+        self.assertNotIn("claude\tmcp", commands)
+        self.assertNotIn("codex\tmcp", commands)
+        self.assertNotIn("copilot\tmcp", commands)
+
+    def test_only_agents_on_path_are_prompted(self) -> None:
+        for installed_agent in self.AGENT_PROMPTS:
+            with self.subTest(installed_agent=installed_agent), tempfile.TemporaryDirectory() as tmp:
+                result, _commands = self.run_setup(Path(tmp), {installed_agent}, "n\n")
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                for agent in self.AGENT_PROMPTS:
+                    if agent == installed_agent:
+                        self.assertNotIn(self.AGENT_MISSING_MESSAGES[agent], result.stdout)
+                        self.assertIn(self.AGENT_USER_SKIP_MESSAGES[agent], result.stdout)
+                    else:
+                        self.assertIn(self.AGENT_MISSING_MESSAGES[agent], result.stdout)
+                        self.assertNotIn(self.AGENT_USER_SKIP_MESSAGES[agent], result.stdout)
+
+    def test_codex_y_keeps_explanation_out_of_branch_value(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result, commands = self.run_setup(Path(tmp), {"codex"}, "y\nglobal\n")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("y: install skills and register MCP servers separately.", result.stderr)
+        self.assertIn("plugin: bundle skills and MCP tools as specula-codex@specula", result.stderr)
+        self.assertIn("Rerun specula setup and choose plugin again to update it.", result.stderr)
+        self.assertNotIn("legacy", result.stderr.lower())
+        self.assertIn("src/specula/skill_install.py", commands)
+        self.assertNotIn("setup_codex_plugin.py", commands)
+        self.assertEqual(commands.count("codex\tmcp\tadd"), 3)
+
+    def test_codex_plugin_keeps_explanation_out_of_branch_value(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result, commands = self.run_setup(Path(tmp), {"codex"}, "plugin\n")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("setup_codex_plugin.py", commands)
+        self.assertNotIn("src/specula/skill_install.py", commands)
+        self.assertNotIn("codex\tmcp\tadd", commands)
+        self.assertIn("Codex plugin configured: specula-codex@specula", result.stdout)
+        self.assertIn("Rerun specula setup and choose 'plugin' again", result.stdout)
+
+
 class TestSetupPythonIsolation(unittest.TestCase):
     def test_setup_invokes_trusted_installers_in_isolated_mode(self) -> None:
         setup = SETUP_SCRIPT.read_text()


### PR DESCRIPTION
## Summary

- prompt only for agent CLIs found on PATH
- explain the Codex y/plugin choices and skill namespaces
- expand ~ in artifact paths for run and direct phase commands

Fixes #76
Fixes #77