### PR TITLE
Reuse phase handoff checks and enable Copilot autopilot

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -142,7 +142,7 @@ Supported adapters are `claude-code` (default), `codex`, `copilot-cli`, `opencod
 
 Specula launches the installed agent CLI directly and uses its existing credentials. Authenticate the CLI before starting a pipeline. Claude Code runs default to maximum reasoning effort; Codex and Copilot use their configured defaults unless `--effort` is supplied.
 
-Passing `--effort` to Copilot requires Copilot CLI 1.0.4 or newer. OpenCode forwards it as a variant, while Pi forwards it as a thinking level.
+Specula runs Copilot CLI with `--autopilot` and fails before launching a task when the installed CLI does not advertise that capability. Passing `--effort` to Copilot requires Copilot CLI 1.0.4 or newer. OpenCode forwards it as a variant, while Pi forwards it as a thinking level.
 
 `--max-turns` maps to Copilot's autopilot continuation limit. Claude Code, Codex, OpenCode, and Pi accept the option for adapter compatibility but do not enforce it. The reviews between steps pass a fixed value of 30 instead of the pipeline option; all four adapters still ignore it. OpenCode and Pi do not support Specula's agent-side stop gate.
 
@@ -230,7 +230,7 @@ This writes `.specula-output/modeling-brief.md` and `.specula-output/analysis-re
 specula specgen --agent=codex --artifact=/path/to/source name
 ```
 
-A single-target individual command uses `.specula-output/` in the current directory; a multi-target command uses `<name>/.specula-output/` for each target. When `SPECULA_RUN_DIR` is set, every target uses `$SPECULA_RUN_DIR/<name>/.specula-output/`. A downstream command stops if its required files from the preceding step are missing.
+A single-target individual command uses `.specula-output/` in the current directory; a multi-target command uses `<name>/.specula-output/` for each target. When `SPECULA_RUN_DIR` is set, every target uses `$SPECULA_RUN_DIR/<name>/.specula-output/`. After an adapter exits successfully, each nonterminal step reuses the next step's existing prerequisite check before returning; the downstream command repeats that same check when it starts, so a wait between steps cannot turn an earlier success into an unchecked handoff.
 
 Use `--check` to run a lightweight path-level preflight without starting an agent. It checks the paths currently gated by that step, but does not validate file contents; warnings such as zero trace files remain non-fatal:
 

--- a/scripts/launch/adapters/copilot-cli.sh
+++ b/scripts/launch/adapters/copilot-cli.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Adapter: copilot-cli
-# Capabilities: model-select, effort-select, auto-approve, background
+# Capabilities: model-select, effort-select, auto-approve, autopilot, background
 # stop-gate: NOT supported — Copilot CLI has no stop-hook mechanism. The
 # generic gate env vars (SPECULA_PHASE/SPECULA_WORK_DIR; see
 # src/specula/stop_gate.py) are simply never read here, so the execution
@@ -122,7 +122,13 @@ load_copilot_help() {
 # The adapter always runs the command in the foreground and redirects to log.
 # Copilot CLI reads skills from project .github/skills/ or global ~/.agents/skills/.
 
-CMD=(copilot -p "$PROMPT" --allow-all)
+load_copilot_help
+if ! grep -q -- '--autopilot' <<< "$COPILOT_HELP"; then
+  echo "copilot-cli adapter: autonomous execution requires --autopilot, but the installed Copilot CLI does not advertise it; upgrade Copilot CLI" >&2
+  exit 1
+fi
+
+CMD=(copilot -p "$PROMPT" --allow-all --autopilot)
 
 if [[ -n "$MODEL" ]]; then
   CMD+=(--model "$MODEL")

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -247,6 +247,7 @@ class Phase:
     accepts_artifact = True  # bug_classification takes no --artifact (rejects it)
     artifact_rejection_message: str | None = None
     dry_prompt_flag = "--prompt"  # bug_classification's dry-run line shows --prompt-file
+    next_phase_key: str | None = None  # consumer whose existing check() validates this handoff
     progress_config = progress.ProgressConfig()
     # Tri-state tuning values set in run(): None = unspecified, "" = explicit
     # reset to the adapter/CLI default, non-empty = explicit override.
@@ -706,6 +707,12 @@ class Phase:
         )
         failed_names = {name for name, _ in failures}
         finalized = [(name, rc) for name, rc in finalized if name not in failed_names]
+        invalid_names = {name for name, _ in integrity_failures + finalized}
+        handoff_failures = self.check_handoff(
+            ws,
+            [name for name in names if name in successful_names and name not in invalid_names],
+            dry_run=dry_run,
+        )
 
         self.summarize(ws, names)
         if not dry_run:
@@ -720,12 +727,17 @@ class Phase:
             print("Output validation failures:")
             for name, rc in finalized:
                 print(f"  FAILED  {name}: invalid phase output (exit {rc})")
+        if handoff_failures:
+            print()
+            print("Handoff validation failures:")
+            for name, rc in handoff_failures:
+                print(f"  FAILED  {name}: next-phase prerequisites not met (exit {rc})")
         if integrity_failures:
             print()
             print("Output integrity failures:")
             for name, rc in integrity_failures:
                 print(f"  FAILED  {name}: protected output was restored (exit {rc})")
-        return self._failure_code(failures + integrity_failures + finalized)
+        return self._failure_code(failures + integrity_failures + finalized + handoff_failures)
 
     def run_alternate(
         self,
@@ -760,6 +772,26 @@ class Phase:
         invalid artifact after a nominally successful adapter exit.
         """
         return []
+
+    def check_handoff(
+        self,
+        ws: Workspace,
+        names: list[str],
+        *,
+        dry_run: bool,
+    ) -> list[tuple[str, int]]:
+        """Reuse the consumer's prerequisite check before publishing success.
+
+        The consumer runs this same ``check()`` again when it starts. Checking
+        both sides of a potentially long wait catches incomplete producer runs
+        immediately without creating a second output-contract implementation.
+        """
+        if dry_run or not names or self.next_phase_key is None:
+            return []
+        next_phase = PHASES[self.next_phase_key]
+        print()
+        print(f"Checking handoff to {self.next_phase_key}...")
+        return [(name, 1) for name in names if not next_phase.check(ws, [name])]
 
     def capture_output_integrity(
         self,
@@ -1058,6 +1090,7 @@ def run_agent_blocking(
 
 class CodeAnalysisPhase(Phase):
     key = "code_analysis"
+    next_phase_key = "spec_generation"
     title = "Specula — Code Analysis Batch Runner"
     usage = r"""
 Batch launcher: spawn one agent per target system for code analysis.
@@ -1181,6 +1214,7 @@ Write your outputs to:
 
 class SpecGenerationPhase(Phase):
     key = "spec_generation"
+    next_phase_key = "harness_generation"
     title = "Specula — Spec Generation Batch Runner"
     usage = r"""
 Batch launcher: spawn one agent per target system for TLA+ spec generation.
@@ -1312,6 +1346,7 @@ Expected files:
 
 class HarnessGenerationPhase(Phase):
     key = "harness_generation"
+    next_phase_key = "spec_validation"
     title = "Specula — Harness Generation (Phase 2.5)"
     usage = r"""
 Batch launcher: spawn one agent per target system for harness generation (Phase 2.5).
@@ -1555,6 +1590,7 @@ Do everything the skill specifies. Do not add, relax, or override any step here.
 
 class SpecValidationPhase(Phase):
     key = "spec_validation"
+    next_phase_key = "bug_confirmation"
     title = "Specula — Spec Validation Batch Runner"
     usage = r"""
 Batch launcher: spawn one agent per target system for spec validation.
@@ -1706,6 +1742,7 @@ Do everything the skill specifies. Do not add, relax, or override any step here.
 
 class BugConfirmationPhase(Phase):
     key = "bug_confirmation"
+    next_phase_key = "bug_classification"
     title = "Specula — Bug Confirmation Batch Runner"
     usage = r"""
 Bug confirmation for each target system. By DEFAULT this runs parallel
@@ -1809,6 +1846,7 @@ Prerequisites:
         debate = bool(ws.opts.get("debate"))
         rounds = int(str(ws.opts.get("rounds", "5")))
         failures: list[tuple[str, int]] = []
+        successful_names: list[str] = []
         retry_limit = self._rate_limit_retries()
         for name in names:
             if not dry_run:
@@ -1846,10 +1884,18 @@ Prerequisites:
                 failures.append((name, code))
                 if code == quota.RATE_LIMIT_RC:
                     break
+            else:
+                successful_names.append(name)
+        handoff_failures = self.check_handoff(ws, successful_names, dry_run=dry_run)
         self.summarize(ws, names)
         if not dry_run:
             self._acceptance(ws, names)
-        return self._failure_code(failures)
+        if handoff_failures:
+            print()
+            print("Handoff validation failures:")
+            for name, rc in handoff_failures:
+                print(f"  FAILED  {name}: next-phase prerequisites not met (exit {rc})")
+        return self._failure_code(failures + handoff_failures)
 
     def finalize_outputs(
         self,

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -2525,9 +2525,12 @@ class CodexAdapter(AdapterCase):
 # ── copilot-cli (bash) ───────────────────────────────────────────────────────
 class CopilotAdapter(AdapterCase):
     CMD = ["bash", str(COPILOT_SH)]
+    DEFAULT_HELP = "--autopilot"
 
     def invoke(self, flags: list[str], *, env_extra: dict[str, str] | None = None) -> AdapterRun:
-        return self.run_adapter(self.CMD, flags, fake_name="copilot", fixture_text="copilot ran\n", env_extra=env_extra)
+        env = {"COPILOT_HELP_TEXT": self.DEFAULT_HELP}
+        env.update(env_extra or {})
+        return self.run_adapter(self.CMD, flags, fake_name="copilot", fixture_text="copilot ran\n", env_extra=env)
 
     def base_flags(self, base: Path) -> list[str]:
         return [self.with_prompt_file(base), f"--log={base}/out.log"]
@@ -2536,13 +2539,20 @@ class CopilotAdapter(AdapterCase):
         base = self.sandbox()
         r = self.invoke(self.base_flags(base))
         self.assertEqual(r["returncode"], 0)
-        # copilot -p "<prompt>" --allow-all
-        self.assertEqual(r["argv"], ["-p", "the prompt", "--allow-all"])
+        # copilot -p "<prompt>" --allow-all --autopilot
+        self.assertEqual(r["argv"], ["-p", "the prompt", "--allow-all", "--autopilot"])
+
+    def test_autopilot_requires_supported_cli(self) -> None:
+        base = self.sandbox()
+        r = self.invoke(self.base_flags(base), env_extra={"COPILOT_HELP_TEXT": "--allow-all"})
+        self.assertEqual(r["returncode"], 1)
+        self.assertIn("does not advertise it; upgrade Copilot CLI", r["stderr"])
+        self.assertEqual(r["argv"], [])  # help probe only; task was never launched
 
     def test_model_flag_appended(self) -> None:
         base = self.sandbox()
         r = self.invoke(self.base_flags(base) + ["--model=gpt-5"])
-        self.assertEqual(r["argv"], ["-p", "the prompt", "--allow-all", "--model", "gpt-5"])
+        self.assertEqual(r["argv"], ["-p", "the prompt", "--allow-all", "--autopilot", "--model", "gpt-5"])
 
     def test_model_from_env(self) -> None:
         base = self.sandbox()
@@ -2570,19 +2580,19 @@ class CopilotAdapter(AdapterCase):
         base = self.sandbox()
         r = self.invoke(
             self.base_flags(base) + ["--claude-alias=claude", "--effort=high"],
-            env_extra={"COPILOT_HELP_TEXT": "  --reasoning-effort <level>"},
+            env_extra={"COPILOT_HELP_TEXT": "  --autopilot\n  --reasoning-effort <level>"},
         )
         self.assertEqual(r["returncode"], 0)
         self.assertEqual(
             r["argv"],
-            ["-p", "the prompt", "--allow-all", "--reasoning-effort", "high"],
+            ["-p", "the prompt", "--allow-all", "--autopilot", "--reasoning-effort", "high"],
         )
 
     def test_effort_alias_fallback(self) -> None:
         base = self.sandbox()
         r = self.invoke(
             self.base_flags(base) + ["--effort=max"],
-            env_extra={"COPILOT_HELP_TEXT": "  --effort <level>"},
+            env_extra={"COPILOT_HELP_TEXT": "  --autopilot\n  --effort <level>"},
         )
         self.assertEqual(r["returncode"], 0)
         self.assertEqual(r["argv"][-2:], ["--effort", "max"])
@@ -2598,7 +2608,7 @@ class CopilotAdapter(AdapterCase):
         base = self.sandbox()
         r = self.invoke(self.base_flags(base) + ["--effort="])
         self.assertEqual(r["returncode"], 0, r["stderr"])
-        self.assertEqual(r["argv"], ["-p", "the prompt", "--allow-all"])
+        self.assertEqual(r["argv"], ["-p", "the prompt", "--allow-all", "--autopilot"])
 
     def test_output_redirected_to_log(self) -> None:
         base = self.sandbox()
@@ -2633,7 +2643,7 @@ class CopilotAdapter(AdapterCase):
             fixture_text=fixture,
             env_extra={
                 "SPECULA_ACTIVITY_LOG": str(activity),
-                "COPILOT_HELP_TEXT": "--reasoning-effort\n--output-format\n--stream",
+                "COPILOT_HELP_TEXT": "--autopilot\n--reasoning-effort\n--output-format\n--stream",
             },
         )
         self.assertEqual(r["returncode"], 0, r["stderr"])
@@ -2654,7 +2664,7 @@ class CopilotAdapter(AdapterCase):
             self.base_flags(base),
             fake_name="copilot",
             fixture_text="old copilot completed\n",
-            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "COPILOT_HELP_TEXT": "--stream"},
+            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "COPILOT_HELP_TEXT": "--autopilot\n--stream"},
         )
         self.assertEqual(r["returncode"], 0, r["stderr"])
         self.assertNotIn("--output-format", r["argv"])
@@ -2671,7 +2681,7 @@ class CopilotAdapter(AdapterCase):
             self.base_flags(base),
             fake_name="copilot",
             fixture_text=fixture,
-            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "COPILOT_HELP_TEXT": "--stream"},
+            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "COPILOT_HELP_TEXT": "--autopilot\n--stream"},
         )
         self.assertEqual(r["returncode"], 0, r["stderr"])
         self.assertEqual((base / "out.log").read_text(), fixture)
@@ -2685,7 +2695,7 @@ class CopilotAdapter(AdapterCase):
             self.base_flags(base),
             fake_name="copilot",
             fixture_text="legacy copilot completed\n",
-            env_extra={"SPECULA_ACTIVITY_LOG": str(activity)},
+            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "COPILOT_HELP_TEXT": "--autopilot"},
         )
         self.assertEqual(r["returncode"], 0, r["stderr"])
         self.assertNotIn("--output-format", r["argv"])
@@ -2749,7 +2759,10 @@ class CopilotAdapter(AdapterCase):
             self.base_flags(base),
             fake_name="copilot",
             fixture_text=fixture,
-            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "COPILOT_HELP_TEXT": "--output-format\n--stream"},
+            env_extra={
+                "SPECULA_ACTIVITY_LOG": str(activity),
+                "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream",
+            },
         )
         self.assertEqual(r["returncode"], 0, r["stderr"])
         self.assertEqual(
@@ -2768,7 +2781,7 @@ class CopilotAdapter(AdapterCase):
             fixture_text=fixture,
             env_extra={
                 "SPECULA_ACTIVITY_LOG": str(activity),
-                "COPILOT_HELP_TEXT": "--output-format\n--stream",
+                "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream",
                 "ADAPTER_EXIT_CODE": "9",
             },
         )
@@ -2792,7 +2805,7 @@ class CopilotAdapter(AdapterCase):
                     fixture_text=fixture,
                     env_extra={
                         "SPECULA_ACTIVITY_LOG": str(activity),
-                        "COPILOT_HELP_TEXT": "--output-format\n--stream",
+                        "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream",
                         "ADAPTER_EXIT_CODE": cli_rc,
                     },
                 )
@@ -2811,7 +2824,10 @@ class CopilotAdapter(AdapterCase):
             [self.with_prompt_file(base), f"--log={log}"],
             fake_name="copilot",
             fixture_text=final,
-            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "COPILOT_HELP_TEXT": "--output-format\n--stream"},
+            env_extra={
+                "SPECULA_ACTIVITY_LOG": str(activity),
+                "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream",
+            },
         )
         self.assertEqual(r["returncode"], 0, r["stderr"])
         self.assertIn("activity log", r["stderr"])

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -658,6 +658,113 @@ class TestBugConfirmationAlternate(PhaseCase):
         self.assertEqual(len(calls), 2)
         self.assertEqual(waits, [1])
 
+    def test_successful_live_confirmation_requires_classification_prerequisites(self) -> None:
+        from specula import confirmlib
+
+        self.seed(BY_KEY["bug_confirmation"]["inputs"])
+        self.patch_attr(phaselib.Phase, "_acceptance", lambda _self, _ws, _names: None)
+
+        def fake_confirmation(cfg: confirmlib.ConfirmConfig) -> int:
+            return 0
+
+        self.patch_attr(confirmlib, "run_parallel_confirmation", fake_confirmation)
+        rc, out = self.run_phase("bug_confirmation", [self.artifact_flag(), NAME])
+
+        self.assertEqual(rc, 1, out)
+        self.assertIn("confirmed-bugs MISSING", out)
+        self.assertIn("Handoff validation failures:", out)
+
+    def test_successful_live_confirmation_hands_nonempty_report_to_classification(self) -> None:
+        from specula import confirmlib
+
+        self.seed(BY_KEY["bug_confirmation"]["inputs"])
+        self.patch_attr(phaselib.Phase, "_acceptance", lambda _self, _ws, _names: None)
+
+        def fake_confirmation(cfg: confirmlib.ConfirmConfig) -> int:
+            report = cfg.ws.work_dir(cfg.name) / "spec" / "confirmed-bugs.md"
+            report.parent.mkdir(parents=True, exist_ok=True)
+            report.write_text("# Confirmed Bugs\n")
+            return 0
+
+        self.patch_attr(confirmlib, "run_parallel_confirmation", fake_confirmation)
+        rc, out = self.run_phase("bug_confirmation", [self.artifact_flag(), NAME])
+
+        self.assertEqual(rc, 0, out)
+        self.assertIn("confirmed-bugs OK", out)
+
+
+class TestHandoffGate(PhaseCase):
+    def setUp(self) -> None:
+        super().setUp()
+        adapters = self.tmp() / "adapters"
+        adapters.mkdir()
+        self.patch_attr(phaselib, "LAUNCH_DIR", adapters.parent)
+        self.patch_attr(phaselib.Phase, "_acceptance", lambda _self, _ws, _names: None)
+        self.set_env("SPECULA_PROGRESS", "off")
+        self.adapter = adapters / "fake.sh"
+
+    def write_adapter(self, body: str) -> None:
+        self.adapter.write_text("#!/usr/bin/env sh\nset -eu\n" + body)
+        self.adapter.chmod(0o755)
+
+    def run_analysis(self, targets: list[str] | None = None) -> tuple[int, str]:
+        return self.run_phase(
+            "code_analysis",
+            [f"--agent={self.adapter.stem}", self.artifact_flag(), *(targets or [NAME])],
+        )
+
+    def test_zero_adapter_exit_without_brief_fails_the_analysis_handoff(self) -> None:
+        self.write_adapter(":\n")
+
+        rc, out = self.run_analysis()
+
+        self.assertEqual(rc, 1, out)
+        self.assertIn("Checking handoff to spec_generation...", out)
+        self.assertIn("MISSING modeling-brief.md", out)
+        self.assertIn("Handoff validation failures:", out)
+
+    def test_analysis_handoff_reuses_spec_generation_check(self) -> None:
+        calls: list[list[str]] = []
+
+        def check(_self: phaselib.SpecGenerationPhase, _ws: phaselib.Workspace, names: list[str]) -> bool:
+            calls.append(names)
+            return True
+
+        self.patch_attr(phaselib.SpecGenerationPhase, "check", check)
+        self.write_adapter(":\n")
+
+        rc, out = self.run_analysis()
+
+        self.assertEqual(rc, 0, out)
+        self.assertEqual(calls, [[NAME]])
+
+    def test_handoff_checks_only_successful_targets(self) -> None:
+        calls: list[list[str]] = []
+
+        def check(_self: phaselib.SpecGenerationPhase, _ws: phaselib.Workspace, names: list[str]) -> bool:
+            calls.append(names)
+            return True
+
+        self.patch_attr(phaselib.SpecGenerationPhase, "check", check)
+        self.write_adapter('name=$(basename "$(dirname "$SPECULA_WORK_DIR")")\n[ "$name" != failed ] || exit 9\n')
+
+        rc, out = self.run_analysis(["failed|g|Go|r", "passed|g|Go|r"])
+
+        self.assertEqual(rc, 9, out)
+        self.assertEqual(calls, [["passed"]])
+
+    def test_handoff_failures_are_attributed_per_target(self) -> None:
+        self.write_adapter(
+            'name=$(basename "$(dirname "$SPECULA_WORK_DIR")")\n'
+            '[ "$name" != passed ] || printf "brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
+        )
+
+        rc, out = self.run_analysis(["missing|g|Go|r", "passed|g|Go|r"])
+
+        self.assertEqual(rc, 1, out)
+        self.assertIn("FAILED  missing: next-phase prerequisites not met", out)
+        self.assertNotIn("FAILED  passed: next-phase prerequisites not met", out)
+
 
 class TestLegacyRepairIdentityFinalization(PhaseCase):
     def setUp(self) -> None:
@@ -1247,9 +1354,10 @@ class TestProgressReporting(PhaseCase):
         adapters.mkdir()
         self.patch_attr(phaselib, "LAUNCH_DIR", adapters.parent)
         self.patch_attr(phaselib.Phase, "_acceptance", lambda _self, _ws, _names: None)
-        # These tests exercise process/progress handling, not the analysis gate.
-        # Keep its optional `git rev-list` probe out of subprocess accounting.
+        # These tests exercise process/progress handling, not the analysis or
+        # handoff gates. Keep their optional probes out of subprocess accounting.
         self.patch_attr(phaselib.CodeAnalysisPhase, "check", lambda _self, _ws, _names: True)
+        self.patch_attr(phaselib.SpecGenerationPhase, "check", lambda _self, _ws, _names: True)
         self.config = ProgressConfig(
             poll_seconds=0.005,
             change_report_seconds=0.0,
@@ -1931,6 +2039,7 @@ class TestModelEffortLiveLaunch(PhaseCase):
         self.adapters.mkdir()
         self.patch_attr(phaselib, "LAUNCH_DIR", self.adapters.parent)
         self.patch_attr(phaselib.Phase, "_acceptance", lambda _self, _ws, _names: None)
+        self.patch_attr(phaselib.SpecGenerationPhase, "check", lambda _self, _ws, _names: True)
         self.set_env("SPECULA_PROGRESS", "off")
 
     def launch(self, adapter_name: str, extra: list[str] | None = None) -> list[str]:


### PR DESCRIPTION
## Summary

- reuse each downstream phase's existing prerequisite `check()` immediately after a successful upstream adapter run
- validate only successful targets, preserve existing failure precedence, and cover the default parallel confirmation path
- run Copilot CLI with `--autopilot` and fail before task launch when the installed CLI does not support it

Fix part of #80 
