### PR TITLE
Add generic policy-block recovery

### DIFF
--- a/scripts/launch/adapters/codex.sh
+++ b/scripts/launch/adapters/codex.sh
@@ -33,6 +33,8 @@ CLAUDE_ALIAS=""
 # empty flag can still win and clear them.
 EFFORT="${CODEX_EFFORT:-}"
 MODEL="${CODEX_MODEL:-}"
+POLICY_BLOCKED_RC=76  # Keep in sync with src/specula/adapters/utils/policy.py.
+PLAIN_POLICY_DIAGNOSTIC_RC=77  # Internal event-stream candidate; never returned to the runner.
 
 for arg in "$@"; do
   case "$arg" in
@@ -217,7 +219,9 @@ run_codex() {
   local marker_file
   local activity_log="${SPECULA_ACTIVITY_LOG:-}"
   local adapter_dir
+  local specula_src
   adapter_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  specula_src="$adapter_dir/../../../src"
   marker_file="$(mktemp)"
 
   # ── Optional outer srt sandbox (M1.3) ──
@@ -249,18 +253,27 @@ run_codex() {
   rm -f "$last_message_file"
   set +e
   if [[ -n "$activity_log" ]]; then
-    local specula_src
     local -a pipeline_status
     local stream_rc
-    specula_src="$adapter_dir/../../../src"
     printf '%s' "$PROMPT" | "${cmd[@]}" --json - 2>&1 | python3 -I -c \
       'import sys; sys.path.insert(0, sys.argv.pop(1)); from specula.adapters.utils.event_stream import main; raise SystemExit(main(sys.argv[1:]))' \
       "$specula_src" codex "$activity_log" "$log_file"
     pipeline_status=("${PIPESTATUS[@]}")
     codex_rc="${pipeline_status[1]}"
     stream_rc="${pipeline_status[2]}"
-    if (( codex_rc == 0 )); then
-      codex_rc="$stream_rc"
+    if (( codex_rc == 75 )); then
+      : # Rate limiting remains the highest-priority retry outcome.
+    elif (( stream_rc == POLICY_BLOCKED_RC )); then
+      codex_rc="$POLICY_BLOCKED_RC"
+    elif (( codex_rc != 0 && stream_rc == PLAIN_POLICY_DIAGNOSTIC_RC )); then
+      codex_rc="$POLICY_BLOCKED_RC"
+    elif (( codex_rc == 0 )); then
+      # A plain diagnostic is only actionable when the CLI itself failed.
+      # Structured policy failures use POLICY_BLOCKED_RC above and remain
+      # authoritative even if a provider CLI accidentally exits zero.
+      if (( stream_rc != PLAIN_POLICY_DIAGNOSTIC_RC )); then
+        codex_rc="$stream_rc"
+      fi
     fi
   else
     local -a pipeline_status
@@ -269,6 +282,17 @@ run_codex() {
     codex_rc="${pipeline_status[1]}"
   fi
   set -e
+
+  if [[ -z "$activity_log" ]] && (( codex_rc != 0 && codex_rc != 75 )); then
+    # Without progress streaming there is no structured event status. Only
+    # classify an already-failed CLI's diagnostic log; successful agent output
+    # may quote an old policy message and must remain successful.
+    if python3 -I -c \
+      'import sys; sys.path.insert(0, sys.argv[1]); from pathlib import Path; from specula.adapters.utils.policy import failed_log_has_policy_block; raise SystemExit(0 if failed_log_has_policy_block(Path(sys.argv[2])) else 1)' \
+      "$specula_src" "$log_file"; then
+      codex_rc="$POLICY_BLOCKED_RC"
+    fi
+  fi
 
   local usage_rc=0
   write_usage_file "$log_file" "$marker_file" || usage_rc=$?

--- a/scripts/launch/adapters/copilot-cli.sh
+++ b/scripts/launch/adapters/copilot-cli.sh
@@ -33,6 +33,8 @@ MODEL="${COPILOT_MODEL:-}"
 EFFORT=""
 LOG_FILE=""
 BACKGROUND=false
+POLICY_BLOCKED_RC=76  # Keep in sync with src/specula/adapters/utils/policy.py.
+PLAIN_POLICY_DIAGNOSTIC_RC=77  # Internal event-stream candidate; never returned to the runner.
 
 for arg in "$@"; do
   case "$arg" in
@@ -128,7 +130,9 @@ if ! grep -q -- '--autopilot' <<< "$COPILOT_HELP"; then
   exit 1
 fi
 
-CMD=(copilot -p "$PROMPT" --allow-all --autopilot)
+# Keep the scripting channel free of version-specific stats footers. Provider
+# diagnostics still go to stderr, which is captured below for policy recovery.
+CMD=(copilot -p "$PROMPT" --allow-all --autopilot --silent)
 
 if [[ -n "$MODEL" ]]; then
   CMD+=(--model "$MODEL")
@@ -154,19 +158,38 @@ if [[ -n "$MAX_TURNS" && "$MAX_TURNS" != "0" ]]; then
 fi
 
 ACTIVITY_LOG="${SPECULA_ACTIVITY_LOG:-}"
-if [[ -z "$ACTIVITY_LOG" ]]; then
-  "${CMD[@]}" > "$LOG_FILE" 2>&1
-  exit $?
-fi
-
 ADAPTER_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SPECULA_SRC="$ADAPTER_DIR/../../../src"
+
+failed_log_is_policy_blocked() {
+  python3 -I -c \
+    'import sys; sys.path.insert(0, sys.argv[1]); from pathlib import Path; from specula.adapters.utils.policy import failed_log_has_policy_block; raise SystemExit(0 if failed_log_has_policy_block(Path(sys.argv[2])) else 1)' \
+    "$SPECULA_SRC" "$LOG_FILE"
+}
+
+if [[ -z "$ACTIVITY_LOG" ]]; then
+  set +e
+  "${CMD[@]}" > "$LOG_FILE" 2>&1
+  COPILOT_RC=$?
+  set -e
+  if (( COPILOT_RC == 75 )); then
+    exit 75
+  fi
+  if (( COPILOT_RC != 0 )) && failed_log_is_policy_blocked; then
+    exit "$POLICY_BLOCKED_RC"
+  fi
+  exit "$COPILOT_RC"
+fi
 
 # JSON streaming arrived after the first Copilot CLI releases. Old clients
 # still stream plain output through the helper without unsupported flags.
 load_copilot_help
+COPILOT_JSON_STREAM=false
+STREAM_ADAPTER=copilot
 if grep -q -- '--output-format' <<< "$COPILOT_HELP"; then
   CMD+=(--output-format json)
+  COPILOT_JSON_STREAM=true
+  STREAM_ADAPTER=copilot-json
 fi
 if grep -q -- '--stream' <<< "$COPILOT_HELP"; then
   CMD+=(--stream on)
@@ -175,13 +198,28 @@ fi
 set +e
 "${CMD[@]}" 2>&1 | python3 -I -c \
   'import sys; sys.path.insert(0, sys.argv.pop(1)); from specula.adapters.utils.event_stream import main; raise SystemExit(main(sys.argv[1:]))' \
-  "$SPECULA_SRC" copilot "$ACTIVITY_LOG" "$LOG_FILE"
+  "$SPECULA_SRC" "$STREAM_ADAPTER" "$ACTIVITY_LOG" "$LOG_FILE"
 PIPELINE_STATUS=("${PIPESTATUS[@]}")
 set -e
 
 COPILOT_RC="${PIPELINE_STATUS[0]}"
 STREAM_RC="${PIPELINE_STATUS[1]}"
+if (( COPILOT_RC == 75 )); then
+  exit 75
+fi
+if (( STREAM_RC == POLICY_BLOCKED_RC )); then
+  exit "$POLICY_BLOCKED_RC"
+fi
+if (( COPILOT_RC != 0 && STREAM_RC == PLAIN_POLICY_DIAGNOSTIC_RC )); then
+  exit "$POLICY_BLOCKED_RC"
+fi
+if (( COPILOT_RC != 0 )) && [[ "$COPILOT_JSON_STREAM" != true ]] && failed_log_is_policy_blocked; then
+  exit "$POLICY_BLOCKED_RC"
+fi
 if (( COPILOT_RC != 0 )); then
   exit "$COPILOT_RC"
+fi
+if (( STREAM_RC == PLAIN_POLICY_DIAGNOSTIC_RC )); then
+  exit 0
 fi
 exit "$STREAM_RC"

--- a/src/specula/adapters/claude_code.py
+++ b/src/specula/adapters/claude_code.py
@@ -31,8 +31,14 @@ from typing import IO, Any
 
 if __package__:
     from .utils.event_stream import stream_events
+    from .utils.policy import POLICY_BLOCKED_RC, final_diagnostic_has_policy_block, looks_policy_blocked
 else:
     from utils.event_stream import stream_events  # type: ignore[import-not-found, no-redef]
+    from utils.policy import (  # type: ignore[import-not-found, no-redef]
+        POLICY_BLOCKED_RC,
+        final_diagnostic_has_policy_block,
+        looks_policy_blocked,
+    )
 
 HELP = __doc__
 
@@ -158,6 +164,30 @@ def _rate_limited(raw_text: str, streaming: bool) -> bool:
         if isinstance(record, dict) and record.get("type") == "result" and error_result(record):
             return True
     return False
+
+
+def _result_policy_blocked(record: object) -> bool:
+    """Whether Claude's terminal result is an unresolved provider policy block.
+
+    Inspect the result text only after the terminal envelope declares an error.
+    Successful agents may legitimately quote a policy-block diagnostic while
+    explaining or repairing an earlier run.
+    """
+    if not isinstance(record, dict):
+        return False
+    verdict = record.get("is_error")
+    subtype = record.get("subtype")
+    terminal_reason = record.get("terminal_reason")
+    api_status = record.get("api_error_status")
+    subtype_is_error = isinstance(subtype, str) and subtype.startswith("error")
+    if (
+        verdict is not True
+        and not subtype_is_error
+        and terminal_reason != "api_error"
+        and api_status in (None, "", 0, "0")
+    ):
+        return False
+    return looks_policy_blocked(record) or looks_policy_blocked(record.get("result"))
 
 
 def _drain(stream: IO[bytes]) -> None:
@@ -385,6 +415,8 @@ def main(argv: list[str]) -> int:
         activity_failed = False
         stream_failed = False
         stream_terminal_record: object | None = None
+        stream_policy_block_error: str | None = None
+        stream_plain_policy_block_error: str | None = None
         stream_plain_diagnostics: tuple[str, ...] = ()
         # This `try` covers the spawn ONLY. An OSError here means no agent work
         # has happened (claude missing / not executable / unreadable prompt), so
@@ -409,6 +441,8 @@ def main(argv: list[str]) -> int:
                     activity_failed = not stream_status.activity_ok
                     stream_failed = not stream_status.log_ok
                     stream_terminal_record = stream_status.terminal_record
+                    stream_policy_block_error = stream_status.policy_block_error
+                    stream_plain_policy_block_error = stream_status.plain_policy_block_error
                     stream_plain_diagnostics = stream_status.plain_diagnostics
                 except OSError as e:
                     # Sink failures are returned after a full drain. An exception
@@ -434,11 +468,19 @@ def main(argv: list[str]) -> int:
             raw_text = _read_capture(capture_path)
 
         # ── Detect rate limit → exit 75 (EX_TEMPFAIL) so callers can wait/retry ──
-        rate_limited = _rate_limited(raw_text, bool(activity_log))
+        rate_limited = cli_rc == 75 or _rate_limited(raw_text, bool(activity_log))
         if rate_limited:
             print("claude-code adapter: rate limit hit", file=sys.stderr)
 
         result = _parse_result(raw_text)
+        policy_blocked = stream_policy_block_error is not None or _result_policy_blocked(result)
+        if activity_log and cli_rc != 0 and stream_plain_policy_block_error is not None:
+            policy_blocked = True
+        if not activity_log and cli_rc != 0 and result is None:
+            # A failed pre-stream CLI may emit only a plain provider diagnostic.
+            # Never apply this scan to a successful run or to arbitrary streamed
+            # assistant history, where quoting an old block is normal task text.
+            policy_blocked = final_diagnostic_has_policy_block(raw_text)
         postprocess_failed = False
         if activity_log:
             try:
@@ -465,6 +507,9 @@ def main(argv: list[str]) -> int:
 
         if rate_limited:
             return 75
+        if policy_blocked:
+            print("claude-code adapter: provider policy block", file=sys.stderr)
+            return POLICY_BLOCKED_RC
         if cli_rc != 0:
             return cli_rc
         return 1 if stream_failed or postprocess_failed else 0

--- a/src/specula/adapters/utils/event_stream.py
+++ b/src/specula/adapters/utils/event_stream.py
@@ -17,6 +17,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO, TextIO, cast
 
+from .policy import (
+    PLAIN_POLICY_DIAGNOSTIC_RC,
+    POLICY_BLOCKED_RC,
+    final_diagnostic_has_policy_block,
+    looks_policy_blocked,
+)
 from .text import SUMMARY_LIMIT, readable, readable_fragment, summary, tool_summary
 from .usage import PiSubagentResult, UsageTotals, accumulate_usage, pi_subagent_results
 
@@ -28,6 +34,9 @@ class StreamStatus:
     terminal_record: object | None
     structured_error: str | None
     rate_limit_error: str | None
+    policy_block_error: str | None
+    plain_policy_block_error: str | None
+    successful_terminal: bool
     terminal_error: str | None
     plain_diagnostics: tuple[str, ...]
     subagent_results: tuple[PiSubagentResult, ...]
@@ -268,6 +277,81 @@ def _looks_rate_limited(value: object, depth: int = 0) -> bool:
     return any(_looks_rate_limited(value.get(key), depth + 1) for key in ("data", "error"))
 
 
+def _policy_diagnostic(value: object, depth: int = 0) -> str:
+    """Extract a readable diagnostic from an already classified error payload."""
+    if depth > 4:
+        return ""
+    if isinstance(value, str):
+        return summary(value, None)
+    if not isinstance(value, dict):
+        return ""
+    for key in ("message", "errorMessage", "error_message", "result", "responseBody", "response_body"):
+        message = value.get(key)
+        if isinstance(message, str) and message.strip():
+            return summary(message, None)
+    for key in ("data", "error", "cause", "body", "response"):
+        diagnostic = _policy_diagnostic(value.get(key), depth + 1)
+        if diagnostic:
+            return diagnostic
+    for key in ("code", "errorCode", "error_code", "errorType", "error_type", "name", "type"):
+        code = value.get(key)
+        if isinstance(code, str) and looks_policy_blocked(code):
+            return summary(code, None)
+    return ""
+
+
+def _claude_result_failed(record: dict[str, object]) -> bool:
+    if record.get("type") != "result":
+        return False
+    subtype = record.get("subtype")
+    api_status = record.get("api_error_status")
+    return (
+        record.get("is_error") is True
+        or (isinstance(subtype, str) and subtype.casefold().startswith("error"))
+        or record.get("terminal_reason") == "api_error"
+        or api_status not in (None, "", 0, "0")
+    )
+
+
+def _structured_policy_block_error(adapter_name: str, record: object) -> str | None:
+    """Classify policy blocks only inside explicit provider-error envelopes."""
+    if not isinstance(record, dict):
+        return None
+
+    payload: object | None = None
+    if adapter_name == "claude-code":
+        if not _claude_result_failed(record):
+            return None
+        # Claude commonly stores the provider diagnostic in the terminal
+        # result string, which is deliberately not a generic recursive field in
+        # looks_policy_blocked: successful reports may quote an old error.
+        result = record.get("result")
+        if looks_policy_blocked(record):
+            payload = record
+        elif looks_policy_blocked(result):
+            payload = result
+    elif adapter_name == "codex":
+        if record.get("type") == "turn.failed":
+            payload = record.get("error")
+    elif adapter_name == "copilot-cli":
+        if record.get("type") == "session.error":
+            payload = record.get("data") if record.get("data") is not None else record
+        elif record.get("type") == "result" and record.get("exitCode") not in (None, 0, "0"):
+            result = record.get("result")
+            payload = result if looks_policy_blocked(result) else record
+    elif adapter_name == "opencode" and record.get("type") == "error":
+        payload = record.get("error") if record.get("error") is not None else record
+    elif adapter_name == "pi":
+        if _pi_terminal_error(record) is not None:
+            payload = record.get("message")
+        elif record.get("type") == "error":
+            payload = record
+
+    if payload is None or not looks_policy_blocked(payload):
+        return None
+    return _policy_diagnostic(payload) or "provider content policy blocked the request"
+
+
 def _structured_rate_limit_error(adapter_name: str, record: object) -> str | None:
     """Return a diagnostic only for an explicit provider-error record."""
     if not isinstance(record, dict):
@@ -425,11 +509,19 @@ def _compact_activity_line(adapter_name: str, record: object, raw_line: bytes) -
     return json.dumps(compact, ensure_ascii=False, separators=(",", ":")).encode() + newline
 
 
-def _read_line(adapter_name: str, line: str, concise: bool) -> tuple[bool, list[_LogEvent], object]:
+def _read_line(
+    adapter_name: str, line: str, concise: bool, *, structured: bool = True
+) -> tuple[bool, list[_LogEvent], object]:
     """One line -> (persist raw?, readable events, parsed record or sentinel).
 
     Never raises on malformed input: a line that is not JSON is the CLI's own
     diagnostic, and losing it is worse than showing it."""
+    if adapter_name == "copilot-cli" and not structured:
+        # Pre-JSON Copilot output is arbitrary agent text. Even a line that
+        # happens to be valid JSON must remain text rather than masquerading as
+        # a provider event envelope.
+        text = summary(line, SUMMARY_LIMIT if concise else None)
+        return True, [_line_event(text)] if text else [], _INVALID_RECORD
     try:
         record = json.loads(line)
     except (TypeError, ValueError):
@@ -464,9 +556,15 @@ _ADAPTER_NAMES = {
     "codex": "codex",
     "copilot": "copilot-cli",
     "copilot-cli": "copilot-cli",
+    # Copilot versions before JSON output emit arbitrary agent text on stdout.
+    # The wrapper uses this internal alias only after capability probing proves
+    # that non-JSON lines are out-of-band CLI diagnostics.
+    "copilot-json": "copilot-cli",
     "opencode": "opencode",
     "pi": "pi",
 }
+
+_STRUCTURED_STREAM_ADAPTERS = frozenset({"claude", "claude-code", "codex", "copilot-json", "opencode", "pi"})
 
 
 def stream_events(
@@ -485,6 +583,7 @@ def stream_events(
     """
     source = source if source is not None else sys.stdin.buffer
     adapter_name = _ADAPTER_NAMES[adapter]
+    structured_stream = adapter in _STRUCTURED_STREAM_ADAPTERS
     usage_totals = UsageTotals()
     last_event = ""
     fragment_active = False
@@ -493,8 +592,12 @@ def stream_events(
     terminal_record: object | None = None
     pi_agent_ended = False
     pi_terminating_tool_completed = False
+    opencode_policy_recovery_activity = False
     structured_error: str | None = None
     rate_limit_error: str | None = None
+    policy_block_error: str | None = None
+    successful_terminal = False
+    final_plain_diagnostic = ""
     plain_diagnostics: list[str] = []
     subagent_results: list[PiSubagentResult] = []
     raw_failures: list[str] = []
@@ -542,24 +645,62 @@ def stream_events(
     def handle_line(raw_line: bytes, *, raw_already_written: bool) -> None:
         nonlocal fragment_active, last_event, line_open, pi_message_had_fragments
         nonlocal pi_agent_ended, pi_terminating_tool_completed
-        nonlocal rate_limit_error, structured_error, terminal_record
+        nonlocal opencode_policy_recovery_activity
+        nonlocal final_plain_diagnostic, policy_block_error, rate_limit_error
+        nonlocal structured_error, successful_terminal, terminal_record
         decoded = raw_line.decode(errors="replace")
-        keep, events, record = _read_line(adapter_name, decoded, concise=False)
+        keep, events, record = _read_line(adapter_name, decoded, concise=False, structured=structured_stream)
+        if structured_stream and decoded.strip():
+            if record is _INVALID_RECORD:
+                # In a promised JSON stream, non-JSON output belongs to the CLI
+                # rather than the agent. Retain it separately from rendered
+                # agent.log content so quoted policy text cannot be mistaken
+                # for a provider diagnostic.
+                plain_diagnostics.append(decoded)
+                final_plain_diagnostic = decoded
+            else:
+                # Only the final non-empty physical stream line may serve as
+                # the out-of-band fallback. A later JSON event supersedes it.
+                final_plain_diagnostic = ""
         accumulate_usage(adapter_name, record, usage_totals)
+        detected_policy_block = _structured_policy_block_error(adapter_name, record)
+        if detected_policy_block is not None:
+            policy_block_error = detected_policy_block
+            if adapter_name == "opencode":
+                opencode_policy_recovery_activity = False
         if adapter_name == "claude-code":
             if isinstance(record, dict) and record.get("type") == "result":
                 terminal_record = record
-            elif record is _INVALID_RECORD and decoded.strip():
-                # Claude's stream-json mode uses non-JSON only for CLI
-                # diagnostics. Retain those few lines so quota banners survive
-                # an activity-sidecar failure without buffering the full stream.
-                plain_diagnostics.append(decoded)
+                successful_terminal = not _claude_result_failed(record)
+                if successful_terminal:
+                    policy_block_error = None
+        elif adapter_name == "codex":
+            if isinstance(record, dict) and record.get("type") in {"turn.completed", "turn.failed"}:
+                terminal_record = record
+                successful_terminal = record.get("type") == "turn.completed"
+                if successful_terminal:
+                    policy_block_error = None
+        elif adapter_name == "copilot-cli":
+            if isinstance(record, dict) and record.get("type") == "result":
+                terminal_record = record
+                successful_terminal = record.get("exitCode") in (0, "0")
+                if successful_terminal:
+                    policy_block_error = None
         elif adapter_name == "opencode":
             detected_rate_limit = _structured_rate_limit_error(adapter_name, record)
             if detected_rate_limit is not None:
                 rate_limit_error = detected_rate_limit
+            if policy_block_error is not None and isinstance(record, dict):
+                part = record.get("part")
+                if isinstance(part, dict) and part.get("type") in {"text", "tool"}:
+                    opencode_policy_recovery_activity = True
             if isinstance(record, dict) and record.get("type") == "step_finish":
                 terminal_record = record
+                part = record.get("part")
+                reason = part.get("reason") if isinstance(part, dict) else None
+                successful_terminal = isinstance(reason, str) and reason.casefold() == "stop"
+                if opencode_policy_recovery_activity and isinstance(reason, str) and reason.casefold() == "stop":
+                    policy_block_error = None
         elif adapter_name == "pi":
             if (
                 isinstance(record, dict)
@@ -572,10 +713,17 @@ def stream_events(
                 pi_terminating_tool_completed = False
                 structured_error = _pi_terminal_error(record)
                 rate_limit_error = _structured_rate_limit_error(adapter_name, record)
+                reason = record["message"].get("stopReason")
+                successful_terminal = isinstance(reason, str) and reason.casefold() == "stop"
+                if successful_terminal:
+                    policy_block_error = None
             elif _pi_successful_terminating_tool(record):
                 pi_terminating_tool_completed = True
             elif isinstance(record, dict) and record.get("type") == "agent_end":
                 pi_agent_ended = True
+                if pi_terminating_tool_completed:
+                    successful_terminal = True
+                    policy_block_error = None
             elif isinstance(record, dict) and record.get("type") == "error":
                 detected_rate_limit = _structured_rate_limit_error(adapter_name, record)
                 if detected_rate_limit is not None:
@@ -659,12 +807,18 @@ def stream_events(
         print(f"adapter event stream warning: {failure}", file=sys.stderr)
     for failure in readable_failures:
         print(f"adapter event stream failed: {failure}", file=sys.stderr)
+    plain_policy_block_error = None
+    if structured_stream and not successful_terminal and final_diagnostic_has_policy_block(final_plain_diagnostic):
+        plain_policy_block_error = summary(final_plain_diagnostic, None)
     return StreamStatus(
         activity_ok=not raw_failures,
         log_ok=not readable_failures,
         terminal_record=terminal_record,
         structured_error=structured_error,
         rate_limit_error=rate_limit_error,
+        policy_block_error=policy_block_error,
+        plain_policy_block_error=plain_policy_block_error,
+        successful_terminal=successful_terminal,
         terminal_error=_terminal_error(
             adapter_name,
             terminal_record,
@@ -689,7 +843,21 @@ def main(argv: list[str]) -> int:
     except OSError as exc:
         print(f"adapter event stream failed: {exc}", file=sys.stderr)
         return 1
-    return 0 if status.log_ok else 1
+    if status.policy_block_error is not None:
+        print(
+            f"adapter event stream policy blocked: {summary(status.policy_block_error, None)}",
+            file=sys.stderr,
+        )
+        return POLICY_BLOCKED_RC
+    if not status.log_ok:
+        return 1
+    if status.plain_policy_block_error is not None:
+        print(
+            f"adapter event stream plain policy diagnostic: {summary(status.plain_policy_block_error, None)}",
+            file=sys.stderr,
+        )
+        return PLAIN_POLICY_DIAGNOSTIC_RC
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/specula/adapters/utils/json_cli.py
+++ b/src/specula/adapters/utils/json_cli.py
@@ -17,6 +17,7 @@ from types import FrameType
 from typing import Any
 
 from .event_stream import StreamStatus, stream_events
+from .policy import POLICY_BLOCKED_RC
 from .text import summary
 from .usage import augment_opencode_usage, augment_pi_usage
 
@@ -285,11 +286,26 @@ def run_json_cli(
                 elif adapter_name == "opencode":
                     usage = augment_opencode_usage(usage, _opencode_database_path(inherited_env))
             usage_ok = _write_usage(options.log_path.with_suffix(".usage.json"), usage)
+            if native_status == RATE_LIMIT_RC:
+                return RATE_LIMIT_RC
             if status is not None and status.rate_limit_error is not None:
                 print(
                     f"{adapter_name} adapter: rate limit hit: {summary(status.rate_limit_error, None)}", file=sys.stderr
                 )
                 return RATE_LIMIT_RC
+            if status is not None and status.policy_block_error is not None:
+                print(
+                    f"{adapter_name} adapter: policy block: {summary(status.policy_block_error, None)}",
+                    file=sys.stderr,
+                )
+                return POLICY_BLOCKED_RC
+            if native_status != 0 and status is not None and status.plain_policy_block_error is not None:
+                print(
+                    f"{adapter_name} adapter: plain policy diagnostic: "
+                    f"{summary(status.plain_policy_block_error, None)}",
+                    file=sys.stderr,
+                )
+                return POLICY_BLOCKED_RC
             if native_status != 0:
                 return native_status
             if stream_failed or status is None or not status.log_ok or not usage_ok:

--- a/src/specula/adapters/utils/policy.py
+++ b/src/specula/adapters/utils/policy.py
@@ -1,0 +1,91 @@
+"""Provider-policy error classification shared by every agent adapter."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+# Dedicated adapter outcome consumed by the common phase runner. Keep it
+# distinct from quota's EX_TEMPFAIL (75): a policy block needs a changed
+# request immediately, not backoff followed by a replay.
+POLICY_BLOCKED_RC = 76
+# Internal event-stream outcome: a final out-of-band diagnostic looks like a
+# policy block, but the wrapper must still confirm that the CLI itself failed.
+# Adapters normalize this to POLICY_BLOCKED_RC; the phase runner never sees it.
+PLAIN_POLICY_DIAGNOSTIC_RC = 77
+_FAILED_LOG_SCAN_BYTES = 256 * 1024
+
+_POLICY_CODES = {
+    "content_filter",
+    "content_filtering",
+    "content_policy",
+    "content_policy_violation",
+    "content_policy_violation_error",
+    "cyber_policy",
+}
+_POLICY_TEXT_RE = re.compile(
+    r"(?:cyber[_\s-]*policy|content[_\s-]*policy|content filtering policy|"
+    r"output blocked by content filtering|blocked by (?:the )?(?:model(?:'s)? )?content filter|"
+    r"flagged for possible cybersecurity risk)",
+    re.IGNORECASE,
+)
+
+
+def _normalized_code(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.casefold()).strip("_")
+
+
+def looks_policy_blocked(value: object, depth: int = 0) -> bool:
+    """Recognize a policy block inside an already identified error payload.
+
+    Callers must first establish that ``value`` came from a provider/terminal
+    error envelope. This intentionally does not decide whether arbitrary agent
+    output is an error: an agent may quote an old policy message while fixing
+    exactly this failure.
+    """
+    if depth > 4:
+        return False
+    if isinstance(value, str):
+        return _normalized_code(value) in _POLICY_CODES or bool(_POLICY_TEXT_RE.search(value))
+    if not isinstance(value, dict):
+        return False
+
+    for key in ("code", "errorCode", "error_code", "errorType", "error_type", "name", "type"):
+        code = value.get(key)
+        if isinstance(code, str) and _normalized_code(code) in _POLICY_CODES:
+            return True
+    for key in ("message", "errorMessage", "error_message", "responseBody", "response_body"):
+        if looks_policy_blocked(value.get(key), depth + 1):
+            return True
+    return any(
+        looks_policy_blocked(value.get(key), depth + 1) for key in ("data", "error", "cause", "body", "response")
+    )
+
+
+def final_diagnostic_has_policy_block(text: str) -> bool:
+    """Classify only a failed CLI's final non-empty diagnostic line."""
+    diagnostic = next((line.strip() for line in reversed(text.splitlines()) if line.strip()), "")
+    if not diagnostic:
+        return False
+    try:
+        json.loads(diagnostic)
+    except (TypeError, ValueError):
+        pass
+    else:
+        # A valid JSON line belongs to an agent/event channel. Structured error
+        # envelopes are classified by the adapter parser, not this fallback.
+        return False
+    return looks_policy_blocked(diagnostic)
+
+
+def failed_log_has_policy_block(path: Path) -> bool:
+    """Narrow fallback for a failed CLI run that could not emit JSON events."""
+    try:
+        with path.open("rb") as stream:
+            stream.seek(0, 2)
+            stream.seek(max(0, stream.tell() - _FAILED_LOG_SCAN_BYTES))
+            text = stream.read(_FAILED_LOG_SCAN_BYTES).decode("utf-8", errors="replace")
+    except OSError:
+        return False
+    return final_diagnostic_has_policy_block(text)

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import time
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -32,6 +33,7 @@ if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import specula.progress as progress
 from specula import quota
+from specula.adapters.utils.policy import POLICY_BLOCKED_RC
 from specula.prompts import render
 from specula.skill_refs import materialize_skill_refs, prompt_skill_ids
 from specula.tlc_resources import (
@@ -51,6 +53,29 @@ SPECULA_ROOT = SCRIPT_DIR.parent.parent
 LAUNCH_DIR = SPECULA_ROOT / "scripts" / "launch"
 AGENT_TERMINATION_GRACE_SECONDS = 2.0
 MAX_DEBATE_ROUNDS = 5
+
+
+@dataclass(frozen=True)
+class _LaunchRequest:
+    """One scheduler request with independent quota and policy state."""
+
+    target: str
+    rate_limit_attempt: int = 1
+    policy_recovery: bool = False
+
+
+_POLICY_RECOVERY_NOTE = """
+
+## Continue After Provider Policy Interruption
+
+The previous invocation was interrupted because the provider blocked a response under its content policy. Continue the same legitimate formal-verification task from the existing workspace. Inspect and preserve completed work, rephrase the blocked portion in neutral formal-verification terms, and complete every required deliverable for this phase. Do not repeat work that is already complete.
+"""
+
+
+def _policy_recovery_prompt(prompt: str) -> str:
+    """Change a blocked request while retaining its phase contract."""
+    return prompt.rstrip() + _POLICY_RECOVERY_NOTE
+
 
 # bash pathname expansion (`for d in .../*/`) orders by the locale collating
 # sequence; adopt the ambient locale so find_repo_dir picks the same repo the
@@ -599,8 +624,8 @@ class Phase:
         failures: list[tuple[str, int]] = []
         successful_names: set[str] = set()
         completed_names: set[str] = set()
-        pending: list[tuple[str, int]] = [(target, 1) for target in targets]
-        rate_limited: list[tuple[str, int]] = []
+        pending = [_LaunchRequest(target) for target in targets]
+        rate_limited: list[_LaunchRequest] = []
         pause_for_rate_limit = False
         stop_launching = False
         waiting_announced = False
@@ -609,9 +634,11 @@ class Phase:
             try:
                 while pending or running:
                     while pending and len(running) < max_parallel and not pause_for_rate_limit and not stop_launching:
-                        target, attempt = pending.pop(0)
-                        name = self.target_name(target)
-                        prompt = self.build_prompt(ws, target)
+                        request = pending.pop(0)
+                        name = self.target_name(request.target)
+                        prompt = self.build_prompt(ws, request.target)
+                        if request.policy_recovery:
+                            prompt = _policy_recovery_prompt(prompt)
                         self._launch(
                             ws,
                             name,
@@ -621,8 +648,9 @@ class Phase:
                             claude_alias,
                             adapter,
                             owner=running,
-                            target=target,
-                            attempt=attempt,
+                            target=request.target,
+                            attempt=request.rate_limit_attempt,
+                            policy_recovery=request.policy_recovery,
                         )
                         print()
 
@@ -645,9 +673,32 @@ class Phase:
                         if rc == 0:
                             successful_names.add(completed_agent.name)
                             continue
+                        if rc == POLICY_BLOCKED_RC:
+                            if not completed_agent.policy_recovery:
+                                print(
+                                    f"[{_ts()}] {completed_agent.name}: provider policy interrupted the run; "
+                                    "continuing once with a revised request"
+                                )
+                                pending.insert(
+                                    0,
+                                    _LaunchRequest(
+                                        completed_agent.target,
+                                        rate_limit_attempt=completed_agent.attempt,
+                                        policy_recovery=True,
+                                    ),
+                                )
+                            else:
+                                failures.append((completed_agent.name, rc))
+                            continue
                         if rc == quota.RATE_LIMIT_RC:
                             if self._reactive_rate_limit_enabled() and completed_agent.attempt <= retry_limit:
-                                rate_limited.append((completed_agent.target, completed_agent.attempt + 1))
+                                rate_limited.append(
+                                    _LaunchRequest(
+                                        completed_agent.target,
+                                        rate_limit_attempt=completed_agent.attempt + 1,
+                                        policy_recovery=completed_agent.policy_recovery,
+                                    )
+                                )
                                 pause_for_rate_limit = True
                             else:
                                 failures.append((completed_agent.name, rc))
@@ -658,14 +709,16 @@ class Phase:
                     if pause_for_rate_limit and any(rc != quota.RATE_LIMIT_RC for _, rc in failures):
                         # A permanent failure wins over 75, but permanent failures
                         # alone do not suppress independent batch targets.
-                        failures.extend((self.target_name(target), quota.RATE_LIMIT_RC) for target, _ in rate_limited)
+                        failures.extend(
+                            (self.target_name(request.target), quota.RATE_LIMIT_RC) for request in rate_limited
+                        )
                         stop_launching = True
 
                     if stop_launching:
                         # A 75 that cannot be retried stops new quota-consuming
                         # work. Let agents already in the current wave finish.
                         if pending:
-                            skipped = [self.target_name(target) for target, _ in pending]
+                            skipped = [self.target_name(request.target) for request in pending]
                             print(
                                 f"[{_ts()}] Rate limit stopped new launches; "
                                 f"skipping {len(skipped)} unstarted target(s): {', '.join(skipped)}"
@@ -674,7 +727,7 @@ class Phase:
                         rate_limited.clear()
                         pause_for_rate_limit = False
                     elif pause_for_rate_limit and not running:
-                        names_to_retry = ", ".join(self.target_name(target) for target, _ in rate_limited)
+                        names_to_retry = ", ".join(self.target_name(request.target) for request in rate_limited)
                         print(f"[{_ts()}] Rate limited: waiting before retrying {names_to_retry}")
                         self._wait_for_rate_limit()
                         # Retry only targets that returned 75. Successful targets
@@ -855,6 +908,7 @@ class Phase:
         owner: list[progress.RunningAgent] | None = None,
         target: str = "",
         attempt: int = 1,
+        policy_recovery: bool = False,
     ) -> progress.RunningAgent | None:
         files = self.agent_files(ws, name)
         for d in files["mkdirs"]:
@@ -947,6 +1001,7 @@ class Phase:
                 adapter_name=adapter.stem,
                 target=target,
                 attempt=attempt,
+                policy_recovery=policy_recovery,
             )
             if owner is not None:
                 owner.append(launched)
@@ -1006,7 +1061,7 @@ def run_agent_blocking(
     model: str | None = None,
     effort: str | None = None,
 ) -> tuple[int, str]:
-    """Run ONE agent invocation, blocking, and return (returncode, log text).
+    """Run an agent turn, blocking, and return (returncode, log text).
 
     The blocking sibling of `Phase._launch`: it shares the same adapter path, the
     same flag set (`--prompt-file` / `--max-turns` / `--claude-alias` /
@@ -1023,7 +1078,8 @@ def run_agent_blocking(
     phase deliverable (`confirmed-bugs.md`) exists only after all findings
     aggregate, never after one turn. ``stop_gate=True`` opts back into the
     original phase key and therefore its deliverable contract. Rate-limit (exit
-    75) is the caller's concern — this runs exactly one invocation.
+    75) is the caller's concern. A provider policy block (exit 76) gets one new
+    invocation in the same workspace with a revised continuation prompt.
     """
     caller_cwd = Path.cwd()
     adapter = adapter if adapter.is_absolute() else (caller_cwd / adapter).resolve()
@@ -1038,13 +1094,7 @@ def run_agent_blocking(
 
     prompt = materialize_skill_refs(prompt, adapter)
     prompt_file.parent.mkdir(parents=True, exist_ok=True)
-    prompt_file.write_text(prompt)
-    with contextlib.suppress(OSError):
-        log_file.unlink()
     last_message_file = _last_message_path(log_file)
-    if adapter.stem == "codex":
-        with contextlib.suppress(OSError):
-            last_message_file.unlink()
     env = os.environ.copy()
     env["SPECULA_PHASE"] = phase_key if stop_gate else f"{phase_key}_turn"
     env["SPECULA_WORK_DIR"] = str(work_dir)
@@ -1076,16 +1126,29 @@ def run_agent_blocking(
         *_model_effort_argv(adapter, model, effort),
         f"--log={log_file}",
     ]
-    rc = subprocess.run(cmd, env=env, cwd=run_cwd).returncode
-    # Codex stdout is a complete CLI transcript, not the assistant's final
-    # response.  The adapter keeps that transcript in `log_file` for diagnosis
-    # and asks `codex exec --output-last-message` for the response separately.
-    # A missing Codex sidecar is an incomplete turn; never reinterpret the CLI
-    # transcript as an assistant answer. Other adapters' log contract remains
-    # result-only.
-    result_file = last_message_file if adapter.stem == "codex" else log_file
-    text = result_file.read_text(errors="replace") if result_file.is_file() else ""
-    return rc, text
+    for policy_attempt in range(2):
+        current_prompt = prompt if policy_attempt == 0 else _policy_recovery_prompt(prompt)
+        prompt_file.write_text(current_prompt)
+        with contextlib.suppress(OSError):
+            log_file.unlink()
+        if adapter.stem == "codex":
+            with contextlib.suppress(OSError):
+                last_message_file.unlink()
+
+        rc = subprocess.run(cmd, env=env, cwd=run_cwd).returncode
+        # Codex stdout is a complete CLI transcript, not the assistant's final
+        # response. The adapter keeps that transcript in `log_file` for
+        # diagnosis and asks `codex exec --output-last-message` for the response
+        # separately. A missing Codex sidecar is an incomplete turn; never
+        # reinterpret the CLI transcript as an assistant answer. Other
+        # adapters' log contract remains result-only.
+        result_file = last_message_file if adapter.stem == "codex" else log_file
+        text = result_file.read_text(errors="replace") if result_file.is_file() else ""
+        if rc != POLICY_BLOCKED_RC or policy_attempt == 1:
+            return rc, text
+        print(f"[{_ts()}] Provider policy interrupted the agent turn; continuing once with a revised request")
+
+    raise AssertionError("unreachable")
 
 
 class CodeAnalysisPhase(Phase):
@@ -2166,8 +2229,16 @@ Output:
         with _cleanup_on_signal():
             for name in names:
                 attempt = 1
+                policy_recovery = False
                 while True:
-                    rc = self._launch_review(ws, name, phase, adapter, claude_alias)
+                    rc = self._launch_review(
+                        ws,
+                        name,
+                        phase,
+                        adapter,
+                        claude_alias,
+                        policy_recovery=policy_recovery,
+                    )
                     if (
                         rc == quota.RATE_LIMIT_RC
                         and self._reactive_rate_limit_enabled()
@@ -2176,6 +2247,13 @@ Output:
                         print(f"[{_ts()}] Rate limited: waiting before retrying {name}")
                         self._wait_for_rate_limit()
                         attempt += 1
+                        continue
+                    if rc == POLICY_BLOCKED_RC and not policy_recovery:
+                        print(
+                            f"[{_ts()}] {name}: provider policy interrupted the review; "
+                            "continuing once with a revised request"
+                        )
+                        policy_recovery = True
                         continue
                     if rc != 0:
                         return self._failure_code([(name, rc)])
@@ -2204,7 +2282,16 @@ Output:
                 print(f"  {name}: (no review file generated — check log)")
         return 0
 
-    def _launch_review(self, ws: Workspace, name: str, phase: str, adapter: Path, claude_alias: str) -> int:
+    def _launch_review(
+        self,
+        ws: Workspace,
+        name: str,
+        phase: str,
+        adapter: Path,
+        claude_alias: str,
+        *,
+        policy_recovery: bool = False,
+    ) -> int:
         wd = ws.work_dir(name)
         # specgen/validation logs go under spec/ to match pipeline summary expectations
         log_dir = wd / "spec" if phase in ("specgen", "validation") else wd
@@ -2218,6 +2305,8 @@ Output:
         else:
             print(f"Unknown phase: {phase}")
             raise SystemExit(1)
+        if policy_recovery:
+            prompt = _policy_recovery_prompt(prompt)
         print(f"[{_ts()}] Reviewing {name} ({phase})...")
         log_dir.mkdir(parents=True, exist_ok=True)
         pid_file = log_dir / f"review-{phase}.pid"
@@ -2278,6 +2367,7 @@ Output:
                 activity_stamp=prelaunch_activity_stamp,
                 adapter_name=adapter.stem,
                 target=name,
+                policy_recovery=policy_recovery,
             )
             pid_file.write_text(f"{proc.pid}\n")
             print(f"  PID={proc.pid}  Log: {log_file}")

--- a/src/specula/progress.py
+++ b/src/specula/progress.py
@@ -50,6 +50,7 @@ class RunningAgent:
     last_event: str = ""
     target: str = ""
     attempt: int = 1
+    policy_recovery: bool = False
 
 
 def enabled() -> bool:

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -468,6 +468,82 @@ class ClaudeCodeAdapter(AdapterCase):
         )
         self.assertEqual(r["returncode"], 75)
 
+    def test_terminal_policy_block_exits_shared_status(self) -> None:
+        base = self.sandbox()
+        record = {
+            "type": "result",
+            **CLAUDE_JSON,
+            "is_error": True,
+            "terminal_reason": "api_error",
+            "api_error_status": 400,
+            "result": "This content was flagged for possible cybersecurity risk.",
+        }
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="claude",
+            fixture_text=json.dumps(record),
+            record_extra=True,
+            env_extra={"ADAPTER_EXIT_CODE": "1"},
+        )
+        self.assertEqual(r["returncode"], 76, r["stderr"])
+
+    def test_streaming_plain_policy_diagnostic_uses_failed_cli_status(self) -> None:
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": "working"}]}}),
+                "HTTP 400: This content was flagged for possible cybersecurity risk.",
+            ]
+        )
+        for native_rc, expected in (("9", 76), ("75", 75), ("0", 0)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                activity = base / "out.activity.jsonl"
+                r = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="claude",
+                    fixture_text=fixture,
+                    record_extra=True,
+                    env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "ADAPTER_EXIT_CODE": native_rc},
+                )
+                self.assertEqual(r["returncode"], expected, r["stderr"])
+
+    def test_successful_stream_terminal_suppresses_later_plain_policy_diagnostic(self) -> None:
+        base = self.sandbox()
+        activity = base / "out.activity.jsonl"
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "result", **CLAUDE_JSON}),
+                "HTTP 400: This content was flagged for possible cybersecurity risk.",
+            ]
+        )
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="claude",
+            fixture_text=fixture,
+            record_extra=True,
+            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "ADAPTER_EXIT_CODE": "9"},
+        )
+        self.assertEqual(r["returncode"], 9, r["stderr"])
+
+    def test_successful_result_quoting_policy_message_is_not_blocked(self) -> None:
+        base = self.sandbox()
+        record = {
+            "type": "result",
+            **CLAUDE_JSON,
+            "result": "The old run said output blocked by content filtering policy; the task is now complete.",
+        }
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="claude",
+            fixture_text=json.dumps(record),
+            record_extra=True,
+        )
+        self.assertEqual(r["returncode"], 0, r["stderr"])
+
     def test_rate_limit_in_stream_result_exits_75(self) -> None:
         base = self.sandbox()
         activity = base / "out.activity.jsonl"
@@ -1345,6 +1421,104 @@ class OpenCodeAdapter(AdapterCase):
             "OpenCode parent session not found in session database",
         )
 
+    def test_structured_policy_block_maps_to_shared_status(self) -> None:
+        base = self.sandbox()
+        records = [
+            {
+                "type": "error",
+                "sessionID": "ses_blocked",
+                "error": {
+                    "name": "APIError",
+                    "data": {
+                        "code": "content_policy_violation",
+                        "message": "Output blocked by content filtering policy",
+                        "statusCode": 400,
+                    },
+                },
+            },
+            {
+                "type": "step_finish",
+                "sessionID": "ses_blocked",
+                "part": {"type": "step-finish", "reason": "stop", "tokens": {}},
+            },
+        ]
+        result = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="opencode",
+            fixture_text="\n".join(json.dumps(record) for record in records) + "\n",
+            env_extra={"ADAPTER_EXIT_CODE": "1"},
+            record_extra=True,
+        )
+        self.assertEqual(result["returncode"], 76, result["stderr"])
+
+    def test_plain_policy_diagnostic_uses_failed_cli_status(self) -> None:
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "step_start", "sessionID": "ses_blocked", "part": {}}),
+                "HTTP 400: This content was flagged for possible cybersecurity risk.",
+            ]
+        )
+        for native_rc, expected in (("9", 76), ("75", 75)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                result = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="opencode",
+                    fixture_text=fixture,
+                    env_extra={"ADAPTER_EXIT_CODE": native_rc},
+                    record_extra=True,
+                )
+                self.assertEqual(result["returncode"], expected, result["stderr"])
+
+    def test_policy_error_followed_by_new_output_and_stop_is_recovered(self) -> None:
+        base = self.sandbox()
+        records = [
+            {
+                "type": "error",
+                "sessionID": "ses_recovered",
+                "error": {"data": {"code": "cyber_policy", "message": "content policy blocked response"}},
+            },
+            {
+                "type": "text",
+                "sessionID": "ses_recovered",
+                "part": {"type": "text", "text": "continued successfully"},
+            },
+            {
+                "type": "step_finish",
+                "sessionID": "ses_recovered",
+                "part": {"type": "step-finish", "reason": "stop", "tokens": {}},
+            },
+        ]
+        result = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="opencode",
+            fixture_text="\n".join(json.dumps(record) for record in records) + "\n",
+            record_extra=True,
+        )
+        self.assertEqual(result["returncode"], 0, result["stderr"])
+
+    def test_native_rate_limit_wins_over_structured_policy_block(self) -> None:
+        base = self.sandbox()
+        fixture = json.dumps(
+            {
+                "type": "error",
+                "sessionID": "ses_blocked",
+                "error": {"data": {"code": "cyber_policy", "message": "content policy blocked response"}},
+            }
+        )
+        result = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="opencode",
+            fixture_text=fixture,
+            env_extra={"ADAPTER_EXIT_CODE": "75"},
+            record_extra=True,
+        )
+        self.assertEqual(result["returncode"], 75, result["stderr"])
+
     def test_structured_rate_limit_maps_native_failure_to_retry_status(self) -> None:
         base = self.sandbox()
         records = [
@@ -1840,6 +2014,73 @@ class PiAdapter(AdapterCase):
                 self.assertIn(message, result["stderr"])
                 self.assertEqual((base / "out.log").read_text(), f"adapter error: {message}\n")
 
+    def test_structured_policy_block_maps_to_shared_status(self) -> None:
+        base = self.sandbox()
+        fixture = json.dumps(
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "content": [],
+                    "stopReason": "error",
+                    "errorMessage": "This content was flagged for possible cybersecurity risk.",
+                    "usage": {},
+                },
+            }
+        )
+        result = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="pi",
+            fixture_text=fixture,
+            record_extra=True,
+        )
+        self.assertEqual(result["returncode"], 76, result["stderr"])
+
+    def test_plain_policy_diagnostic_uses_failed_cli_status(self) -> None:
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "session", "id": "pi_blocked"}),
+                "HTTP 400: This content was flagged for possible cybersecurity risk.",
+            ]
+        )
+        for native_rc, expected in (("9", 76), ("75", 75)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                result = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="pi",
+                    fixture_text=fixture,
+                    env_extra={"ADAPTER_EXIT_CODE": native_rc},
+                    record_extra=True,
+                )
+                self.assertEqual(result["returncode"], expected, result["stderr"])
+
+    def test_native_rate_limit_wins_over_structured_policy_block(self) -> None:
+        base = self.sandbox()
+        fixture = json.dumps(
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "content": [],
+                    "stopReason": "error",
+                    "errorMessage": "This content was flagged for possible cybersecurity risk.",
+                    "usage": {},
+                },
+            }
+        )
+        result = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="pi",
+            fixture_text=fixture,
+            env_extra={"ADAPTER_EXIT_CODE": "75"},
+            record_extra=True,
+        )
+        self.assertEqual(result["returncode"], 75, result["stderr"])
+
     def test_structured_rate_limit_maps_to_retry_status(self) -> None:
         for native_status in (0, 1):
             with self.subTest(native_status=native_status):
@@ -2312,6 +2553,135 @@ class CodexAdapter(AdapterCase):
                 r = self.invoke(self.base_flags(base), env_extra={"ADAPTER_EXIT_CODE": cli_rc})
                 self.assertEqual(r["returncode"], int(cli_rc), r["stderr"])
 
+    def test_policy_block_overrides_native_failure_with_activity_stream(self) -> None:
+        base = self.sandbox()
+        activity = base / "out.activity.jsonl"
+        fixture = json.dumps(
+            {
+                "type": "turn.failed",
+                "error": {
+                    "code": "cyber_policy",
+                    "message": "This content was flagged for possible cybersecurity risk.",
+                },
+            }
+        )
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="codex",
+            fixture_text=fixture,
+            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "ADAPTER_EXIT_CODE": "9"},
+            record_extra=True,
+        )
+        self.assertEqual(r["returncode"], 76, r["stderr"])
+
+    def test_streaming_plain_policy_diagnostic_uses_failed_cli_status(self) -> None:
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": "thread-1"}),
+                "HTTP 400: This content was flagged for possible cybersecurity risk.",
+            ]
+        )
+        for native_rc, expected in (("9", 76), ("75", 75), ("0", 0)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                activity = base / "out.activity.jsonl"
+                r = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="codex",
+                    fixture_text=fixture,
+                    env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "ADAPTER_EXIT_CODE": native_rc},
+                    record_extra=True,
+                )
+                self.assertEqual(r["returncode"], expected, r["stderr"])
+
+    def test_successful_stream_terminal_suppresses_later_plain_policy_diagnostic(self) -> None:
+        base = self.sandbox()
+        activity = base / "out.activity.jsonl"
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "turn.completed", "usage": {}}),
+                "HTTP 400: This content was flagged for possible cybersecurity risk.",
+            ]
+        )
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="codex",
+            fixture_text=fixture,
+            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "ADAPTER_EXIT_CODE": "9"},
+            record_extra=True,
+        )
+        self.assertEqual(r["returncode"], 9, r["stderr"])
+
+    def test_later_structured_record_supersedes_plain_policy_diagnostic(self) -> None:
+        base = self.sandbox()
+        activity = base / "out.activity.jsonl"
+        fixture = "\n".join(
+            [
+                "HTTP 400: This content was flagged for possible cybersecurity risk.",
+                json.dumps({"type": "turn.failed", "error": {"message": "unrelated transport failure"}}),
+            ]
+        )
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="codex",
+            fixture_text=fixture,
+            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "ADAPTER_EXIT_CODE": "9"},
+            record_extra=True,
+        )
+        self.assertEqual(r["returncode"], 9, r["stderr"])
+
+    def test_policy_error_followed_by_completed_turn_is_recovered(self) -> None:
+        base = self.sandbox()
+        activity = base / "out.activity.jsonl"
+        fixture = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "turn.failed",
+                        "error": {"code": "cyber_policy", "message": "content policy blocked response"},
+                    }
+                ),
+                json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "recovered"}}),
+                json.dumps({"type": "turn.completed", "usage": {}}),
+            ]
+        )
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="codex",
+            fixture_text=fixture,
+            env_extra={"SPECULA_ACTIVITY_LOG": str(activity)},
+            record_extra=True,
+        )
+        self.assertEqual(r["returncode"], 0, r["stderr"])
+
+    def test_progress_off_failed_policy_diagnostic_exits_shared_status(self) -> None:
+        base = self.sandbox()
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="codex",
+            fixture_text="HTTP 400: output blocked by content filtering policy\n",
+            env_extra={"ADAPTER_EXIT_CODE": "9"},
+            record_extra=True,
+        )
+        self.assertEqual(r["returncode"], 76, r["stderr"])
+
+    def test_progress_off_successful_policy_quote_remains_success(self) -> None:
+        base = self.sandbox()
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="codex",
+            fixture_text="The old log said output blocked by content filtering policy.\n",
+            record_extra=True,
+        )
+        self.assertEqual(r["returncode"], 0, r["stderr"])
+
     def test_structured_turn_failure_is_logged_but_cli_owns_status(self) -> None:
         base = self.sandbox()
         activity = base / "out.activity.jsonl"
@@ -2343,6 +2713,11 @@ class CodexAdapter(AdapterCase):
                 "item",
                 {"type": "item.completed", "item": {"id": "item_1", "type": "error", "message": "lagged"}},
                 "adapter warning: lagged\n",
+            ),
+            (
+                "non-terminal-policy-diagnostic",
+                {"type": "error", "message": "content policy blocked one transient response"},
+                "adapter error: content policy blocked one transient response\n",
             ),
         ]
         for name, record, expected_log in cases:
@@ -2548,8 +2923,9 @@ class CopilotAdapter(AdapterCase):
         base = self.sandbox()
         r = self.invoke(self.base_flags(base))
         self.assertEqual(r["returncode"], 0)
-        # copilot -p "<prompt>" --allow-all --autopilot
-        self.assertEqual(r["argv"], ["-p", "the prompt", "--allow-all", "--autopilot"])
+        # --silent suppresses Copilot's stats footer without hiding provider
+        # diagnostics written to stderr.
+        self.assertEqual(r["argv"], ["-p", "the prompt", "--allow-all", "--autopilot", "--silent"])
 
     def test_autopilot_requires_supported_cli(self) -> None:
         base = self.sandbox()
@@ -2561,7 +2937,10 @@ class CopilotAdapter(AdapterCase):
     def test_model_flag_appended(self) -> None:
         base = self.sandbox()
         r = self.invoke(self.base_flags(base) + ["--model=gpt-5"])
-        self.assertEqual(r["argv"], ["-p", "the prompt", "--allow-all", "--autopilot", "--model", "gpt-5"])
+        self.assertEqual(
+            r["argv"],
+            ["-p", "the prompt", "--allow-all", "--autopilot", "--silent", "--model", "gpt-5"],
+        )
 
     def test_model_from_env(self) -> None:
         base = self.sandbox()
@@ -2594,7 +2973,7 @@ class CopilotAdapter(AdapterCase):
         self.assertEqual(r["returncode"], 0)
         self.assertEqual(
             r["argv"],
-            ["-p", "the prompt", "--allow-all", "--autopilot", "--reasoning-effort", "high"],
+            ["-p", "the prompt", "--allow-all", "--autopilot", "--silent", "--reasoning-effort", "high"],
         )
 
     def test_effort_alias_fallback(self) -> None:
@@ -2617,7 +2996,7 @@ class CopilotAdapter(AdapterCase):
         base = self.sandbox()
         r = self.invoke(self.base_flags(base) + ["--effort="])
         self.assertEqual(r["returncode"], 0, r["stderr"])
-        self.assertEqual(r["argv"], ["-p", "the prompt", "--allow-all", "--autopilot"])
+        self.assertEqual(r["argv"], ["-p", "the prompt", "--allow-all", "--autopilot", "--silent"])
 
     def test_output_redirected_to_log(self) -> None:
         base = self.sandbox()
@@ -2695,6 +3074,52 @@ class CopilotAdapter(AdapterCase):
         self.assertEqual(r["returncode"], 0, r["stderr"])
         self.assertEqual((base / "out.log").read_text(), fixture)
         self.assertEqual(activity.read_text(), fixture)
+
+    def test_old_cli_json_shaped_policy_text_is_not_an_error_event(self) -> None:
+        fixture = json.dumps(
+            {
+                "type": "session.error",
+                "data": {
+                    "errorType": "cyber_policy",
+                    "message": "The old run quoted a content policy blocked response.",
+                },
+            }
+        )
+        for native_rc in ("0", "9"):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                activity = base / "out.activity.jsonl"
+                r = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="copilot",
+                    fixture_text=fixture,
+                    env_extra={
+                        "SPECULA_ACTIVITY_LOG": str(activity),
+                        "COPILOT_HELP_TEXT": "--autopilot\n--stream",
+                        "ADAPTER_EXIT_CODE": native_rc,
+                    },
+                )
+                self.assertEqual(r["returncode"], int(native_rc), r["stderr"])
+                self.assertEqual((base / "out.log").read_text(), fixture + "\n")
+                self.assertEqual(activity.read_text(), fixture)
+
+    def test_old_cli_plain_policy_failure_maps_to_shared_status(self) -> None:
+        base = self.sandbox()
+        activity = base / "out.activity.jsonl"
+        fixture = "HTTP 400: This content was flagged for possible cybersecurity risk.\n"
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="copilot",
+            fixture_text=fixture,
+            env_extra={
+                "SPECULA_ACTIVITY_LOG": str(activity),
+                "COPILOT_HELP_TEXT": "--autopilot\n--stream",
+                "ADAPTER_EXIT_CODE": "9",
+            },
+        )
+        self.assertEqual(r["returncode"], 76, r["stderr"])
 
     def test_cli_without_stream_support_falls_back_without_new_flags(self) -> None:
         base = self.sandbox()
@@ -2795,6 +3220,128 @@ class CopilotAdapter(AdapterCase):
             },
         )
         self.assertEqual(r["returncode"], 9, r["stderr"])
+
+    def test_policy_session_error_overrides_native_failure(self) -> None:
+        base = self.sandbox()
+        activity = base / "out.activity.jsonl"
+        fixture = json.dumps(
+            {
+                "type": "session.error",
+                "data": {
+                    "errorType": "cyber_policy",
+                    "message": "This content was flagged for possible cybersecurity risk.",
+                    "statusCode": 400,
+                },
+            }
+        )
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="copilot",
+            fixture_text=fixture,
+            env_extra={
+                "SPECULA_ACTIVITY_LOG": str(activity),
+                "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream",
+                "ADAPTER_EXIT_CODE": "9",
+            },
+        )
+        self.assertEqual(r["returncode"], 76, r["stderr"])
+
+    def test_json_stream_plain_policy_diagnostic_uses_failed_cli_status(self) -> None:
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "session.start", "data": {"sessionId": "session-1"}}),
+                "HTTP 400: This content was flagged for possible cybersecurity risk.",
+            ]
+        )
+        for native_rc, expected in (("9", 76), ("75", 75), ("0", 0)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                activity = base / "out.activity.jsonl"
+                r = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="copilot",
+                    fixture_text=fixture,
+                    env_extra={
+                        "SPECULA_ACTIVITY_LOG": str(activity),
+                        "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream",
+                        "ADAPTER_EXIT_CODE": native_rc,
+                    },
+                )
+                self.assertEqual(r["returncode"], expected, r["stderr"])
+
+    def test_successful_stream_terminal_suppresses_later_plain_policy_diagnostic(self) -> None:
+        base = self.sandbox()
+        activity = base / "out.activity.jsonl"
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "result", "exitCode": 0}),
+                "HTTP 400: This content was flagged for possible cybersecurity risk.",
+            ]
+        )
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="copilot",
+            fixture_text=fixture,
+            env_extra={
+                "SPECULA_ACTIVITY_LOG": str(activity),
+                "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream",
+                "ADAPTER_EXIT_CODE": "9",
+            },
+        )
+        self.assertEqual(r["returncode"], 9, r["stderr"])
+
+    def test_policy_session_error_followed_by_success_result_is_recovered(self) -> None:
+        base = self.sandbox()
+        activity = base / "out.activity.jsonl"
+        fixture = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "session.error",
+                        "data": {"errorType": "cyber_policy", "message": "content policy blocked response"},
+                    }
+                ),
+                json.dumps({"type": "assistant.message", "data": {"content": "recovered"}}),
+                json.dumps({"type": "result", "exitCode": 0}),
+            ]
+        )
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="copilot",
+            fixture_text=fixture,
+            env_extra={
+                "SPECULA_ACTIVITY_LOG": str(activity),
+                "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream",
+            },
+        )
+        self.assertEqual(r["returncode"], 0, r["stderr"])
+
+    def test_progress_off_failed_policy_diagnostic_exits_shared_status(self) -> None:
+        base = self.sandbox()
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="copilot",
+            fixture_text="HTTP 400: output blocked by content filtering policy\n",
+            env_extra={"COPILOT_HELP_TEXT": "--autopilot", "ADAPTER_EXIT_CODE": "9"},
+        )
+        self.assertEqual(r["returncode"], 76, r["stderr"])
+        self.assertIn("--silent", r["argv"])
+
+    def test_progress_off_successful_policy_quote_remains_success(self) -> None:
+        base = self.sandbox()
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="copilot",
+            fixture_text="The old log said output blocked by content filtering policy.\n",
+            env_extra={"COPILOT_HELP_TEXT": "--autopilot"},
+        )
+        self.assertEqual(r["returncode"], 0, r["stderr"])
 
     @unittest.skipUnless(Path("/dev/full").exists(), "requires /dev/full")
     def test_readable_log_failure_keeps_raw_stream_and_fails_adapter(self) -> None:

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -49,6 +49,7 @@ if str(SRC) not in sys.path:  # test the tree this file lives in, installed or n
 import specula.progress as progress_module  # noqa: E402
 import specula.quota as quota  # noqa: E402
 from specula import phaselib  # noqa: E402
+from specula.adapters.utils.policy import POLICY_BLOCKED_RC  # noqa: E402
 from specula.progress import ProgressConfig, RunningAgent  # noqa: E402
 from specula.skill_refs import CODEX_PLUGIN_NAME, prompt_skill_ids  # noqa: E402
 
@@ -767,6 +768,158 @@ class TestHandoffGate(PhaseCase):
         self.assertIn("FAILED  missing: next-phase prerequisites not met", out)
         self.assertNotIn("FAILED  passed: next-phase prerequisites not met", out)
 
+    def test_policy_block_with_complete_handoff_still_requires_continuation(self) -> None:
+        count = self.tmp() / "count"
+        handoff_calls: list[list[str]] = []
+
+        def check(_self: phaselib.SpecGenerationPhase, ws: phaselib.Workspace, names: list[str]) -> bool:
+            handoff_calls.append(names)
+            return all((ws.work_dir(name) / "modeling-brief.md").is_file() for name in names)
+
+        self.patch_attr(phaselib.SpecGenerationPhase, "check", check)
+        self.set_env("COUNT_FILE", str(count))
+        self.write_adapter(
+            'printf x >> "$COUNT_FILE"\n'
+            'printf "brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
+            '[ "$(wc -c < "$COUNT_FILE")" -ne 1 ] || exit 76\n'
+        )
+
+        rc, out = self.run_analysis()
+
+        self.assertEqual(rc, 0, out)
+        self.assertEqual(count.read_text(), "xx")
+        self.assertEqual(handoff_calls, [[NAME]])
+        self.assertIn("continuing once with a revised request", out)
+
+    def test_repeated_policy_block_is_not_whitened_by_preexisting_handoff(self) -> None:
+        count = self.tmp() / "count"
+        brief = self.work_dir() / "modeling-brief.md"
+        brief.parent.mkdir(parents=True, exist_ok=True)
+        brief.write_text("stale brief\n")
+        self.set_env("COUNT_FILE", str(count))
+        self.write_adapter('printf x >> "$COUNT_FILE"\nexit 76\n')
+
+        rc, out = self.run_analysis()
+
+        self.assertEqual(rc, POLICY_BLOCKED_RC, out)
+        self.assertEqual(count.read_text(), "xx")
+
+    def test_policy_block_continues_once_with_changed_prompt_in_same_workspace(self) -> None:
+        count = self.tmp() / "count"
+        captures = self.tmp()
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("CAPTURE_DIR", str(captures))
+        self.write_adapter(
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            'for arg do case "$arg" in --prompt-file=*) prompt=${arg#*=} ;; esac; done\n'
+            'cp "$prompt" "$CAPTURE_DIR/prompt-$attempt.md"\n'
+            'printf "%s\\n" "$SPECULA_WORK_DIR" >> "$CAPTURE_DIR/workspaces"\n'
+            '[ "$attempt" -ne 1 ] || exit 76\n'
+            'printf "brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
+        )
+
+        rc, out = self.run_analysis()
+
+        self.assertEqual(rc, 0, out)
+        self.assertEqual(count.read_text(), "xx")
+        first = (captures / "prompt-1.md").read_text()
+        second = (captures / "prompt-2.md").read_text()
+        self.assertNotIn("Continue After Provider Policy Interruption", first)
+        self.assertIn("Continue After Provider Policy Interruption", second)
+        self.assertTrue(second.startswith(first.rstrip()))
+        self.assertEqual((captures / "workspaces").read_text().splitlines(), [str(self.work_dir())] * 2)
+        self.assertIn("continuing once with a revised request", out)
+
+    def test_repeated_policy_block_stops_after_one_continuation(self) -> None:
+        count = self.tmp() / "count"
+        self.set_env("COUNT_FILE", str(count))
+        self.write_adapter('printf x >> "$COUNT_FILE"\nexit 76\n')
+
+        rc, out = self.run_analysis()
+
+        self.assertEqual(rc, POLICY_BLOCKED_RC, out)
+        self.assertEqual(count.read_text(), "xx")
+        self.assertIn(f"adapter exited {POLICY_BLOCKED_RC}", out)
+
+    def test_policy_and_rate_limit_retry_budgets_are_independent(self) -> None:
+        count = self.tmp() / "count"
+        self.set_env("COUNT_FILE", str(count))
+        self.write_adapter(
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            '[ "$attempt" -ne 1 ] || exit 76\n'
+            '[ "$attempt" -ne 2 ] || exit 75\n'
+            'printf "brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
+        )
+        waits: list[int] = []
+        self.patch_attr(phaselib.Phase, "_wait_for_rate_limit", lambda _self: waits.append(1))
+        self.set_env("SPECULA_RATE_LIMIT_REACTIVE", "1")
+        self.set_env("SPECULA_RATE_LIMIT_RETRIES", "1")
+
+        rc, out = self.run_analysis()
+
+        self.assertEqual(rc, 0, out)
+        self.assertEqual(count.read_text(), "xxx")
+        self.assertEqual(waits, [1])
+
+    def test_policy_recovery_does_not_reset_spent_rate_limit_retries(self) -> None:
+        count = self.tmp() / "count"
+        self.set_env("COUNT_FILE", str(count))
+        self.write_adapter(
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            '[ "$attempt" -ne 1 ] || exit 75\n'
+            '[ "$attempt" -ne 2 ] || exit 76\n'
+            '[ "$attempt" -ne 3 ] || exit 75\n'
+            'printf "brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
+        )
+        waits: list[int] = []
+        self.patch_attr(phaselib.Phase, "_wait_for_rate_limit", lambda _self: waits.append(1))
+        self.set_env("SPECULA_RATE_LIMIT_REACTIVE", "1")
+        self.set_env("SPECULA_RATE_LIMIT_RETRIES", "1")
+
+        rc, out = self.run_analysis()
+
+        self.assertEqual(rc, quota.RATE_LIMIT_RC, out)
+        self.assertEqual(count.read_text(), "xxx")
+        self.assertEqual(waits, [1])
+
+    def test_policy_recovery_is_independent_per_parallel_target(self) -> None:
+        counts = self.tmp()
+        self.set_env("COUNT_DIR", str(counts))
+        self.write_adapter(
+            'name=$(basename "$(dirname "$SPECULA_WORK_DIR")")\n'
+            'printf x >> "$COUNT_DIR/$name"\n'
+            'if [ "$name" = a ] && [ "$(wc -c < "$COUNT_DIR/$name")" -eq 1 ]; then exit 76; fi\n'
+            'printf "brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
+        )
+
+        rc, out = self.run_phase(
+            "code_analysis",
+            [
+                "--max-parallel=2",
+                f"--agent={self.adapter.stem}",
+                self.artifact_flag(),
+                "a|g|Go|r",
+                "b|g|Go|r",
+            ],
+        )
+
+        self.assertEqual(rc, 0, out)
+        self.assertEqual((counts / "a").read_text(), "xx")
+        self.assertEqual((counts / "b").read_text(), "x")
+
+    def test_ordinary_adapter_failure_is_not_retried(self) -> None:
+        count = self.tmp() / "count"
+        self.set_env("COUNT_FILE", str(count))
+        self.write_adapter('printf x >> "$COUNT_FILE"\nexit 9\n')
+
+        rc, out = self.run_analysis()
+
+        self.assertEqual(rc, 9, out)
+        self.assertEqual(count.read_text(), "x")
+
 
 class TestLegacyRepairIdentityFinalization(PhaseCase):
     def setUp(self) -> None:
@@ -1112,6 +1265,64 @@ class TestLegacyRepairIdentityFinalization(PhaseCase):
 
 
 class TestRunAgentBlocking(PhaseCase):
+    def test_policy_block_continues_once_with_revised_prompt(self) -> None:
+        adapter = self.tmp() / "adapter.sh"
+        count = self.tmp() / "count"
+        captures = self.tmp()
+        adapter.write_text(
+            "#!/bin/sh\n"
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            'for arg do case "$arg" in --prompt-file=*) prompt=${arg#*=} ;; --log=*) log=${arg#*=} ;; esac; done\n'
+            'cp "$prompt" "$CAPTURE_DIR/prompt-$attempt.md"\n'
+            '[ "$attempt" -ne 1 ] || exit 76\n'
+            'printf "continued\\n" > "$log"\n'
+        )
+        adapter.chmod(0o755)
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("CAPTURE_DIR", str(captures))
+
+        rc, text = phaselib.run_agent_blocking(
+            adapter,
+            "original prompt",
+            captures / "prompt.md",
+            captures / "turn.log",
+            phase_key="bug_confirmation",
+            work_dir=self.work_dir(),
+            claude_alias="profile",
+        )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(text, "continued\n")
+        self.assertEqual(count.read_text(), "xx")
+        self.assertEqual((captures / "prompt-1.md").read_text(), "original prompt")
+        second_prompt = (captures / "prompt-2.md").read_text()
+        self.assertTrue(second_prompt.startswith("original prompt"))
+        self.assertIn(
+            "Continue After Provider Policy Interruption",
+            second_prompt,
+        )
+
+    def test_policy_block_in_blocking_turn_is_bounded(self) -> None:
+        adapter = self.tmp() / "adapter.sh"
+        count = self.tmp() / "count"
+        adapter.write_text('#!/bin/sh\nprintf x >> "$COUNT_FILE"\nexit 76\n')
+        adapter.chmod(0o755)
+        self.set_env("COUNT_FILE", str(count))
+
+        rc, _ = phaselib.run_agent_blocking(
+            adapter,
+            "original prompt",
+            self.tmp() / "prompt.md",
+            self.tmp() / "turn.log",
+            phase_key="bug_confirmation",
+            work_dir=self.work_dir(),
+            claude_alias="profile",
+        )
+
+        self.assertEqual(rc, POLICY_BLOCKED_RC)
+        self.assertEqual(count.read_text(), "xx")
+
     def test_turn_phase_scopes_stop_gate_sets_cwd_and_removes_stale_log(self) -> None:
         adapter = self.tmp() / "adapter.sh"
         capture = self.tmp() / "capture.txt"
@@ -2213,6 +2424,71 @@ class TestReviewPhase(PhaseCase):
         rc, out = self.run_phase("review", ["analysis", "--agent=fake", NAME])
         self.assertEqual(rc, 0, out)
         self.assertEqual(count.read_text(), "xx")
+        self.assertEqual(waits, [1])
+
+    def test_review_policy_block_continues_once_with_revised_prompt(self) -> None:
+        count = self.tmp() / "count"
+        prompts = self.tmp()
+        self.install_adapter(
+            "fake",
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            'for arg do case "$arg" in --prompt=*) prompt=${arg#*=} ;; esac; done\n'
+            'printf "%s" "$prompt" > "$PROMPT_DIR/prompt-$attempt.md"\n'
+            '[ "$attempt" -ne 1 ] || exit 76\n',
+        )
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("PROMPT_DIR", str(prompts))
+        self.set_env("SPECULA_PROGRESS", "off")
+
+        rc, out = self.run_phase("review", ["analysis", "--agent=fake", NAME])
+
+        self.assertEqual(rc, 0, out)
+        self.assertEqual(count.read_text(), "xx")
+        self.assertNotIn(
+            "Continue After Provider Policy Interruption",
+            (prompts / "prompt-1.md").read_text(),
+        )
+        first_prompt = (prompts / "prompt-1.md").read_text()
+        second_prompt = (prompts / "prompt-2.md").read_text()
+        self.assertTrue(second_prompt.startswith(first_prompt.rstrip()))
+        self.assertIn(
+            "Continue After Provider Policy Interruption",
+            second_prompt,
+        )
+
+    def test_review_policy_block_is_bounded(self) -> None:
+        count = self.tmp() / "count"
+        self.install_adapter("fake", 'printf x >> "$COUNT_FILE"\nexit 76\n')
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("SPECULA_PROGRESS", "off")
+
+        rc, out = self.run_phase("review", ["analysis", "--agent=fake", NAME])
+
+        self.assertEqual(rc, POLICY_BLOCKED_RC, out)
+        self.assertEqual(count.read_text(), "xx")
+
+    def test_review_policy_recovery_does_not_reset_rate_limit_retries(self) -> None:
+        count = self.tmp() / "count"
+        self.install_adapter(
+            "fake",
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            '[ "$attempt" -ne 1 ] || exit 75\n'
+            '[ "$attempt" -ne 2 ] || exit 76\n'
+            '[ "$attempt" -ne 3 ] || exit 75\n',
+        )
+        waits: list[int] = []
+        self.patch_attr(phaselib.Phase, "_wait_for_rate_limit", lambda _self: waits.append(1))
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("SPECULA_PROGRESS", "off")
+        self.set_env("SPECULA_RATE_LIMIT_REACTIVE", "1")
+        self.set_env("SPECULA_RATE_LIMIT_RETRIES", "1")
+
+        rc, out = self.run_phase("review", ["analysis", "--agent=fake", NAME])
+
+        self.assertEqual(rc, quota.RATE_LIMIT_RC, out)
+        self.assertEqual(count.read_text(), "xxx")
         self.assertEqual(waits, [1])
 
     def test_review_normalizes_signal_exit_status(self) -> None:

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -1,0 +1,176 @@
+"""Boundary tests for provider-policy error classification."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[2] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from specula.adapters.utils.policy import (  # noqa: E402
+    failed_log_has_policy_block,
+    final_diagnostic_has_policy_block,
+    looks_policy_blocked,
+)
+
+
+class TestPolicyErrorPayload(unittest.TestCase):
+    """The caller has already established that each payload is an error."""
+
+    def test_typed_policy_codes(self) -> None:
+        cases = (
+            {"code": "cyber_policy"},
+            {"errorCode": "CYBER-POLICY"},
+            {"error_code": "content_policy_violation"},
+            {"errorType": "content-policy-violation"},
+        )
+        for payload in cases:
+            with self.subTest(payload=payload):
+                self.assertTrue(looks_policy_blocked(payload))
+
+    def test_narrow_policy_text_fallbacks(self) -> None:
+        messages = (
+            "Output blocked by content filtering policy",
+            "Your previous response was blocked by the model's content filter.",
+            "This content was flagged for possible cybersecurity risk.",
+        )
+        for message in messages:
+            with self.subTest(message=message):
+                self.assertTrue(looks_policy_blocked({"message": message}))
+
+    def test_generic_http_400_is_not_a_policy_block(self) -> None:
+        cases = (
+            {
+                "statusCode": 400,
+                "code": "invalid_request_error",
+                "message": "Invalid parameter: messages",
+            },
+            {
+                "error": {
+                    "status": 400,
+                    "type": "bad_request",
+                    "message": "The request body could not be parsed",
+                }
+            },
+        )
+        for payload in cases:
+            with self.subTest(payload=payload):
+                self.assertFalse(looks_policy_blocked(payload))
+
+    def test_text_fallback_does_not_match_broad_policy_language(self) -> None:
+        messages = (
+            "The request was rejected by policy",
+            "Cybersecurity analysis failed before producing a result",
+            "The output filter returned no rows",
+        )
+        for message in messages:
+            with self.subTest(message=message):
+                self.assertFalse(looks_policy_blocked({"message": message}))
+
+    def test_deeply_nested_provider_error_is_recognized(self) -> None:
+        payload = {
+            "error": {
+                "data": {
+                    "response": {
+                        "body": {
+                            "error_code": "content_policy_violation",
+                        }
+                    }
+                }
+            }
+        }
+
+        self.assertTrue(looks_policy_blocked(payload))
+
+    def test_recursion_is_bounded(self) -> None:
+        payload = {
+            "error": {
+                "error": {
+                    "error": {
+                        "error": {
+                            "error": {
+                                "code": "cyber_policy",
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        self.assertFalse(looks_policy_blocked(payload))
+
+
+class TestFailedLogPolicyFallback(unittest.TestCase):
+    def test_failed_log_with_observed_cybersecurity_message(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            log = Path(raw) / "agent.log"
+            log.write_text(
+                "HTTP 400: This content was flagged for possible cybersecurity risk.\n",
+                encoding="utf-8",
+            )
+
+            self.assertTrue(failed_log_has_policy_block(log))
+
+    def test_failed_log_with_typed_cyber_policy_code(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            log = Path(raw) / "agent.log"
+            log.write_text("HTTP 400: error code=cyber_policy\n", encoding="utf-8")
+
+            self.assertTrue(failed_log_has_policy_block(log))
+
+    def test_failed_log_with_generic_400_is_not_a_policy_block(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            log = Path(raw) / "agent.log"
+            log.write_text("HTTP 400: invalid request body\n", encoding="utf-8")
+
+            self.assertFalse(failed_log_has_policy_block(log))
+
+    def test_failed_log_fallback_scans_only_the_recent_tail(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            log = Path(raw) / "agent.log"
+            log.write_text(
+                "output blocked by content filtering policy\n" + ("x" * 300_000),
+                encoding="utf-8",
+            )
+            self.assertFalse(failed_log_has_policy_block(log))
+
+            log.write_text(
+                ("x" * 300_000) + "\noutput blocked by content filtering policy\n",
+                encoding="utf-8",
+            )
+            self.assertTrue(failed_log_has_policy_block(log))
+
+    def test_quoted_policy_text_before_unrelated_failure_is_not_a_policy_block(self) -> None:
+        text = (
+            "The agent report quoted: output blocked by content filtering policy.\nfatal: unrelated transport failure\n"
+        )
+
+        self.assertFalse(final_diagnostic_has_policy_block(text))
+
+    def test_json_shaped_policy_text_is_not_a_plain_diagnostic(self) -> None:
+        text = '{"type":"session.error","data":{"message":"content policy blocked response"}}\n'
+
+        self.assertFalse(final_diagnostic_has_policy_block(text))
+
+    def test_copilot_stats_footer_is_not_scanned_backward(self) -> None:
+        text = (
+            "HTTP 400: This content was flagged for possible cybersecurity risk.\n\n"
+            "Changes    +0 -0\n"
+            "Requests   1 Premium (10s)\n"
+            "Tokens     ↑ 29.9k (11.0k cached) • ↓ 5\n"
+            "Resume this session with: copilot --resume=example\n"
+        )
+
+        self.assertFalse(final_diagnostic_has_policy_block(text))
+
+    def test_missing_failed_log_is_not_a_policy_block(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            self.assertFalse(failed_log_has_policy_block(Path(raw) / "missing.log"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -293,7 +293,7 @@ class TestProgressParsing(unittest.TestCase):
                 raise KeyboardInterrupt
 
             with self.assertRaises(KeyboardInterrupt):
-                stream_events("copilot", raw, log, interrupted_stream())
+                stream_events("copilot-json", raw, log, interrupted_stream())
 
             self.assertEqual(raw.read_bytes(), event)
             self.assertEqual(log.read_text(), "reading kilo.c\n")
@@ -342,7 +342,7 @@ class TestProgressParsing(unittest.TestCase):
 
             stderr = io.StringIO()
             with contextlib.redirect_stderr(stderr):
-                status = stream_events("copilot", Path("/dev/full"), log, source())
+                status = stream_events("copilot-json", Path("/dev/full"), log, source())
 
             self.assertTrue(drained)
             self.assertFalse(status.activity_ok)


### PR DESCRIPTION
## Summary

- normalize structured provider content-policy failures across all supported agent adapters
- retry an affected agent turn once in the same workspace with a revised formal-verification prompt, without model- or agent-specific branching
- recognize a final out-of-band policy diagnostic only when the structured stream has no successful terminal event and the CLI itself fails
- keep pre-JSON Copilot output as agent text and run Copilot with `--silent` so version-specific stats cannot hide provider diagnostics
- preserve rate-limit retry state and reuse the existing phase handoff checks after recovery
- prevent stale handoff files and quoted historical errors from masking or fabricating a successful recovery


Fixes #80
