### PR TITLE
Cap Codex tool output at 10k tokens

### DIFF
--- a/scripts/launch/adapters/codex.sh
+++ b/scripts/launch/adapters/codex.sh
@@ -238,6 +238,8 @@ run_codex() {
   # substantially larger. Preserve the activity stream and the Codex exit code
   # added by the progress lifecycle work.
   cmd+=(codex exec --dangerously-bypass-approvals-and-sandbox --output-last-message "$last_message_file")
+  # Keep one large tool result from jumping past Codex's auto-compaction point.
+  cmd+=(-c "tool_output_token_limit=10000")
   # Model / reasoning effort (additive — empty leaves codex config.toml default).
   [[ -n "$MODEL" ]] && cmd+=(-m "$MODEL")
   [[ -n "$EFFORT" ]] && cmd+=(-c "model_reasoning_effort=$EFFORT")

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -2195,6 +2195,8 @@ class CodexAdapter(AdapterCase):
                 "--dangerously-bypass-approvals-and-sandbox",
                 "--output-last-message",
                 str(base / "out.last-message.txt"),
+                "-c",
+                "tool_output_token_limit=10000",
                 "-",
             ],
         )
@@ -2276,6 +2278,8 @@ class CodexAdapter(AdapterCase):
                 "--dangerously-bypass-approvals-and-sandbox",
                 "--output-last-message",
                 str(base / "out.last-message.txt"),
+                "-c",
+                "tool_output_token_limit=10000",
                 "--json",
                 "-",
             ],
@@ -2440,6 +2444,8 @@ class CodexAdapter(AdapterCase):
                 "--dangerously-bypass-approvals-and-sandbox",
                 "--output-last-message",
                 str(base / "out.last-message.txt"),
+                "-c",
+                "tool_output_token_limit=10000",
                 "-m",
                 "gpt-5.5",
                 "-c",
@@ -2458,7 +2464,8 @@ class CodexAdapter(AdapterCase):
         self.assertEqual(r["returncode"], 0)
         argv = r["argv"]
         self.assertEqual(argv[argv.index("-m") + 1], "gpt-5.6-sol")
-        self.assertEqual(argv[argv.index("-c") + 1], "model_reasoning_effort=ultra")
+        configs = [argv[i + 1] for i, arg in enumerate(argv[:-1]) if arg == "-c"]
+        self.assertEqual(configs, ["tool_output_token_limit=10000", "model_reasoning_effort=ultra"])
         self.assertEqual(r["modelenv"], "<unset>")
         self.assertEqual(r["effortenv"], "<unset>")
 
@@ -2485,6 +2492,8 @@ class CodexAdapter(AdapterCase):
                 "--dangerously-bypass-approvals-and-sandbox",
                 "--output-last-message",
                 str(base / "out.last-message.txt"),
+                "-c",
+                "tool_output_token_limit=10000",
                 "-",
             ],
         )


### PR DESCRIPTION
## Summary

- cap each Codex tool output retained in conversation history at 10,000 tokens
- apply the cap through the shared Codex adapter for every Specula Codex run
- update adapter command-construction tests for normal, streamed, and model/effort paths