### PR TITLE
Preserve invariant coverage during repair

### DIFF
--- a/skills/bug-confirmation/references/repair-request-format.md
+++ b/skills/bug-confirmation/references/repair-request-format.md
@@ -129,13 +129,17 @@ Phase 3 in repair mode (`--repair`) processes each request with status `OPEN`:
 3. Apply the repair for its `target`:
    - **SPEC_REPAIR** — tighten the cited action / add the missing guard in `base.tla` so the model matches the implementation at the cited `file:line`.
    - **FAULT_MODEL** — correct the fault model as a whole: the fault action's semantics in `base.tla`, its counter/wrapper in `MC.tla`, the cfg constants, or removing a fault that is not in the system's failure model. Not just `MC.cfg` bounds.
-   - **INVARIANT** — weaken / correct the cited invariant per the evidence.
+   - **INVARIANT** — revise the cited invariant so it expresses the safety property supported by the request's evidence, cross-checked against the relevant implementation and developer intent. Weakening is sometimes the right consequence, because a false violation often reveals an over-strong requirement, but weakening is never the goal by itself.
+     - Explain why the old violation is an artifact and identify the exact requirement the old invariant imposed that the evidence does not support.
+     - Preserve every part of the invariant that the evidence still supports. Make the smallest evidence-backed revision for this request, then follow Step 4 in order: full trace validation first, scoped model checking second. Do not weaken the invariant again in response to a counterexample from that re-run; record the result and leave the fresh classification to the next Phase 4 pass.
+     - Show that the revised invariant remains a falsifiable oracle in the affected hunt cfgs: identify modeled behavior that could make its predicate false when the prohibited behavior occurs. Do not replace it with `TRUE`, a type predicate already implied by `TypeOK`, an antecedent that is unreachable or always false in every affected cfg, an oracle flag that no modeled transition ever assigns its violating value, or a feature/config guard that disables it in every affected cfg. If another enabled invariant fully subsumes it, record that fact and do not count it as independent coverage.
+     - If the evidence supports no safety property in this area, remove the invariant from the affected cfg wiring instead of replacing it with a vacuous predicate. Keep the definition only if another cfg still uses it, and mark the property not applicable in `brief-coverage.md` and the affected cfg's `bug-report.md` entry so it is not counted as coverage.
 4. Re-validate (follow the validation-workflow skill):
    - Run **full trace validation on all traces** — the soundness gate. If the repair excludes a real trace, it is wrong; undo it and reconsider.
    - Re-run model checking on the request's `scope.hunt_cfgs`, and update `bug-report.md` for the affected cfg.
 5. Set `status: CONSUMED` and append a `History` entry (tag `phase3-repair`) describing what changed and the re-run result (original CE gone / new CE / unchanged).
 
-Process **only** active `OPEN` requests here; never touch `CONSUMED` or `DEFERRED`. The implementation is ground truth — do not overfit the spec to make a trace pass (model checking catches overfit repairs; see the validation-workflow skill). Do not edit `confirmed-bugs.md` in repair mode — the next Phase 4 confirmation pass owns it.
+Process **only** active `OPEN` requests here; never touch `CONSUMED` or `DEFERRED`. The request's cited evidence, cross-checked against the relevant source, tests, documentation, and declared failure model, is the ground truth: do not revise the model or invariant merely to make a trace pass, remove the original counterexample, or obtain a green TLC run. Model checking can show that the revised invariant holds in the explored state space; it cannot by itself show that the invariant still has useful detection power. Do not edit `confirmed-bugs.md` in repair mode — the next Phase 4 confirmation pass owns it.
 
 ## When NOT to create a request
 

--- a/skills/tla-checking-workflow/SKILL.md
+++ b/skills/tla-checking-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tla-checking-workflow
-description: "TLA+ Model Checking workflow. Use when: (1) running TLC model checking or simulation on a TLA+ spec, (2) analyzing counterexamples from invariant violations, (3) determining whether a violation is a spec issue, an overly-strong invariant, or a real bug in the system implementation."
+description: "TLA+ Model Checking workflow. Use when: (1) running TLC model checking or simulation on a TLA+ spec, (2) analyzing counterexamples from invariant violations, (3) determining whether a violation is an invariant mismatch, a spec issue, or a real bug in the system implementation."
 ---
 
 Read `guide.md` for the full workflow methodology.

--- a/skills/tla-checking-workflow/guide.md
+++ b/skills/tla-checking-workflow/guide.md
@@ -1,6 +1,6 @@
 # TLA+ Model Checking Workflow
 
-Run TLC model checking, monitor execution, analyze counterexamples, and determine whether violations stem from overly-strong invariants, spec modeling issues, or real system bugs.
+Run TLC model checking, monitor execution, analyze counterexamples, and determine whether violations stem from invariant mismatches, spec modeling issues, or real system bugs.
 
 ## Input / Output
 
@@ -29,7 +29,7 @@ Every counterexample falls into exactly one category:
 
 | Case | Meaning | Who is Wrong | Action |
 |------|---------|-------------|--------|
-| **Case A** | Invariant Too Strong | Invariant | Weaken the invariant |
+| **Case A** | Invariant Mismatch | Invariant | Revise the invariant to match the implementation-backed safety property |
 | **Case B** | Spec Modeling Issue | Spec | Fix the spec to match implementation |
 | **Case C** | Real Bug | Implementation | STOP — report to user immediately |
 
@@ -174,18 +174,19 @@ If the counterexample's preconditions look implausible in the real system (e.g.,
 
 ### Step 4: Classify the Counterexample
 
-#### Case A: Invariant Too Strong
+#### Case A: Invariant Mismatch
 
 **Signs**:
 - The behavior in the counterexample is reasonable and expected in the real system
 - The implementation intentionally allows this state
-- The invariant is too restrictive — it excludes legitimate system states
+- The invariant encodes a requirement the implementation does not promise — often it is too restrictive, incomplete, or stated at the wrong level
 
 **Action**:
 1. Explain to the user why the behavior is reasonable (cite implementation code)
-2. Propose a weakened invariant that permits this legitimate behavior
-3. Apply the modification
-4. Restart model checking
+2. Identify the exact false requirement in the old invariant and separate it from the constraints the implementation still guarantees
+3. Revise the invariant to express the implementation-backed safety property, preserving every still-valid constraint; weakening may be a consequence, but it is not the objective
+4. Make the smallest evidence-backed revision and restart model checking. Treat every further counterexample as fresh evidence: return to Step 1 and classify it independently before making another change
+5. Confirm that the revised invariant remains a falsifiable oracle in the affected cfgs: identify modeled behavior that could make its predicate false when the prohibited behavior occurs. Do not accept `TRUE`, a type predicate already implied by `TypeOK`, an antecedent that is unreachable or always false in every affected cfg, an oracle flag that no modeled transition ever assigns its violating value, or a feature/config guard that disables the check in every affected cfg. If another enabled invariant fully subsumes it, record that fact and do not count it as independent coverage. If the implementation genuinely promises no safety property in this area, remove the invariant from the affected cfg wiring instead of counting it as coverage; when the current workflow uses `brief-coverage.md` and per-cfg `bug-report.md` entries, mark the property not applicable there
 
 #### Case B: Spec Modeling Issue
 

--- a/skills/workflow-overview.md
+++ b/skills/workflow-overview.md
@@ -111,7 +111,7 @@ Verify spec reproduces every state transition in real traces. Catches spec-imple
 
 ### 3B: Model Checking — Convergence
 
-Run `MC.cfg` (0 faults) to verify structural invariants hold. Fix spec issues (Case A: invariant too strong, Case B: spec modeling issue).
+Run `MC.cfg` (0 faults) to verify structural invariants hold. Fix fidelity issues (Case A: invariant mismatch, Case B: spec modeling issue).
 
 ### 3C: Bug Hunting
 

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -1678,9 +1678,12 @@ Prerequisites:
 
 You are running spec validation in **REPAIR MODE**. The bug-confirmation phase handed
 back counterexamples it judged to be spec / fault-model / invariant **artifacts** (not
-real bugs), each recorded as a repair request. Repair the spec so the artifact no longer
-arises, re-validate, re-run model checking, and mark each request CONSUMED. The pipeline
-then re-confirms the fresh output — you do not re-check anything here.
+real bugs), each recorded as a repair request. Use each request's cited evidence and
+cross-check the relevant implementation, tests, documentation, and declared failure model
+to revise the spec, fault model, or invariant so it faithfully expresses what the system
+permits and guarantees; do not optimize merely for making the artifact disappear.
+Re-validate, re-run model checking, and mark each request CONSUMED. The pipeline then
+re-confirms the fresh output — you do not re-check anything here.
 
 ## Inputs
 - **Repair requests**: {spec_dir}/repair-requests/   (process ONLY status OPEN)

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -536,6 +536,8 @@ class TestRepairMode(PhaseCase):
         self.assertIn(f"--log={wd / 'spec-repair.log'}", out)
         body = (wd / ".spec-repair-prompt.md").read_text()
         self.assertIn("REPAIR MODE", body)
+        self.assertIn("request's cited evidence", body)
+        self.assertIn("do not optimize merely for making the artifact disappear", body)
         for skill in ("bug-confirmation", "validation-workflow", "tla-trace-workflow", "tla-checking-workflow"):
             self.assertIn(f"**{skill}**", body)
             self.assertNotIn(f"${skill}", body)


### PR DESCRIPTION
## Summary

- treat Case A as an invariant mismatch and require the smallest evidence-backed revision that preserves every still-valid constraint
- reject vacuous replacements such as `TRUE`, TypeOK-implied predicates, unreachable antecedents, unwritable oracle flags, and cfg guards that disable the check everywhere
- hand counterexamples from a repair re-run back to Phase 4 for fresh classification instead of weakening the invariant again in the same repair turn
- ground the repair prompt in each request's cited evidence and protect that behavior with a prompt regression test