### PR TITLE
Make policy retries configurable

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -146,7 +146,7 @@ Specula runs Copilot CLI with `--autopilot` and fails before launching a task wh
 
 `--max-turns` maps to Copilot's autopilot continuation limit. Claude Code, Codex, OpenCode, and Pi accept the option for adapter compatibility but do not enforce it. The reviews between steps pass a fixed value of 30 instead of the pipeline option; all four adapters still ignore it. OpenCode and Pi do not support Specula's agent-side stop gate.
 
-`--policy-retries=N` sets the continuation budget for each phase agent or confirmation turn after a provider policy interruption. The default is `20`, so each recovery loop permits the initial adapter invocation plus at most 20 continuation invocations; `0` disables policy recovery.
+`--policy-retries=N` sets the provider-policy continuation budget for each logical phase agent or confirmation turn. The default is `20`, so one logical turn may advance through at most 20 revised continuation levels after its initial request; `0` disables policy recovery. Automatic rate-limit retries preserve the current level and may replay it without resetting or consuming another policy continuation.
 
 ## Output Structure
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -146,6 +146,8 @@ Specula runs Copilot CLI with `--autopilot` and fails before launching a task wh
 
 `--max-turns` maps to Copilot's autopilot continuation limit. Claude Code, Codex, OpenCode, and Pi accept the option for adapter compatibility but do not enforce it. The reviews between steps pass a fixed value of 30 instead of the pipeline option; all four adapters still ignore it. OpenCode and Pi do not support Specula's agent-side stop gate.
 
+`--policy-retries=N` sets the continuation budget for each phase agent or confirmation turn after a provider policy interruption. The default is `20`, so each recovery loop permits the initial adapter invocation plus at most 20 continuation invocations; `0` disables policy recovery.
+
 ## Output Structure
 
 Runs are isolated by default under:
@@ -259,6 +261,7 @@ specula run [options] "name|owner/repository|language|reference"
 | `--tlc-worker-limit=N` | Optionally bound aggregate TLC exploration workers; omitted means report-only |
 | `--max-parallel=N` | Set a hard concurrency limit. If omitted, ordinary steps run 1 target agent at a time and per-finding confirmation runs up to 4 Reproducer agents at a time |
 | `--max-turns=N` | Set Copilot's autopilot continuation limit; accepted but ignored by Claude Code, Codex, OpenCode, and Pi |
+| `--policy-retries=N` | Set provider-policy continuation retries for each phase agent or confirmation turn after its initial adapter invocation (default `20`; `0` disables recovery) |
 | `--enable-reviews` | Enable reviews between steps |
 | `--legacy-confirm` | Use one confirmation agent instead of per-finding agents |
 | `--skip-analysis`, `--skip-specgen`, `--skip-harness` | Reuse earlier outputs |

--- a/skills/workflow-overview.md
+++ b/skills/workflow-overview.md
@@ -165,7 +165,7 @@ After all applicable phases have run, assign a Report Tier (A/B/C) based on the 
 bash scripts/launch/launch_pipeline.sh "system-name|github/repo|Lang|Reference description"
 ```
 
-Options: `--skip-analysis`, `--skip-specgen`, `--skip-harness`, `--skip-validation`, `--max-parallel=N`
+Options: `--skip-analysis`, `--skip-specgen`, `--skip-harness`, `--skip-validation`, `--max-parallel=N`, `--policy-retries=N`
 
 ### Scheduler (with quota monitoring)
 

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -36,12 +36,12 @@ import threading
 import traceback
 from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from specula import quota
-from specula.phaselib import DEFAULT_POLICY_RETRIES, SPECULA_ROOT, Workspace, run_agent_blocking
+from specula.phaselib import DEFAULT_POLICY_RETRIES, SPECULA_ROOT, PolicyRetryState, Workspace, run_agent_blocking
 from specula.prompts import render
 from specula.skill_refs import prompt_skill_ids
 
@@ -162,6 +162,35 @@ class ConfirmConfig:
     rounds: int = 5
     max_turns: str = "0"
     policy_retries: int = DEFAULT_POLICY_RETRIES
+    # Runtime-only cursors survive this config's automatic rc75 retries. They
+    # are deliberately absent from candidate/verdict fingerprints and disk.
+    _policy_states: dict[tuple[str, ...], tuple[str, PolicyRetryState]] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+    _policy_states_lock: Any = field(default_factory=threading.Lock, init=False, repr=False, compare=False)
+
+    def policy_state(self, key: tuple[str, ...], prompt: str) -> PolicyRetryState:
+        """Return the cursor for one stable logical turn in this target run."""
+        prompt_digest = hashlib.sha256(prompt.encode()).hexdigest()
+        with self._policy_states_lock:
+            entry = self._policy_states.get(key)
+            if entry is None or entry[0] != prompt_digest:
+                state = PolicyRetryState()
+                self._policy_states[key] = (prompt_digest, state)
+                return state
+            return entry[1]
+
+    def clear_policy_states(self, prefix: tuple[str, ...] = ()) -> None:
+        """Discard terminal cursors, optionally below one logical-key prefix."""
+        with self._policy_states_lock:
+            if not prefix:
+                self._policy_states.clear()
+                return
+            for key in [key for key in self._policy_states if key[: len(prefix)] == prefix]:
+                del self._policy_states[key]
 
 
 @dataclass
@@ -279,6 +308,7 @@ def run_turn(
     if cfg.dry_run:
         _log(f"    [{f.id}] [DRY] turn {turn_no} {role} → {log.name}")
         return ("REPRODUCED" if role == "A" and turn_no == 1 else None), ""
+    policy_state = cfg.policy_state(("finding", f.id, str(turn_no), role), prompt)
     rc, text = run_agent_blocking(
         cfg.adapter,
         prompt,
@@ -293,6 +323,7 @@ def run_turn(
         model=cfg.model,
         effort=cfg.effort,
         policy_retries=cfg.policy_retries,
+        policy_state=policy_state,
     )
     if rc == 75:
         raise RateLimited(f"{f.id} turn {turn_no} {role}")
@@ -1077,13 +1108,17 @@ def run_finding_safe(cfg: ConfirmConfig, f: Finding) -> Outcome:
     to discard the whole target's report: the rest of the batch still delivers."""
     cached = _load_verdict(f, cfg)
     if cached is not None:
+        cfg.clear_policy_states(("finding", f.id))
         _log(f"  [{f.id}] cached {cached.status} — skip (idempotent)")
         return cached
     try:
         o = run_finding(cfg, f)
         _save_verdict(o, cfg)
+        cfg.clear_policy_states(("finding", f.id))
         return o
     except Exception as exc:  # RateLimited / ConfirmationFailed / anything unexpected
+        if not isinstance(exc, RateLimited):
+            cfg.clear_policy_states(("finding", f.id))
         try:
             f.fdir.mkdir(parents=True, exist_ok=True)
             (f.fdir / "error.txt").write_text(traceback.format_exc())
@@ -2144,6 +2179,7 @@ def consolidate(cfg: ConfirmConfig) -> None:
     if source_errs:
         raise ConsolidateFailed(f"invalid model-checking input for {cfg.name}: {source_errs[0]}")
     if out.is_file() and _candidate_cache_valid(cfg, out, expected_mc_ids, expected_families):
+        cfg.clear_policy_states(("consolidate",))
         _log(f"  {cfg.name}: candidates.json present and valid — skipping consolidate")
         return
     bug_report = spec_dir / "bug-report.md"
@@ -2169,21 +2205,28 @@ def consolidate(cfg: ConfirmConfig) -> None:
     # Do not let a failed agent make a stale output look fresh.
     out.unlink(missing_ok=True)
     (spec_dir / _CANDIDATE_CACHE).unlink(missing_ok=True)
-    rc, _ = run_agent_blocking(
-        cfg.adapter,
-        prompt,
-        spec_dir / ".consolidate.prompt.md",
-        spec_dir / ".consolidate.log",
-        phase_key=PHASE_KEY,
-        work_dir=wd,
-        claude_alias=cfg.claude_alias,
-        max_turns=cfg.max_turns,
-        model=cfg.model,
-        effort=cfg.effort,
-        policy_retries=cfg.policy_retries,
-    )
+    policy_state = cfg.policy_state(("consolidate",), prompt)
+    try:
+        rc, _ = run_agent_blocking(
+            cfg.adapter,
+            prompt,
+            spec_dir / ".consolidate.prompt.md",
+            spec_dir / ".consolidate.log",
+            phase_key=PHASE_KEY,
+            work_dir=wd,
+            claude_alias=cfg.claude_alias,
+            max_turns=cfg.max_turns,
+            model=cfg.model,
+            effort=cfg.effort,
+            policy_retries=cfg.policy_retries,
+            policy_state=policy_state,
+        )
+    except BaseException:
+        cfg.clear_policy_states(("consolidate",))
+        raise
     if rc == 75:
         raise RateLimited(f"{cfg.name} consolidate")
+    cfg.clear_policy_states(("consolidate",))
     if rc != 0:
         out.unlink(missing_ok=True)
         raise ConsolidateFailed(f"consolidate adapter exited {rc}")
@@ -2361,6 +2404,7 @@ def run_parallel_confirmation(cfg: ConfirmConfig) -> int:
     target. Returns 75 for exclusively rate-limited incomplete findings and 1 for
     permanent/format/infrastructure incomplete findings while retaining their
     partial report. Pre-fan-out or aggregation failures withhold the deliverable."""
+    result = 1
     try:
         try:
             if not cfg.dry_run:
@@ -2368,16 +2412,17 @@ def run_parallel_confirmation(cfg: ConfirmConfig) -> int:
                 log_path.parent.mkdir(parents=True, exist_ok=True)
                 log_path.write_text("")  # summary link + `tail -f` follow THIS run
                 _set_log_file(log_path)
-            return _drive_confirmation(cfg)
+            result = _drive_confirmation(cfg)
         except Exception as exc:
             try:
                 _log(f"confirmation driver crashed ({exc})")
             except OSError:
                 print(f"confirmation driver crashed ({exc})", flush=True)
-            if cfg.dry_run:
-                return 1
-            return _withhold(cfg, "confirmation driver failure — deliverable withheld")
+            result = 1 if cfg.dry_run else _withhold(cfg, "confirmation driver failure — deliverable withheld")
+        return result
     finally:
+        if result != quota.RATE_LIMIT_RC:
+            cfg.clear_policy_states()
         _set_log_file(None)
 
 

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -41,7 +41,7 @@ from pathlib import Path
 from typing import Any
 
 from specula import quota
-from specula.phaselib import SPECULA_ROOT, Workspace, run_agent_blocking
+from specula.phaselib import DEFAULT_POLICY_RETRIES, SPECULA_ROOT, Workspace, run_agent_blocking
 from specula.prompts import render
 from specula.skill_refs import prompt_skill_ids
 
@@ -161,6 +161,7 @@ class ConfirmConfig:
     debate: bool = False
     rounds: int = 5
     max_turns: str = "0"
+    policy_retries: int = DEFAULT_POLICY_RETRIES
 
 
 @dataclass
@@ -291,6 +292,7 @@ def run_turn(
         max_turns=cfg.max_turns,
         model=cfg.model,
         effort=cfg.effort,
+        policy_retries=cfg.policy_retries,
     )
     if rc == 75:
         raise RateLimited(f"{f.id} turn {turn_no} {role}")
@@ -2178,6 +2180,7 @@ def consolidate(cfg: ConfirmConfig) -> None:
         max_turns=cfg.max_turns,
         model=cfg.model,
         effort=cfg.effort,
+        policy_retries=cfg.policy_retries,
     )
     if rc == 75:
         raise RateLimited(f"{cfg.name} consolidate")

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -53,6 +53,7 @@ SPECULA_ROOT = SCRIPT_DIR.parent.parent
 LAUNCH_DIR = SPECULA_ROOT / "scripts" / "launch"
 AGENT_TERMINATION_GRACE_SECONDS = 2.0
 MAX_DEBATE_ROUNDS = 5
+DEFAULT_POLICY_RETRIES = 20
 
 
 @dataclass(frozen=True)
@@ -61,7 +62,7 @@ class _LaunchRequest:
 
     target: str
     rate_limit_attempt: int = 1
-    policy_recovery: bool = False
+    policy_attempt: int = 0
 
 
 _POLICY_RECOVERY_NOTE = """
@@ -75,6 +76,13 @@ The previous invocation was interrupted because the provider blocked a response 
 def _policy_recovery_prompt(prompt: str) -> str:
     """Change a blocked request while retaining its phase contract."""
     return prompt.rstrip() + _POLICY_RECOVERY_NOTE
+
+
+def _parse_policy_retries(raw: str) -> int:
+    """Parse a continuation count shared by pipeline, phases, and reviews."""
+    if not re.fullmatch(r"[0-9]+", raw):
+        raise ValueError("expected a non-negative integer")
+    return int(raw)
 
 
 # bash pathname expansion (`for d in .../*/`) orders by the locale collating
@@ -278,6 +286,7 @@ class Phase:
     # reset to the adapter/CLI default, non-empty = explicit override.
     _model: str | None = None
     _effort: str | None = None
+    _policy_retries = DEFAULT_POLICY_RETRIES
 
     # ── per-phase hooks ──
     def parse_flag(self, arg: str, extra: dict[str, str | bool]) -> bool:
@@ -448,6 +457,7 @@ class Phase:
     def run(self, argv: list[str]) -> int:
         max_parallel: int | None = None
         max_turns = "0"
+        policy_retries = DEFAULT_POLICY_RETRIES
         dry_run = False
         check_only = False
         agent = "claude-code"
@@ -482,6 +492,13 @@ class Phase:
                 # Adapter-specific passthrough. Keep it a string: an adapter may
                 # deliberately accept values beyond the launcher's vocabulary.
                 max_turns = arg[len("--max-turns=") :]
+            elif arg.startswith("--policy-retries="):
+                raw = arg[len("--policy-retries=") :]
+                try:
+                    policy_retries = _parse_policy_retries(raw)
+                except ValueError:
+                    print(f"Invalid --policy-retries: '{raw}' (expected a non-negative integer)")
+                    return 1
             elif arg.startswith("--agent="):
                 agent = arg[len("--agent=") :]
             elif arg.startswith("--claude-alias="):
@@ -532,6 +549,7 @@ class Phase:
         # `--effort=` can still reset the underlying CLI to its own default.
         self._model = model if model is not None else (os.environ.get("SPECULA_MODEL") or None)
         self._effort = effort if effort is not None else (os.environ.get("SPECULA_EFFORT") or None)
+        self._policy_retries = policy_retries
 
         # A direct multi-target phase command has no Pipeline.run_dir, but its
         # agents must still share one TLC budget. Preserve the scope supplied by
@@ -585,6 +603,7 @@ class Phase:
         print(f"Targets:      {len(targets)}")
         print(f"Max parallel: {max_parallel}")
         print(f"Max turns:    {max_turns}")
+        print(f"Policy retries: {policy_retries}")
         print()
 
         print(self.check_header)
@@ -637,7 +656,7 @@ class Phase:
                         request = pending.pop(0)
                         name = self.target_name(request.target)
                         prompt = self.build_prompt(ws, request.target)
-                        if request.policy_recovery:
+                        if request.policy_attempt > 0:
                             prompt = _policy_recovery_prompt(prompt)
                         self._launch(
                             ws,
@@ -650,7 +669,7 @@ class Phase:
                             owner=running,
                             target=request.target,
                             attempt=request.rate_limit_attempt,
-                            policy_recovery=request.policy_recovery,
+                            policy_attempt=request.policy_attempt,
                         )
                         print()
 
@@ -674,17 +693,19 @@ class Phase:
                             successful_names.add(completed_agent.name)
                             continue
                         if rc == POLICY_BLOCKED_RC:
-                            if not completed_agent.policy_recovery:
+                            if completed_agent.policy_attempt < self._policy_retries:
+                                next_policy_attempt = completed_agent.policy_attempt + 1
                                 print(
                                     f"[{_ts()}] {completed_agent.name}: provider policy interrupted the run; "
-                                    "continuing once with a revised request"
+                                    f"retrying with a revised request "
+                                    f"({next_policy_attempt}/{self._policy_retries})"
                                 )
                                 pending.insert(
                                     0,
                                     _LaunchRequest(
                                         completed_agent.target,
                                         rate_limit_attempt=completed_agent.attempt,
-                                        policy_recovery=True,
+                                        policy_attempt=next_policy_attempt,
                                     ),
                                 )
                             else:
@@ -696,7 +717,7 @@ class Phase:
                                     _LaunchRequest(
                                         completed_agent.target,
                                         rate_limit_attempt=completed_agent.attempt + 1,
-                                        policy_recovery=completed_agent.policy_recovery,
+                                        policy_attempt=completed_agent.policy_attempt,
                                     )
                                 )
                                 pause_for_rate_limit = True
@@ -908,7 +929,7 @@ class Phase:
         owner: list[progress.RunningAgent] | None = None,
         target: str = "",
         attempt: int = 1,
-        policy_recovery: bool = False,
+        policy_attempt: int = 0,
     ) -> progress.RunningAgent | None:
         files = self.agent_files(ws, name)
         for d in files["mkdirs"]:
@@ -1001,7 +1022,7 @@ class Phase:
                 adapter_name=adapter.stem,
                 target=target,
                 attempt=attempt,
-                policy_recovery=policy_recovery,
+                policy_attempt=policy_attempt,
             )
             if owner is not None:
                 owner.append(launched)
@@ -1060,6 +1081,7 @@ def run_agent_blocking(
     stop_gate: bool = False,
     model: str | None = None,
     effort: str | None = None,
+    policy_retries: int = DEFAULT_POLICY_RETRIES,
 ) -> tuple[int, str]:
     """Run an agent turn, blocking, and return (returncode, log text).
 
@@ -1078,9 +1100,12 @@ def run_agent_blocking(
     phase deliverable (`confirmed-bugs.md`) exists only after all findings
     aggregate, never after one turn. ``stop_gate=True`` opts back into the
     original phase key and therefore its deliverable contract. Rate-limit (exit
-    75) is the caller's concern. A provider policy block (exit 76) gets one new
-    invocation in the same workspace with a revised continuation prompt.
+    75) is the caller's concern. A provider policy block (exit 76) gets up to
+    ``policy_retries`` new invocations in the same workspace with a revised
+    continuation prompt.
     """
+    if policy_retries < 0:
+        raise ValueError("policy_retries must be a non-negative integer")
     caller_cwd = Path.cwd()
     adapter = adapter if adapter.is_absolute() else (caller_cwd / adapter).resolve()
     prompt_file = prompt_file if prompt_file.is_absolute() else (caller_cwd / prompt_file).resolve()
@@ -1126,7 +1151,7 @@ def run_agent_blocking(
         *_model_effort_argv(adapter, model, effort),
         f"--log={log_file}",
     ]
-    for policy_attempt in range(2):
+    for policy_attempt in range(policy_retries + 1):
         current_prompt = prompt if policy_attempt == 0 else _policy_recovery_prompt(prompt)
         prompt_file.write_text(current_prompt)
         with contextlib.suppress(OSError):
@@ -1144,9 +1169,13 @@ def run_agent_blocking(
         # adapters' log contract remains result-only.
         result_file = last_message_file if adapter.stem == "codex" else log_file
         text = result_file.read_text(errors="replace") if result_file.is_file() else ""
-        if rc != POLICY_BLOCKED_RC or policy_attempt == 1:
+        if rc != POLICY_BLOCKED_RC or policy_attempt >= policy_retries:
             return rc, text
-        print(f"[{_ts()}] Provider policy interrupted the agent turn; continuing once with a revised request")
+        next_policy_attempt = policy_attempt + 1
+        print(
+            f"[{_ts()}] Provider policy interrupted the agent turn; retrying with a revised request "
+            f"({next_policy_attempt}/{policy_retries})"
+        )
 
     raise AssertionError("unreachable")
 
@@ -1177,6 +1206,7 @@ Options:
   --check             Only verify repos exist
   --max-parallel=N    Max concurrent agents (default: 1)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
+  --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
   --model=NAME        Model forwarded to the selected adapter
@@ -1295,6 +1325,7 @@ Options:
   --check             Only verify prerequisites exist
   --max-parallel=N    Max concurrent agents (default: 1)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
+  --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
   --model=NAME        Model forwarded to the selected adapter
@@ -1428,6 +1459,7 @@ Options:
   --check             Only verify prerequisites exist
   --max-parallel=N    Max concurrent agents (default: 1)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
+  --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
   --model=NAME        Model forwarded to the selected adapter
@@ -1557,6 +1589,7 @@ Options:
   --check             Only verify prerequisites exist
   --max-parallel=N    Max concurrent agents (default: 1)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
+  --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
   --model=NAME        Model forwarded to the selected adapter
@@ -1674,6 +1707,7 @@ Options:
   --repair            Repair mode: process OPEN repair requests (confirmation back-edge)
   --max-parallel=N    Max concurrent agents (default: 1)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
+  --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
   --model=NAME        Model forwarded to the selected adapter
@@ -1831,6 +1865,7 @@ Options:
   --max-parallel=N    Hard limit for concurrent findings in parallel mode, or concurrent target agents in
                       --legacy-confirm (defaults: 4 in parallel mode, 1 otherwise)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
+  --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
   --model=NAME        Model forwarded to the selected adapter
@@ -1929,6 +1964,7 @@ Prerequisites:
                 claude_alias=claude_alias,
                 model=self._model,
                 effort=self._effort,
+                policy_retries=self._policy_retries,
                 dry_run=dry_run,
                 prompt_extra=self._read_prompt_extra(ws, name),
             )
@@ -2169,6 +2205,7 @@ Options (after <phase>):
   --claude-alias=NAME Claude CLI profile (default: claude)
   --model=NAME        Model forwarded to the selected adapter
   --effort=LEVEL      Reasoning effort forwarded to the selected adapter
+  --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
 
 Phases:
   analysis    — Review code analysis output (modeling-brief.md, analysis-report.md)
@@ -2191,6 +2228,7 @@ Output:
         claude_alias = os.environ.get("CLAUDE_ALIAS") or "claude"
         model: str | None = None
         effort: str | None = None
+        policy_retries = DEFAULT_POLICY_RETRIES
         targets: list[str] = []
         for arg in argv[1:]:
             if arg.startswith("--agent="):
@@ -2201,6 +2239,13 @@ Output:
                 model = arg[len("--model=") :]
             elif arg.startswith("--effort="):
                 effort = arg[len("--effort=") :]
+            elif arg.startswith("--policy-retries="):
+                raw = arg[len("--policy-retries=") :]
+                try:
+                    policy_retries = _parse_policy_retries(raw)
+                except ValueError:
+                    print(f"Invalid --policy-retries: '{raw}' (expected a non-negative integer)")
+                    return 1
             elif arg in ("--help", "-h"):
                 sys.stdout.write(self.usage)
                 return 0
@@ -2209,6 +2254,7 @@ Output:
 
         self._model = model if model is not None else (os.environ.get("SPECULA_MODEL") or None)
         self._effort = effort if effort is not None else (os.environ.get("SPECULA_EFFORT") or None)
+        self._policy_retries = policy_retries
 
         if not phase or not targets:
             print(f"Usage: {SCRIPT_DIR}/phaselib.py review <analysis|specgen|validation> name [name ...]")
@@ -2225,11 +2271,13 @@ Output:
         print("========================================")
         print(f" Specula — Review Agent ({phase})")
         print("========================================")
+        print(f"Policy retries: {policy_retries}")
+        print()
 
         with _cleanup_on_signal():
             for name in names:
                 attempt = 1
-                policy_recovery = False
+                policy_attempt = 0
                 while True:
                     rc = self._launch_review(
                         ws,
@@ -2237,7 +2285,7 @@ Output:
                         phase,
                         adapter,
                         claude_alias,
-                        policy_recovery=policy_recovery,
+                        policy_attempt=policy_attempt,
                     )
                     if (
                         rc == quota.RATE_LIMIT_RC
@@ -2248,12 +2296,12 @@ Output:
                         self._wait_for_rate_limit()
                         attempt += 1
                         continue
-                    if rc == POLICY_BLOCKED_RC and not policy_recovery:
+                    if rc == POLICY_BLOCKED_RC and policy_attempt < self._policy_retries:
+                        policy_attempt += 1
                         print(
                             f"[{_ts()}] {name}: provider policy interrupted the review; "
-                            "continuing once with a revised request"
+                            f"retrying with a revised request ({policy_attempt}/{self._policy_retries})"
                         )
-                        policy_recovery = True
                         continue
                     if rc != 0:
                         return self._failure_code([(name, rc)])
@@ -2290,7 +2338,7 @@ Output:
         adapter: Path,
         claude_alias: str,
         *,
-        policy_recovery: bool = False,
+        policy_attempt: int = 0,
     ) -> int:
         wd = ws.work_dir(name)
         # specgen/validation logs go under spec/ to match pipeline summary expectations
@@ -2305,7 +2353,7 @@ Output:
         else:
             print(f"Unknown phase: {phase}")
             raise SystemExit(1)
-        if policy_recovery:
+        if policy_attempt > 0:
             prompt = _policy_recovery_prompt(prompt)
         print(f"[{_ts()}] Reviewing {name} ({phase})...")
         log_dir.mkdir(parents=True, exist_ok=True)
@@ -2367,7 +2415,7 @@ Output:
                 activity_stamp=prelaunch_activity_stamp,
                 adapter_name=adapter.stem,
                 target=name,
-                policy_recovery=policy_recovery,
+                policy_attempt=policy_attempt,
             )
             pid_file.write_text(f"{proc.pid}\n")
             print(f"  PID={proc.pid}  Log: {log_file}")

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -23,9 +23,10 @@ import secrets
 import signal
 import subprocess
 import sys
+import threading
 import time
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -54,6 +55,14 @@ LAUNCH_DIR = SPECULA_ROOT / "scripts" / "launch"
 AGENT_TERMINATION_GRACE_SECONDS = 2.0
 MAX_DEBATE_ROUNDS = 5
 DEFAULT_POLICY_RETRIES = 20
+
+
+@dataclass
+class PolicyRetryState:
+    """Cursor for one logical agent turn across caller-managed rate-limit retries."""
+
+    policy_attempt: int = 0
+    _lock: Any = field(default_factory=threading.Lock, init=False, repr=False, compare=False)
 
 
 @dataclass(frozen=True)
@@ -1082,6 +1091,7 @@ def run_agent_blocking(
     model: str | None = None,
     effort: str | None = None,
     policy_retries: int = DEFAULT_POLICY_RETRIES,
+    policy_state: PolicyRetryState | None = None,
 ) -> tuple[int, str]:
     """Run an agent turn, blocking, and return (returncode, log text).
 
@@ -1100,9 +1110,11 @@ def run_agent_blocking(
     phase deliverable (`confirmed-bugs.md`) exists only after all findings
     aggregate, never after one turn. ``stop_gate=True`` opts back into the
     original phase key and therefore its deliverable contract. Rate-limit (exit
-    75) is the caller's concern. A provider policy block (exit 76) gets up to
-    ``policy_retries`` new invocations in the same workspace with a revised
-    continuation prompt.
+    75) is the caller's concern. A provider policy block (exit 76) advances up
+    to ``policy_retries`` continuation levels in the same workspace. Callers
+    that automatically replay exit 75 may pass ``policy_state`` so that replay
+    resumes the same level instead of resetting the logical turn's budget. The
+    caller must discard that state after any non-75 terminal result.
     """
     if policy_retries < 0:
         raise ValueError("policy_retries must be a non-negative integer")
@@ -1151,33 +1163,36 @@ def run_agent_blocking(
         *_model_effort_argv(adapter, model, effort),
         f"--log={log_file}",
     ]
-    for policy_attempt in range(policy_retries + 1):
-        current_prompt = prompt if policy_attempt == 0 else _policy_recovery_prompt(prompt)
-        prompt_file.write_text(current_prompt)
-        with contextlib.suppress(OSError):
-            log_file.unlink()
-        if adapter.stem == "codex":
+    state = policy_state if policy_state is not None else PolicyRetryState()
+    with state._lock:
+        if not 0 <= state.policy_attempt <= policy_retries:
+            raise ValueError("policy_state attempt must be within policy_retries")
+        while True:
+            policy_attempt = state.policy_attempt
+            current_prompt = prompt if policy_attempt == 0 else _policy_recovery_prompt(prompt)
+            prompt_file.write_text(current_prompt)
             with contextlib.suppress(OSError):
-                last_message_file.unlink()
+                log_file.unlink()
+            if adapter.stem == "codex":
+                with contextlib.suppress(OSError):
+                    last_message_file.unlink()
 
-        rc = subprocess.run(cmd, env=env, cwd=run_cwd).returncode
-        # Codex stdout is a complete CLI transcript, not the assistant's final
-        # response. The adapter keeps that transcript in `log_file` for
-        # diagnosis and asks `codex exec --output-last-message` for the response
-        # separately. A missing Codex sidecar is an incomplete turn; never
-        # reinterpret the CLI transcript as an assistant answer. Other
-        # adapters' log contract remains result-only.
-        result_file = last_message_file if adapter.stem == "codex" else log_file
-        text = result_file.read_text(errors="replace") if result_file.is_file() else ""
-        if rc != POLICY_BLOCKED_RC or policy_attempt >= policy_retries:
-            return rc, text
-        next_policy_attempt = policy_attempt + 1
-        print(
-            f"[{_ts()}] Provider policy interrupted the agent turn; retrying with a revised request "
-            f"({next_policy_attempt}/{policy_retries})"
-        )
-
-    raise AssertionError("unreachable")
+            rc = subprocess.run(cmd, env=env, cwd=run_cwd).returncode
+            # Codex stdout is a complete CLI transcript, not the assistant's final
+            # response. The adapter keeps that transcript in `log_file` for
+            # diagnosis and asks `codex exec --output-last-message` for the response
+            # separately. A missing Codex sidecar is an incomplete turn; never
+            # reinterpret the CLI transcript as an assistant answer. Other
+            # adapters' log contract remains result-only.
+            result_file = last_message_file if adapter.stem == "codex" else log_file
+            text = result_file.read_text(errors="replace") if result_file.is_file() else ""
+            if rc != POLICY_BLOCKED_RC or policy_attempt >= policy_retries:
+                return rc, text
+            state.policy_attempt = policy_attempt + 1
+            print(
+                f"[{_ts()}] Provider policy interrupted the agent turn; retrying with a revised request "
+                f"({state.policy_attempt}/{policy_retries})"
+            )
 
 
 class CodeAnalysisPhase(Phase):

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -39,7 +39,13 @@ from typing import Any
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from specula import quota as _quota
-from specula.phaselib import _logical_cwd, _normalize_artifact_dir, _wc_l
+from specula.phaselib import (
+    DEFAULT_POLICY_RETRIES,
+    _logical_cwd,
+    _normalize_artifact_dir,
+    _parse_policy_retries,
+    _wc_l,
+)
 from specula.tlc_resources import (
     MEMORY_LIMIT_ENV,
     RUN_POLICY_FILENAME,
@@ -103,6 +109,7 @@ Options:
   --max-parallel=N       Hard limit for concurrent agents. When omitted, ordinary phases run 1 target
                          agent at a time and per-finding bug confirmation runs up to 4 at a time
   --max-turns=N          Max agent turns (default: 0 = unlimited)
+  --policy-retries=N     Policy-block continuation retries after the initial attempt (default: 20; 0 disables)
   --agent=NAME           Agent adapter to use (default: claude-code; e.g., claude-code, codex, copilot-cli, opencode, pi)
   --claude-alias=NAME    Claude CLI profile (default: claude)
   --model=NAME           Model forwarded to every agent adapter
@@ -270,6 +277,7 @@ class Pipeline:
         # including "", is an explicit value forwarded for launcher validation.
         self.max_parallel: str | None = None
         self.max_turns = "0"  # deprecated verbatim passthrough
+        self.policy_retries = DEFAULT_POLICY_RETRIES
         self.dry_run = False
         self.skip_analysis = False
         self.skip_specgen = False
@@ -355,6 +363,16 @@ class Pipeline:
                 self.max_parallel = arg.split("=", 1)[1]
             elif arg.startswith("--max-turns="):
                 self.max_turns = arg.split("=", 1)[1]
+            elif arg.startswith("--policy-retries="):
+                raw = arg.split("=", 1)[1]
+                try:
+                    self.policy_retries = _parse_policy_retries(raw)
+                except ValueError:
+                    print(
+                        f"ERROR: --policy-retries must be a non-negative integer, got '{raw}'",
+                        file=sys.stderr,
+                    )
+                    return 1
             elif arg.startswith("--agent="):
                 self.agent = arg.split("=", 1)[1]
             elif arg.startswith("--claude-alias="):
@@ -617,6 +635,7 @@ class Pipeline:
             "agent": self.agent,
             "model": model,
             "effort": effort,
+            "policy_retries": self.policy_retries,
             "claude_alias": self.claude_alias,
             "artifact": self.artifact,
             "artifact_git_sha": artifact_sha,
@@ -1373,6 +1392,7 @@ class Pipeline:
             args.append(f"--max-parallel={self.max_parallel}")
         args += [
             f"--max-turns={self.max_turns}",
+            f"--policy-retries={self.policy_retries}",
             f"--agent={self.agent}",
             f"--claude-alias={self.claude_alias}",
             *self._model_effort_args(),
@@ -1491,6 +1511,7 @@ class Pipeline:
             phase,
             f"--agent={self.agent}",
             f"--claude-alias={self.claude_alias}",
+            f"--policy-retries={self.policy_retries}",
             *self._model_effort_args(),
             *names,
         ]
@@ -1906,6 +1927,7 @@ class Pipeline:
         print(f"Targets:      {len(self.targets)}")
         print(f"Max parallel: {self._max_parallel_summary()}")
         print(f"Max turns:    {self.max_turns}")
+        print(f"Policy retries: {self.policy_retries}")
         print(f"Agent:        {self.agent}  (claude-alias={self.claude_alias})")
         memory_limit = self.tlc_memory_limit or os.environ.get(MEMORY_LIMIT_ENV) or "auto (80% available)"
         worker_limit = self.tlc_worker_limit or os.environ.get(WORKER_LIMIT_ENV) or "unbounded (report only)"

--- a/src/specula/progress.py
+++ b/src/specula/progress.py
@@ -50,7 +50,7 @@ class RunningAgent:
     last_event: str = ""
     target: str = ""
     attempt: int = 1
-    policy_recovery: bool = False
+    policy_attempt: int = 0
 
 
 def enabled() -> bool:

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -143,7 +143,7 @@ class CliE2E(unittest.TestCase):
         self.assertIn("[DRY RUN] bash scripts/launch/launch_code_analysis.sh", out)
         self.assertIn("Pipeline completed", out)
 
-    def test_run_model_effort_reach_phase_and_review_commands(self) -> None:
+    def test_run_tuning_and_policy_retries_reach_phase_and_review_commands(self) -> None:
         for model, effort in (("gpt-5.5", "high"), ("", "")):
             with self.subTest(model=model, effort=effort):
                 root = self.specroot()
@@ -157,6 +157,7 @@ class CliE2E(unittest.TestCase):
                         "--agent=codex",
                         f"--model={model}",
                         f"--effort={effort}",
+                        "--policy-retries=100",
                         "footest",
                     ],
                     cwd=work,
@@ -167,10 +168,12 @@ class CliE2E(unittest.TestCase):
                 for line in (phase_line, review_line):
                     self.assertIn(f"--model={model}", line)
                     self.assertIn(f"--effort={effort}", line)
+                    self.assertIn("--policy-retries=100", line)
                 self.assertIn("launch_review.sh analysis --agent=codex", review_line)
                 meta = json.loads((self.sole_run_dir(root) / "run.json").read_text())
                 self.assertEqual(meta["model"], model or None)
                 self.assertEqual(meta["effort"], effort or None)
+                self.assertEqual(meta["policy_retries"], 100)
 
     def test_run_json_records_argv(self) -> None:
         root = self.specroot()

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -60,6 +60,38 @@ def _boom(*_args: object, **_kwargs: object) -> tuple[int, str]:
     raise AssertionError("run_agent_blocking must not be called (cached finding)")
 
 
+def _scripted_policy_adapter(root: Path, returncodes: list[int]) -> tuple[Path, Path]:
+    """Create a real adapter that captures prompts and follows one rc script."""
+    adapter = root / "scripted-adapter.sh"
+    count = root / "adapter-count"
+    cases = "\n".join(f"  {attempt}) rc={rc} ;;" for attempt, rc in enumerate(returncodes, 1))
+    adapter.write_text(
+        "#!/bin/sh\n"
+        "prompt=\n"
+        "log=\n"
+        'for arg do case "$arg" in\n'
+        "  --prompt-file=*) prompt=${arg#*=} ;;\n"
+        "  --log=*) log=${arg#*=} ;;\n"
+        "esac; done\n"
+        'printf x >> "$COUNT_FILE"\n'
+        'attempt=$(wc -c < "$COUNT_FILE")\n'
+        'cp "$prompt" "$CAPTURE_DIR/prompt-$attempt.md"\n'
+        'case "$attempt" in\n'
+        f"{cases}\n"
+        "  *) rc=99 ;;\n"
+        "esac\n"
+        'if [ "$rc" -eq 0 ]; then\n'
+        '  printf "%s\\n" "$ADAPTER_SUCCESS_TEXT" > "$log"\n'
+        '  if [ -n "${ADAPTER_OUTPUT_FILE:-}" ]; then\n'
+        '    printf "%s\\n" "$ADAPTER_OUTPUT_TEXT" > "$ADAPTER_OUTPUT_FILE"\n'
+        "  fi\n"
+        "fi\n"
+        'exit "$rc"\n'
+    )
+    adapter.chmod(0o755)
+    return adapter, count
+
+
 class ConfirmCase(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = tempfile.mkdtemp()
@@ -82,7 +114,8 @@ class ConfirmCase(unittest.TestCase):
         return ws
 
     def cfg(self, ws: Workspace, name: str, **kw: Any) -> C.ConfirmConfig:
-        return C.ConfirmConfig(name=name, ws=ws, adapter=Path("/x"), worktree=False, repo_dir="", **kw)
+        adapter = kw.pop("adapter", Path("/x"))
+        return C.ConfirmConfig(name=name, ws=ws, adapter=adapter, worktree=False, repo_dir="", **kw)
 
     def finding(self, ws: Workspace, name: str, fid: str = "MC-1") -> C.Finding:
         fdir = ws.work_dir(name) / "confirmation" / fid
@@ -312,6 +345,27 @@ class TestDriver(ConfirmCase):
         self.assertEqual(rc, 0)
         self.assertEqual(worker_counts, [1])
 
+    def test_parallel_findings_have_independent_policy_state(self) -> None:
+        findings = [{"id": fid, "source": "model-checking", "title": fid, "summary": "s"} for fid in ("MC-1", "MC-2")]
+        ws = self.seed("T", findings)
+        states: dict[str, object] = {}
+        lock = threading.Lock()
+
+        def agent(*args: object, **kwargs: object) -> tuple[int, str]:
+            fid = Path(str(args[2])).parent.name
+            with lock:
+                states[fid] = kwargs["policy_state"]
+            return (0, _response("FALSE POSITIVE"))
+
+        cfg = self.cfg(ws, "T", max_parallel=2)
+        with mock.patch.object(C, "run_agent_blocking", agent):
+            rc = C.run_parallel_confirmation(cfg)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(set(states), {"MC-1", "MC-2"})
+        self.assertIsNot(states["MC-1"], states["MC-2"])
+        self.assertEqual(cfg._policy_states, {})
+
     def test_serial_rate_limit_stops_launching_and_preserves_later_cache(self) -> None:
         findings = [
             {"id": fid, "source": "model-checking", "title": fid, "summary": "s"} for fid in ("MC-1", "MC-2", "MC-3")
@@ -432,6 +486,77 @@ class TestDriver(ConfirmCase):
         self.assertNotIn("STALE REPORT", text)  # overwritten, not left stale
         self.assertIn("INCOMPLETE", text)
 
+    def test_rate_limit_retry_preserves_finding_policy_budget(self) -> None:
+        ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
+        root = Path(self.tmp)
+        adapter, count = _scripted_policy_adapter(root, [76, 75, 76, 0])
+        cfg = self.cfg(ws, "T", adapter=adapter, max_parallel=1, policy_retries=1)
+        env = {
+            "COUNT_FILE": str(count),
+            "CAPTURE_DIR": str(root),
+            "ADAPTER_SUCCESS_TEXT": _response("FALSE POSITIVE"),
+        }
+
+        with mock.patch.dict(os.environ, env, clear=False):
+            first_rc = C.run_parallel_confirmation(cfg)
+            second_rc = C.run_parallel_confirmation(cfg)
+
+        self.assertEqual((first_rc, second_rc), (75, 1))
+        self.assertEqual(count.read_text(), "xxx")
+        prompts = [(root / f"prompt-{attempt}.md").read_text() for attempt in range(1, 4)]
+        marker = "Continue After Provider Policy Interruption"
+        self.assertNotIn(marker, prompts[0])
+        self.assertIn(marker, prompts[1])
+        self.assertEqual(prompts[2], prompts[1])
+        self.assertFalse((root / "prompt-4.md").exists())
+
+    def test_initial_rate_limit_does_not_consume_finding_policy_budget(self) -> None:
+        ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
+        root = Path(self.tmp)
+        adapter, count = _scripted_policy_adapter(root, [75, 76, 0])
+        cfg = self.cfg(ws, "T", adapter=adapter, max_parallel=1, policy_retries=1)
+        env = {
+            "COUNT_FILE": str(count),
+            "CAPTURE_DIR": str(root),
+            "ADAPTER_SUCCESS_TEXT": _response("FALSE POSITIVE"),
+        }
+
+        with mock.patch.dict(os.environ, env, clear=False):
+            first_rc = C.run_parallel_confirmation(cfg)
+            second_rc = C.run_parallel_confirmation(cfg)
+
+        self.assertEqual((first_rc, second_rc), (75, 0))
+        self.assertEqual(count.read_text(), "xxx")
+        prompts = [(root / f"prompt-{attempt}.md").read_text() for attempt in range(1, 4)]
+        marker = "Continue After Provider Policy Interruption"
+        self.assertNotIn(marker, prompts[0])
+        self.assertEqual(prompts[1], prompts[0])
+        self.assertIn(marker, prompts[2])
+
+    def test_later_turn_rate_limit_preserves_earlier_turn_policy_budget(self) -> None:
+        ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
+        root = Path(self.tmp)
+        adapter, count = _scripted_policy_adapter(root, [76, 0, 75, 0, 0])
+        cfg = self.cfg(ws, "T", adapter=adapter, max_parallel=1, policy_retries=1, debate=True, rounds=1)
+        env = {
+            "COUNT_FILE": str(count),
+            "CAPTURE_DIR": str(root),
+            "ADAPTER_SUCCESS_TEXT": _response("ENV_LIMITED"),
+        }
+
+        with mock.patch.dict(os.environ, env, clear=False):
+            first_rc = C.run_parallel_confirmation(cfg)
+            second_rc = C.run_parallel_confirmation(cfg)
+
+        self.assertEqual((first_rc, second_rc), (75, 0))
+        self.assertEqual(count.read_text(), "xxxxx")
+        marker = "Continue After Provider Policy Interruption"
+        self.assertNotIn(marker, (root / "prompt-1.md").read_text())
+        self.assertIn(marker, (root / "prompt-2.md").read_text())
+        self.assertNotIn(marker, (root / "prompt-3.md").read_text())
+        self.assertIn(marker, (root / "prompt-4.md").read_text())
+        self.assertNotIn(marker, (root / "prompt-5.md").read_text())
+
     def test_consolidate_prompt_invokes_installed_skill_without_path(self) -> None:
         ws = Workspace(["T"])
         spec = ws.work_dir("T") / "spec"
@@ -458,6 +583,34 @@ class TestDriver(ConfirmCase):
         self.assertNotIn("$validation-workflow", prompts[0])
         self.assertNotIn("/skills/", prompts[0])
         self.assertNotIn(".claude/skills", prompts[0])
+
+    def test_rate_limit_retry_preserves_consolidate_policy_budget(self) -> None:
+        ws = Workspace(["T"])
+        spec = ws.work_dir("T") / "spec"
+        spec.mkdir(parents=True)
+        root = Path(self.tmp)
+        adapter, count = _scripted_policy_adapter(root, [76, 75, 76, 0])
+        cfg = self.cfg(ws, "T", adapter=adapter, policy_retries=1)
+        env = {
+            "COUNT_FILE": str(count),
+            "CAPTURE_DIR": str(root),
+            "ADAPTER_SUCCESS_TEXT": "",
+            "ADAPTER_OUTPUT_FILE": str(spec / "candidates.json"),
+            "ADAPTER_OUTPUT_TEXT": '{"generated_by":"consolidate","findings":[]}',
+        }
+
+        with mock.patch.dict(os.environ, env, clear=False):
+            first_rc = C.run_parallel_confirmation(cfg)
+            second_rc = C.run_parallel_confirmation(cfg)
+
+        self.assertEqual((first_rc, second_rc), (75, 1))
+        self.assertEqual(count.read_text(), "xxx")
+        prompts = [(root / f"prompt-{attempt}.md").read_text() for attempt in range(1, 4)]
+        marker = "Continue After Provider Policy Interruption"
+        self.assertNotIn(marker, prompts[0])
+        self.assertIn(marker, prompts[1])
+        self.assertEqual(prompts[2], prompts[1])
+        self.assertFalse((root / "prompt-4.md").exists())
 
     def test_consolidate_failure_withholds_not_raises(self) -> None:
         # No candidates.json → consolidate runs the agent. A non-75 failure that

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -108,16 +108,26 @@ class TestConfirmConfigCompatibility(ConfirmCase):
         self.assertEqual(cfg.prompt_extra, "EXTRA")
         self.assertIsNone(cfg.model)
         self.assertIsNone(cfg.effort)
+        self.assertEqual(cfg.policy_retries, 20)
 
     def test_turn_threads_explicit_empty_tuning(self) -> None:
         ws = Workspace(["T"])
-        cfg = C.ConfirmConfig("T", ws, Path("/adapter"), worktree=False, model="", effort="")
+        cfg = C.ConfirmConfig(
+            "T",
+            ws,
+            Path("/adapter"),
+            worktree=False,
+            model="",
+            effort="",
+            policy_retries=100,
+        )
         finding = C.Finding({"id": "MC-1"}, ws.work_dir("T") / "confirmation" / "MC-1")
         with mock.patch.object(C, "run_agent_blocking", return_value=(0, "VERDICT: FALSE POSITIVE")) as run:
             verdict, _ = C.run_turn(cfg, finding, "A", 1, "prompt", cwd="/repo-worktree")
         self.assertEqual(verdict, "FALSE POSITIVE")
         self.assertEqual(run.call_args.kwargs["model"], "")
         self.assertEqual(run.call_args.kwargs["effort"], "")
+        self.assertEqual(run.call_args.kwargs["policy_retries"], 100)
         self.assertEqual(run.call_args.kwargs["gate_work_dir"], finding.fdir)
         self.assertEqual(run.call_args.kwargs["cwd"], "/repo-worktree")
 
@@ -427,16 +437,21 @@ class TestDriver(ConfirmCase):
         spec = ws.work_dir("T") / "spec"
         spec.mkdir(parents=True)
         prompts: list[str] = []
+        retry_budgets: list[int] = []
 
-        def run(_adapter: Path, prompt: str, *_args: object, **_kwargs: object) -> tuple[int, str]:
+        def run(_adapter: Path, prompt: str, *_args: object, **kwargs: object) -> tuple[int, str]:
             prompts.append(prompt)
+            retry_budget = kwargs["policy_retries"]
+            assert isinstance(retry_budget, int)
+            retry_budgets.append(retry_budget)
             (spec / "candidates.json").write_text('{"generated_by":"consolidate","findings":[]}')
             return (0, "")
 
         with mock.patch.object(C, "run_agent_blocking", run):
-            C.consolidate(self.cfg(ws, "T"))
+            C.consolidate(self.cfg(ws, "T", policy_retries=100))
 
         self.assertEqual(len(prompts), 1)
+        self.assertEqual(retry_budgets, [100])
         self.assertIn("installed Specula skill **validation-workflow**", prompts[0])
         self.assertIn("<!-- specula-skill:", prompts[0])
         self.assertIn(":validation-workflow -->", prompts[0])

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -606,6 +606,14 @@ class TestArgErrors(PhaseCase):
         self.assertEqual(rc, 1)
         self.assertIn("--legacy-confirm and --debate cannot be used together", out)
 
+    def test_policy_retries_rejects_non_decimal_values(self) -> None:
+        for value in ("", "-1", "1.5", "bad", "+1"):
+            with self.subTest(value=value):
+                rc, out = self.run_phase("code_analysis", [f"--policy-retries={value}", NAME])
+                self.assertEqual(rc, 1)
+                self.assertIn("Invalid --policy-retries", out)
+                self.assertIn("non-negative integer", out)
+
     def test_help_prints_usage(self) -> None:
         for spec in PHASES:
             with self.subTest(phase=spec["key"]):
@@ -617,6 +625,8 @@ class TestArgErrors(PhaseCase):
                 self.assertNotIn("launch_", out)
                 self.assertIn("--model=NAME", out)
                 self.assertIn("--effort=LEVEL", out)
+                self.assertIn("--policy-retries=N", out)
+                self.assertIn("default: 20", out)
 
 
 class TestBugConfirmationAlternate(PhaseCase):
@@ -661,6 +671,21 @@ class TestBugConfirmationAlternate(PhaseCase):
         self.assertEqual(len(calls), 2)
         self.assertEqual(waits, [1])
 
+    def test_policy_retry_budget_reaches_parallel_confirmation(self) -> None:
+        from specula import confirmlib
+
+        seen: list[int] = []
+
+        def fake_confirmation(cfg: confirmlib.ConfirmConfig) -> int:
+            seen.append(cfg.policy_retries)
+            return 0
+
+        self.patch_attr(confirmlib, "run_parallel_confirmation", fake_confirmation)
+        rc, out = self.dry_run(BY_KEY["bug_confirmation"], extra=["--policy-retries=100"])
+
+        self.assertEqual(rc, 0, out)
+        self.assertEqual(seen, [100])
+
     def test_successful_live_confirmation_requires_classification_prerequisites(self) -> None:
         from specula import confirmlib
 
@@ -703,6 +728,7 @@ class TestHandoffGate(PhaseCase):
         adapters.mkdir()
         self.patch_attr(phaselib, "LAUNCH_DIR", adapters.parent)
         self.patch_attr(phaselib.Phase, "_acceptance", lambda _self, _ws, _names: None)
+        self.patch_attr(phaselib.Phase, "progress_config", ProgressConfig(poll_seconds=0.005))
         self.set_env("SPECULA_PROGRESS", "off")
         self.adapter = adapters / "fake.sh"
 
@@ -710,10 +736,14 @@ class TestHandoffGate(PhaseCase):
         self.adapter.write_text("#!/usr/bin/env sh\nset -eu\n" + body)
         self.adapter.chmod(0o755)
 
-    def run_analysis(self, targets: list[str] | None = None) -> tuple[int, str]:
+    def run_analysis(
+        self,
+        targets: list[str] | None = None,
+        options: list[str] | None = None,
+    ) -> tuple[int, str]:
         return self.run_phase(
             "code_analysis",
-            [f"--agent={self.adapter.stem}", self.artifact_flag(), *(targets or [NAME])],
+            [*(options or []), f"--agent={self.adapter.stem}", self.artifact_flag(), *(targets or [NAME])],
         )
 
     def test_zero_adapter_exit_without_brief_fails_the_analysis_handoff(self) -> None:
@@ -789,7 +819,7 @@ class TestHandoffGate(PhaseCase):
         self.assertEqual(rc, 0, out)
         self.assertEqual(count.read_text(), "xx")
         self.assertEqual(handoff_calls, [[NAME]])
-        self.assertIn("continuing once with a revised request", out)
+        self.assertIn("retrying with a revised request (1/20)", out)
 
     def test_repeated_policy_block_is_not_whitened_by_preexisting_handoff(self) -> None:
         count = self.tmp() / "count"
@@ -799,12 +829,12 @@ class TestHandoffGate(PhaseCase):
         self.set_env("COUNT_FILE", str(count))
         self.write_adapter('printf x >> "$COUNT_FILE"\nexit 76\n')
 
-        rc, out = self.run_analysis()
+        rc, out = self.run_analysis(options=["--policy-retries=1"])
 
         self.assertEqual(rc, POLICY_BLOCKED_RC, out)
         self.assertEqual(count.read_text(), "xx")
 
-    def test_policy_block_continues_once_with_changed_prompt_in_same_workspace(self) -> None:
+    def test_policy_block_continues_with_changed_prompt_in_same_workspace(self) -> None:
         count = self.tmp() / "count"
         captures = self.tmp()
         self.set_env("COUNT_FILE", str(count))
@@ -829,9 +859,9 @@ class TestHandoffGate(PhaseCase):
         self.assertIn("Continue After Provider Policy Interruption", second)
         self.assertTrue(second.startswith(first.rstrip()))
         self.assertEqual((captures / "workspaces").read_text().splitlines(), [str(self.work_dir())] * 2)
-        self.assertIn("continuing once with a revised request", out)
+        self.assertIn("retrying with a revised request (1/20)", out)
 
-    def test_repeated_policy_block_stops_after_one_continuation(self) -> None:
+    def test_default_policy_retry_budget_stops_after_twenty_continuations(self) -> None:
         count = self.tmp() / "count"
         self.set_env("COUNT_FILE", str(count))
         self.write_adapter('printf x >> "$COUNT_FILE"\nexit 76\n')
@@ -839,8 +869,21 @@ class TestHandoffGate(PhaseCase):
         rc, out = self.run_analysis()
 
         self.assertEqual(rc, POLICY_BLOCKED_RC, out)
-        self.assertEqual(count.read_text(), "xx")
+        self.assertEqual(count.read_text(), "x" * 21)
+        self.assertIn("retrying with a revised request (20/20)", out)
+        self.assertNotIn("(21/20)", out)
         self.assertIn(f"adapter exited {POLICY_BLOCKED_RC}", out)
+
+    def test_zero_policy_retries_disables_continuation(self) -> None:
+        count = self.tmp() / "count"
+        self.set_env("COUNT_FILE", str(count))
+        self.write_adapter('printf x >> "$COUNT_FILE"\nexit 76\n')
+
+        rc, out = self.run_analysis(options=["--policy-retries=0"])
+
+        self.assertEqual(rc, POLICY_BLOCKED_RC, out)
+        self.assertEqual(count.read_text(), "x")
+        self.assertNotIn("retrying with a revised request", out)
 
     def test_policy_and_rate_limit_retry_budgets_are_independent(self) -> None:
         count = self.tmp() / "count"
@@ -850,6 +893,7 @@ class TestHandoffGate(PhaseCase):
             'attempt=$(wc -c < "$COUNT_FILE")\n'
             '[ "$attempt" -ne 1 ] || exit 76\n'
             '[ "$attempt" -ne 2 ] || exit 75\n'
+            '[ "$attempt" -ne 3 ] || exit 76\n'
             'printf "brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
         )
         waits: list[int] = []
@@ -857,10 +901,10 @@ class TestHandoffGate(PhaseCase):
         self.set_env("SPECULA_RATE_LIMIT_REACTIVE", "1")
         self.set_env("SPECULA_RATE_LIMIT_RETRIES", "1")
 
-        rc, out = self.run_analysis()
+        rc, out = self.run_analysis(options=["--policy-retries=2"])
 
         self.assertEqual(rc, 0, out)
-        self.assertEqual(count.read_text(), "xxx")
+        self.assertEqual(count.read_text(), "xxxx")
         self.assertEqual(waits, [1])
 
     def test_policy_recovery_does_not_reset_spent_rate_limit_retries(self) -> None:
@@ -891,7 +935,9 @@ class TestHandoffGate(PhaseCase):
         self.write_adapter(
             'name=$(basename "$(dirname "$SPECULA_WORK_DIR")")\n'
             'printf x >> "$COUNT_DIR/$name"\n'
-            'if [ "$name" = a ] && [ "$(wc -c < "$COUNT_DIR/$name")" -eq 1 ]; then exit 76; fi\n'
+            'attempt=$(wc -c < "$COUNT_DIR/$name")\n'
+            'if [ "$name" = a ] && [ "$attempt" -le 2 ]; then exit 76; fi\n'
+            'if [ "$name" = b ] && [ "$attempt" -le 1 ]; then exit 76; fi\n'
             'printf "brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
         )
 
@@ -899,6 +945,7 @@ class TestHandoffGate(PhaseCase):
             "code_analysis",
             [
                 "--max-parallel=2",
+                "--policy-retries=2",
                 f"--agent={self.adapter.stem}",
                 self.artifact_flag(),
                 "a|g|Go|r",
@@ -907,8 +954,8 @@ class TestHandoffGate(PhaseCase):
         )
 
         self.assertEqual(rc, 0, out)
-        self.assertEqual((counts / "a").read_text(), "xx")
-        self.assertEqual((counts / "b").read_text(), "x")
+        self.assertEqual((counts / "a").read_text(), "xxx")
+        self.assertEqual((counts / "b").read_text(), "xx")
 
     def test_ordinary_adapter_failure_is_not_retried(self) -> None:
         count = self.tmp() / "count"
@@ -1265,7 +1312,7 @@ class TestLegacyRepairIdentityFinalization(PhaseCase):
 
 
 class TestRunAgentBlocking(PhaseCase):
-    def test_policy_block_continues_once_with_revised_prompt(self) -> None:
+    def test_policy_block_retries_with_one_non_accumulating_recovery_note(self) -> None:
         adapter = self.tmp() / "adapter.sh"
         count = self.tmp() / "count"
         captures = self.tmp()
@@ -1275,7 +1322,7 @@ class TestRunAgentBlocking(PhaseCase):
             'attempt=$(wc -c < "$COUNT_FILE")\n'
             'for arg do case "$arg" in --prompt-file=*) prompt=${arg#*=} ;; --log=*) log=${arg#*=} ;; esac; done\n'
             'cp "$prompt" "$CAPTURE_DIR/prompt-$attempt.md"\n'
-            '[ "$attempt" -ne 1 ] || exit 76\n'
+            '[ "$attempt" -gt 2 ] || exit 76\n'
             'printf "continued\\n" > "$log"\n'
         )
         adapter.chmod(0o755)
@@ -1290,20 +1337,24 @@ class TestRunAgentBlocking(PhaseCase):
             phase_key="bug_confirmation",
             work_dir=self.work_dir(),
             claude_alias="profile",
+            policy_retries=2,
         )
 
         self.assertEqual(rc, 0)
         self.assertEqual(text, "continued\n")
-        self.assertEqual(count.read_text(), "xx")
+        self.assertEqual(count.read_text(), "xxx")
         self.assertEqual((captures / "prompt-1.md").read_text(), "original prompt")
         second_prompt = (captures / "prompt-2.md").read_text()
+        third_prompt = (captures / "prompt-3.md").read_text()
         self.assertTrue(second_prompt.startswith("original prompt"))
         self.assertIn(
             "Continue After Provider Policy Interruption",
             second_prompt,
         )
+        self.assertEqual(third_prompt, second_prompt)
+        self.assertEqual(second_prompt.count("Continue After Provider Policy Interruption"), 1)
 
-    def test_policy_block_in_blocking_turn_is_bounded(self) -> None:
+    def test_default_policy_retry_budget_bounds_blocking_turn(self) -> None:
         adapter = self.tmp() / "adapter.sh"
         count = self.tmp() / "count"
         adapter.write_text('#!/bin/sh\nprintf x >> "$COUNT_FILE"\nexit 76\n')
@@ -1321,7 +1372,28 @@ class TestRunAgentBlocking(PhaseCase):
         )
 
         self.assertEqual(rc, POLICY_BLOCKED_RC)
-        self.assertEqual(count.read_text(), "xx")
+        self.assertEqual(count.read_text(), "x" * 21)
+
+    def test_zero_policy_retries_disables_blocking_continuation(self) -> None:
+        adapter = self.tmp() / "adapter.sh"
+        count = self.tmp() / "count"
+        adapter.write_text('#!/bin/sh\nprintf x >> "$COUNT_FILE"\nexit 76\n')
+        adapter.chmod(0o755)
+        self.set_env("COUNT_FILE", str(count))
+
+        rc, _ = phaselib.run_agent_blocking(
+            adapter,
+            "original prompt",
+            self.tmp() / "prompt.md",
+            self.tmp() / "turn.log",
+            phase_key="bug_confirmation",
+            work_dir=self.work_dir(),
+            claude_alias="profile",
+            policy_retries=0,
+        )
+
+        self.assertEqual(rc, POLICY_BLOCKED_RC)
+        self.assertEqual(count.read_text(), "x")
 
     def test_turn_phase_scopes_stop_gate_sets_cwd_and_removes_stale_log(self) -> None:
         adapter = self.tmp() / "adapter.sh"
@@ -2298,6 +2370,10 @@ class TestReviewPhase(PhaseCase):
     assembles (no --dry-run, so drive the pure builders directly to stay off the
     network) plus its arg validation."""
 
+    def setUp(self) -> None:
+        super().setUp()
+        self.patch_attr(phaselib.Phase, "progress_config", ProgressConfig(poll_seconds=0.005))
+
     def review(self) -> phaselib.ReviewPhase:
         return phaselib.ReviewPhase()
 
@@ -2351,9 +2427,19 @@ class TestReviewPhase(PhaseCase):
                 self.assertIn("specula review <phase>", out)
                 self.assertIn("--model=NAME", out)
                 self.assertIn("--effort=LEVEL", out)
+                self.assertIn("--policy-retries=N", out)
+                self.assertIn("default: 20", out)
                 self.assertIn(".specula-output/review-analysis.md", out)
                 self.assertIn(".specula-output/spec/review-specgen.md", out)
                 self.assertIn(".specula-output/spec/review-validation.md", out)
+
+    def test_review_rejects_invalid_policy_retry_values(self) -> None:
+        for value in ("", "-1", "1.5", "bad", "+1"):
+            with self.subTest(value=value):
+                rc, out = self.run_phase("review", ["analysis", f"--policy-retries={value}", NAME])
+                self.assertEqual(rc, 1)
+                self.assertIn("Invalid --policy-retries", out)
+                self.assertIn("non-negative integer", out)
 
     def test_review_streams_activity_through_shared_monitor(self) -> None:
         event = json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "reviewing"}})
@@ -2426,7 +2512,7 @@ class TestReviewPhase(PhaseCase):
         self.assertEqual(count.read_text(), "xx")
         self.assertEqual(waits, [1])
 
-    def test_review_policy_block_continues_once_with_revised_prompt(self) -> None:
+    def test_review_policy_block_retries_with_non_accumulating_revised_prompt(self) -> None:
         count = self.tmp() / "count"
         prompts = self.tmp()
         self.install_adapter(
@@ -2435,27 +2521,33 @@ class TestReviewPhase(PhaseCase):
             'attempt=$(wc -c < "$COUNT_FILE")\n'
             'for arg do case "$arg" in --prompt=*) prompt=${arg#*=} ;; esac; done\n'
             'printf "%s" "$prompt" > "$PROMPT_DIR/prompt-$attempt.md"\n'
-            '[ "$attempt" -ne 1 ] || exit 76\n',
+            '[ "$attempt" -gt 2 ] || exit 76\n',
         )
         self.set_env("COUNT_FILE", str(count))
         self.set_env("PROMPT_DIR", str(prompts))
         self.set_env("SPECULA_PROGRESS", "off")
 
-        rc, out = self.run_phase("review", ["analysis", "--agent=fake", NAME])
+        rc, out = self.run_phase(
+            "review",
+            ["analysis", "--agent=fake", "--policy-retries=2", NAME],
+        )
 
         self.assertEqual(rc, 0, out)
-        self.assertEqual(count.read_text(), "xx")
+        self.assertEqual(count.read_text(), "xxx")
         self.assertNotIn(
             "Continue After Provider Policy Interruption",
             (prompts / "prompt-1.md").read_text(),
         )
         first_prompt = (prompts / "prompt-1.md").read_text()
         second_prompt = (prompts / "prompt-2.md").read_text()
+        third_prompt = (prompts / "prompt-3.md").read_text()
         self.assertTrue(second_prompt.startswith(first_prompt.rstrip()))
         self.assertIn(
             "Continue After Provider Policy Interruption",
             second_prompt,
         )
+        self.assertEqual(third_prompt, second_prompt)
+        self.assertEqual(second_prompt.count("Continue After Provider Policy Interruption"), 1)
 
     def test_review_policy_block_is_bounded(self) -> None:
         count = self.tmp() / "count"
@@ -2463,10 +2555,28 @@ class TestReviewPhase(PhaseCase):
         self.set_env("COUNT_FILE", str(count))
         self.set_env("SPECULA_PROGRESS", "off")
 
-        rc, out = self.run_phase("review", ["analysis", "--agent=fake", NAME])
+        rc, out = self.run_phase(
+            "review",
+            ["analysis", "--agent=fake", "--policy-retries=1", NAME],
+        )
 
         self.assertEqual(rc, POLICY_BLOCKED_RC, out)
         self.assertEqual(count.read_text(), "xx")
+
+    def test_review_zero_policy_retries_disables_continuation(self) -> None:
+        count = self.tmp() / "count"
+        self.install_adapter("fake", 'printf x >> "$COUNT_FILE"\nexit 76\n')
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("SPECULA_PROGRESS", "off")
+
+        rc, out = self.run_phase(
+            "review",
+            ["analysis", "--agent=fake", "--policy-retries=0", NAME],
+        )
+
+        self.assertEqual(rc, POLICY_BLOCKED_RC, out)
+        self.assertEqual(count.read_text(), "x")
+        self.assertNotIn("retrying with a revised request", out)
 
     def test_review_policy_recovery_does_not_reset_rate_limit_retries(self) -> None:
         count = self.tmp() / "count"

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -662,6 +662,32 @@ class TestParsing(TmpCwd):
         self.assertIn("--max-parallel=1", p._phase_args(["t"]))
         self.assertEqual(p._max_parallel_summary(), "1")
 
+    def test_policy_retry_default_and_explicit_value_are_forwarded(self) -> None:
+        default = pl.Pipeline()
+        self.assertIsNone(default.parse_args(["t|g|l|r"]))
+        self.assertEqual(default.policy_retries, 20)
+        self.assertIn("--policy-retries=20", default._phase_args(["t"]))
+
+        explicit = pl.Pipeline()
+        self.assertIsNone(explicit.parse_args(["--policy-retries=100", "t|g|l|r"]))
+        self.assertEqual(explicit.policy_retries, 100)
+        self.assertIn("--policy-retries=100", explicit._phase_args(["t"]))
+
+        disabled = pl.Pipeline()
+        self.assertIsNone(disabled.parse_args(["--policy-retries=0", "t|g|l|r"]))
+        self.assertEqual(disabled.policy_retries, 0)
+        self.assertIn("--policy-retries=0", disabled._phase_args(["t"]))
+
+    def test_invalid_policy_retry_budget_is_rejected_at_parse(self) -> None:
+        for value in ("", "-1", "1.5", "bad", "+1"):
+            with self.subTest(value=value):
+                p = pl.Pipeline()
+                err = io.StringIO()
+                with contextlib.redirect_stderr(err):
+                    rc = p.parse_args([f"--policy-retries={value}", "t|g|l|r"])
+                self.assertEqual(rc, 1)
+                self.assertIn("--policy-retries must be a non-negative integer", err.getvalue())
+
     def test_max_parallel_summary_reports_per_finding_default(self) -> None:
         p = pl.Pipeline()
         self.assertIsNone(p.parse_args(["t|g|l|r"]))
@@ -732,6 +758,8 @@ class TestParsing(TmpCwd):
         self.assertIn("Full Specula pipeline", out)
         self.assertIn("--model=NAME", out)
         self.assertIn("--effort=LEVEL", out)
+        self.assertIn("--policy-retries=N", out)
+        self.assertIn("default: 20", out)
 
     def test_default_target_is_cwd_basename(self) -> None:
         p = pl.Pipeline()
@@ -794,12 +822,20 @@ class TestRunReview(TmpCwd):
     as "--agent=..." and abort with "Unknown phase"; --dry-run only logs the
     command, so the sequencing golden never caught it. Pin the arg order here."""
 
-    def _capture(self, phase: str, *, model: str | None = None, effort: str | None = None) -> list[str]:
+    def _capture(
+        self,
+        phase: str,
+        *,
+        model: str | None = None,
+        effort: str | None = None,
+        policy_retries: int = 20,
+    ) -> list[str]:
         p = make_pipeline(
             ["footest|foo/bar|Go|ref"],
             skip_reviews=False,
             model=model,
             effort=effort,
+            policy_retries=policy_retries,
         )
         seen: list[list[str]] = []
         p._phase = lambda banner, script, args: seen.append(args)  # type: ignore[method-assign]
@@ -817,7 +853,12 @@ class TestRunReview(TmpCwd):
         args = self._capture("specgen")
         self.assertIn("--agent=claude-code", args)
         self.assertIn("--claude-alias=claude", args)
+        self.assertIn("--policy-retries=20", args)
         self.assertEqual(args[-1], "footest")
+
+    def test_explicit_policy_retry_budget_reaches_review(self) -> None:
+        args = self._capture("analysis", policy_retries=100)
+        self.assertIn("--policy-retries=100", args)
 
     def test_model_effort_values_and_empty_are_forwarded(self) -> None:
         args = self._capture("analysis", model="gpt-5.5", effort="high")

--- a/tests/unit/test_workspace_isolation.py
+++ b/tests/unit/test_workspace_isolation.py
@@ -290,6 +290,7 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
         self.assertEqual(meta["agent"], "claude-code")
         self.assertIsNone(meta["model"])
         self.assertEqual(meta["effort"], "max")
+        self.assertEqual(meta["policy_retries"], 20)
         self.assertIsNone(meta["artifact_git_sha"])  # no artifact given
         self.assertIn("created", meta)
         # env exported for the phase subprocesses


### PR DESCRIPTION
## Summary

- Add --policy-retries=N with a default of 20; zero disables policy recovery.
- Apply the same initial-attempt-plus-N-continuations semantics to ordinary phases, reviews, and parallel confirmation turns.
- Keep policy and rate-limit budgets independent, avoid accumulating recovery notes, and record the resolved budget in run metadata.


Follow-up to #80.