### PR TITLE
Add exact-session recovery for transient agent failures

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -142,11 +142,15 @@ Supported adapters are `claude-code` (default), `codex`, `copilot-cli`, `opencod
 
 Specula launches the installed agent CLI directly and uses its existing credentials. Authenticate the CLI before starting a pipeline. Claude Code runs default to maximum reasoning effort; Codex and Copilot use their configured defaults unless `--effort` is supplied.
 
-Specula runs Copilot CLI with `--autopilot` and fails before launching a task when the installed CLI does not advertise that capability. Passing `--effort` to Copilot requires Copilot CLI 1.0.4 or newer. OpenCode forwards it as a variant, while Pi forwards it as a thinking level.
+Specula runs Copilot CLI with `--autopilot` and fails before launching a task when the installed CLI does not advertise that capability. Resume-aware pipeline launches require Copilot CLI 1.0.51 or newer plus JSON output; Specula captures the full session UUID and uses `--resume`, refusing ambiguous or missing-session recovery instead of using `--session-id`, which can create an empty session for a stale UUID. Passing `--effort` to Copilot requires Copilot CLI 1.0.4 or newer. OpenCode forwards it as a variant, while Pi forwards it as a thinking level.
 
 `--max-turns` maps to Copilot's autopilot continuation limit. Claude Code, Codex, OpenCode, and Pi accept the option for adapter compatibility but do not enforce it. The reviews between steps pass a fixed value of 30 instead of the pipeline option; all four adapters still ignore it. OpenCode and Pi do not support Specula's agent-side stop gate.
 
-`--policy-retries=N` sets the provider-policy continuation budget for each logical phase agent or confirmation turn. The default is `20`, so one logical turn may advance through at most 20 revised continuation levels after its initial request; `0` disables policy recovery. Automatic rate-limit retries preserve the current level and may replay it without resetting or consuming another policy continuation.
+`--policy-retries=N` sets the provider-policy continuation budget for each logical phase agent or confirmation turn. The default is `20`, so one logical turn may advance through at most 20 revised continuation levels after its initial request; `0` disables policy recovery. Automatic rate-limit retries preserve the current level and exact session when available, without resetting or consuming another policy continuation.
+
+`--transient-resumes=N` sets the continuation budget for narrowly classified capacity, provider 5xx, and transport failures. The default is `20`; `0` disables transient recovery. When an adapter has captured the native session identifier, Specula resumes that exact session with a short continuation instead of replaying the original task; if the CLI failed before emitting an ID, it safely retries the original prompt. Corrupt or mismatched state fails closed, and failed invocation logs are retained with `.attempt-N` names before the current log is replaced.
+
+An exact resume preserves the provider-persisted conversation and the files already written in the retained workspace. It cannot restore the terminated CLI process's in-memory state or an in-flight child process, and a provider may omit a partial response that was never committed to the native session.
 
 ## Output Structure
 
@@ -262,6 +266,7 @@ specula run [options] "name|owner/repository|language|reference"
 | `--max-parallel=N` | Set a hard concurrency limit. If omitted, ordinary steps run 1 target agent at a time and per-finding confirmation runs up to 4 Reproducer agents at a time |
 | `--max-turns=N` | Set Copilot's autopilot continuation limit; accepted but ignored by Claude Code, Codex, OpenCode, and Pi |
 | `--policy-retries=N` | Set provider-policy continuation retries for each phase agent or confirmation turn after its initial adapter invocation (default `20`; `0` disables recovery) |
+| `--transient-resumes=N` | Set native-session continuation retries for retryable provider or transport failures (default `20`; `0` disables recovery) |
 | `--enable-reviews` | Enable reviews between steps |
 | `--legacy-confirm` | Use one confirmation agent instead of per-finding agents |
 | `--skip-analysis`, `--skip-specgen`, `--skip-harness` | Reuse earlier outputs |

--- a/scripts/launch/adapters/codex.sh
+++ b/scripts/launch/adapters/codex.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Adapter: codex
-# Capabilities: max-turns, model-select, effort-select, auto-approve, background, stop-gate
+# Capabilities: max-turns, model-select, effort-select, auto-approve, background, stop-gate, resume
 #
 # Unified interface for invoking Codex CLI.
 #
@@ -19,6 +19,8 @@
 #   --effort LEVEL         Reasoning effort (e.g. minimal|low|medium|high|ultra);
 #                          passed as -c model_reasoning_effort. Env: CODEX_EFFORT.
 #                          Empty -> codex config.toml default.
+#   --resume-state PATH    Persist the exact Codex session ID and resume it when
+#                          the state already contains one. Never selects --last.
 #   --help                 Show this help
 
 set -euo pipefail
@@ -29,12 +31,17 @@ MAX_TURNS=""
 LOG_FILE=""
 BACKGROUND=false
 CLAUDE_ALIAS=""
+RESUME_STATE=""
+RESUME_STATE_SET=false
 # Read adapter-specific environment defaults before parsing so an explicit
 # empty flag can still win and clear them.
 EFFORT="${CODEX_EFFORT:-}"
 MODEL="${CODEX_MODEL:-}"
 POLICY_BLOCKED_RC=76  # Keep in sync with src/specula/adapters/utils/policy.py.
 PLAIN_POLICY_DIAGNOSTIC_RC=77  # Internal event-stream candidate; never returned to the runner.
+TRANSIENT_FAILURE_RC=74  # Keep in sync with src/specula/adapters/utils/transient.py.
+PLAIN_TRANSIENT_DIAGNOSTIC_RC=78  # Internal event-stream candidate; never returned to the runner.
+RESUME_STATE_FAILURE_RC=79  # Internal event-stream integrity failure; never returned to the runner.
 
 for arg in "$@"; do
   case "$arg" in
@@ -46,6 +53,7 @@ for arg in "$@"; do
     --claude-alias=*) CLAUDE_ALIAS="${arg#*=}" ;;
     --effort=*)      EFFORT="${arg#*=}" ;;
     --model=*)       MODEL="${arg#*=}" ;;
+    --resume-state=*) RESUME_STATE="${arg#*=}"; RESUME_STATE_SET=true ;;
     --help|-h)
       sed -n '2,/^$/{ s/^# //; s/^#//; p }' "$0"
       exit 0
@@ -58,6 +66,7 @@ done
 # fallback variables into Codex itself: an explicit `--model=` / `--effort=`
 # must genuinely return to config.toml defaults.
 unset CODEX_MODEL CODEX_EFFORT
+unset SPECULA_RESUME_STATE SPECULA_RESUME_MODEL SPECULA_RESUME_EFFORT
 
 # ── Validate arguments ──
 
@@ -81,6 +90,16 @@ if [[ -z "$LOG_FILE" ]]; then
   exit 1
 fi
 
+if [[ "$RESUME_STATE_SET" == true && -z "$RESUME_STATE" ]]; then
+  echo "codex adapter: --resume-state requires a path" >&2
+  exit 1
+fi
+
+if [[ -n "$RESUME_STATE" && -d "$RESUME_STATE" ]]; then
+  echo "codex adapter: --resume-state must be a file path: $RESUME_STATE" >&2
+  exit 1
+fi
+
 # ── Resolve prompt ──
 
 if [[ -n "$PROMPT_FILE" ]]; then
@@ -89,6 +108,23 @@ if [[ -n "$PROMPT_FILE" ]]; then
     exit 1
   fi
   PROMPT="$(cat "$PROMPT_FILE")"
+fi
+
+ADAPTER_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPECULA_SRC="$ADAPTER_DIR/../../../src"
+RESUME_CWD="$(pwd -P)"
+RESUME_SESSION_ID=""
+
+read_resume_session_id() {
+  python3 -I "$SPECULA_SRC/specula/adapters/utils/resume.py" read \
+    "$RESUME_STATE" codex "$RESUME_CWD" "$MODEL" "$EFFORT"
+}
+
+if [[ -n "$RESUME_STATE" ]]; then
+  if ! RESUME_SESSION_ID="$(read_resume_session_id)"; then
+    echo "codex adapter: invalid or incompatible resume state: $RESUME_STATE" >&2
+    exit 1
+  fi
 fi
 
 # ── Run ──
@@ -102,8 +138,15 @@ write_usage_file() {
   local marker_file="$2"
   local usage_file="${log_file%.log}.usage.json"
   local write_rc=0
+  local exact_session_id=""
 
-  python3 - <<'PY' "$usage_file"
+  if [[ -n "$RESUME_STATE" ]]; then
+    if ! exact_session_id="$(read_resume_session_id)"; then
+      return 1
+    fi
+  fi
+
+  python3 - <<'PY' "$usage_file" "$exact_session_id"
 import json
 import sys
 
@@ -111,7 +154,7 @@ with open(sys.argv[1], "w") as f:
     json.dump(
         {
             "agent": "codex",
-            "session_id": None,
+            "session_id": sys.argv[2] or None,
             "session_file": None,
             "total_cost_usd": None,
             "usage": {},
@@ -129,19 +172,60 @@ PY
   [[ -d "$sessions_dir" ]] || return 0
 
   local session_path=""
-  session_path="$(
-    find "$sessions_dir" -type f -name 'rollout-*.jsonl' -newer "$marker_file" 2>/dev/null \
-    | sort \
-    | tail -n1
-  )"
+  if [[ -n "$RESUME_STATE" ]]; then
+    # A resume-aware run is keyed exclusively by the ID captured from this
+    # Codex stream. Never guess with a timestamp marker (or `--last`): another
+    # concurrent Codex process may have written the newest rollout.
+    [[ -n "$exact_session_id" ]] || return 0
+    session_path="$(python3 - "$sessions_dir" "$exact_session_id" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+sessions_dir = Path(sys.argv[1])
+session_id = sys.argv[2]
+
+# Normal Codex rollout filenames end in the thread UUID, which is both exact
+# and cheap to locate. Fall back to the first session_meta record for layouts
+# whose filename does not expose the ID.
+for path in sorted(sessions_dir.rglob("rollout-*.jsonl")):
+    if path.is_file() and path.name.endswith(f"-{session_id}.jsonl"):
+        print(path)
+        raise SystemExit(0)
+
+for path in sorted(sessions_dir.rglob("rollout-*.jsonl")):
+    try:
+        with path.open(encoding="utf-8") as stream:
+            first = json.loads(stream.readline())
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        continue
+    if first.get("type") != "session_meta":
+        continue
+    payload = first.get("payload")
+    if isinstance(payload, dict) and payload.get("id") == session_id:
+        print(path)
+        raise SystemExit(0)
+PY
+    )"
+  else
+    session_path="$(
+      find "$sessions_dir" -type f -name 'rollout-*.jsonl' -newer "$marker_file" 2>/dev/null \
+      | sort \
+      | tail -n1
+    )"
+  fi
 
   [[ -n "$session_path" ]] || return 0
 
   local session_file
   local session_id
   session_file="$(basename "$session_path" .jsonl)"
-  session_id="${session_path#${sessions_dir}/}"
-  session_id="${session_id%.jsonl}"
+  if [[ -n "$RESUME_STATE" ]]; then
+    session_id="$exact_session_id"
+  else
+    session_id="${session_path#${sessions_dir}/}"
+    session_id="${session_id%.jsonl}"
+  fi
 
   local ccusage_output=""
   if command -v npx >/dev/null 2>&1; then
@@ -152,6 +236,7 @@ import json
 import sys
 
 session_file = sys.argv[1]
+exact_session_id = sys.argv[2] or None
 
 try:
     data = json.load(sys.stdin)
@@ -163,7 +248,7 @@ for session in data.get("sessions", []):
         json.dump(
             {
                 "agent": "codex",
-                "session_id": session.get("sessionId"),
+                "session_id": exact_session_id or session.get("sessionId"),
                 "session_file": session.get("sessionFile"),
                 "total_cost_usd": session.get("costUSD"),
                 "usage": {
@@ -181,7 +266,7 @@ for session in data.get("sessions", []):
         sys.exit(0)
 
 sys.exit(1)
-' "$session_file" 2>/dev/null
+' "$session_file" "$exact_session_id" 2>/dev/null
     )" || true
   fi
 
@@ -218,11 +303,23 @@ run_codex() {
   local last_message_file="${log_file%.log}.last-message.txt"
   local marker_file
   local activity_log="${SPECULA_ACTIVITY_LOG:-}"
+  local temporary_activity_log=""
   local adapter_dir
   local specula_src
   adapter_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   specula_src="$adapter_dir/../../../src"
   marker_file="$(mktemp)"
+  if [[ -n "$RESUME_STATE" && -z "$activity_log" ]]; then
+    if ! temporary_activity_log="$(mktemp "${TMPDIR:-/tmp}/specula-codex-activity-XXXXXX.jsonl")"; then
+      rm -f "$marker_file" || true
+      echo "codex adapter: unable to create temporary activity log for session capture" >&2
+      return 1
+    fi
+    # Native resume requires the exact thread.started ID. Keep JSON streaming
+    # enabled even when the user disables progress display; the temporary raw
+    # sidecar is removed below and does not opt the UI back into progress.
+    activity_log="$temporary_activity_log"
+  fi
 
   # ── Optional outer srt sandbox (M1.3) ──
   # Opt-in via SPECULA_SANDBOX=on; additive — off/unset leaves the codex argv
@@ -247,31 +344,54 @@ run_codex() {
   # Model / reasoning effort (additive — empty leaves codex config.toml default).
   [[ -n "$MODEL" ]] && cmd+=(-m "$MODEL")
   [[ -n "$EFFORT" ]] && cmd+=(-c "model_reasoning_effort=$EFFORT")
+  if [[ -n "$RESUME_SESSION_ID" ]]; then
+    cmd+=(resume "$RESUME_SESSION_ID")
+  fi
 
   local codex_rc=0
+  local transient_classified=false
   # Never let a failed/retried turn reuse the preceding turn's answer.
   rm -f "$last_message_file"
   set +e
   if [[ -n "$activity_log" ]]; then
     local -a pipeline_status
+    local -a stream_args=(codex "$activity_log" "$log_file")
     local stream_rc
+    if [[ -n "$RESUME_STATE" ]]; then
+      stream_args+=("$RESUME_STATE" "$RESUME_CWD" "$MODEL" "$EFFORT")
+    fi
     printf '%s' "$PROMPT" | "${cmd[@]}" --json - 2>&1 | python3 -I -c \
       'import sys; sys.path.insert(0, sys.argv.pop(1)); from specula.adapters.utils.event_stream import main; raise SystemExit(main(sys.argv[1:]))' \
-      "$specula_src" codex "$activity_log" "$log_file"
+      "$specula_src" "${stream_args[@]}"
     pipeline_status=("${PIPESTATUS[@]}")
     codex_rc="${pipeline_status[1]}"
     stream_rc="${pipeline_status[2]}"
-    if (( codex_rc == 75 )); then
-      : # Rate limiting remains the highest-priority retry outcome.
+    if (( stream_rc == RESUME_STATE_FAILURE_RC )); then
+      # Session-integrity failure is fail-closed even when the native CLI also
+      # reports a retryable status. Never resume a state whose exact ID changed.
+      codex_rc=1
+    elif (( codex_rc == 75 || stream_rc == 75 )); then
+      codex_rc=75  # Rate limiting remains the highest-priority retry outcome.
     elif (( stream_rc == POLICY_BLOCKED_RC )); then
       codex_rc="$POLICY_BLOCKED_RC"
+    elif (( codex_rc == POLICY_BLOCKED_RC )); then
+      : # Preserve an already-normalized policy outcome over transient status.
     elif (( codex_rc != 0 && stream_rc == PLAIN_POLICY_DIAGNOSTIC_RC )); then
       codex_rc="$POLICY_BLOCKED_RC"
+    elif (( stream_rc == TRANSIENT_FAILURE_RC )); then
+      # A structured provider envelope is authoritative over an ordinary CLI
+      # failure (and over an accidental zero exit), but not over 75/76 above.
+      codex_rc="$TRANSIENT_FAILURE_RC"
+      transient_classified=true
+    elif (( codex_rc != 0 && stream_rc == PLAIN_TRANSIENT_DIAGNOSTIC_RC )); then
+      codex_rc="$TRANSIENT_FAILURE_RC"
+      transient_classified=true
     elif (( codex_rc == 0 )); then
       # A plain diagnostic is only actionable when the CLI itself failed.
       # Structured policy failures use POLICY_BLOCKED_RC above and remain
       # authoritative even if a provider CLI accidentally exits zero.
-      if (( stream_rc != PLAIN_POLICY_DIAGNOSTIC_RC )); then
+      if (( stream_rc != PLAIN_POLICY_DIAGNOSTIC_RC \
+            && stream_rc != PLAIN_TRANSIENT_DIAGNOSTIC_RC )); then
         codex_rc="$stream_rc"
       fi
     fi
@@ -291,7 +411,22 @@ run_codex() {
       'import sys; sys.path.insert(0, sys.argv[1]); from pathlib import Path; from specula.adapters.utils.policy import failed_log_has_policy_block; raise SystemExit(0 if failed_log_has_policy_block(Path(sys.argv[2])) else 1)' \
       "$specula_src" "$log_file"; then
       codex_rc="$POLICY_BLOCKED_RC"
+    elif (( codex_rc != POLICY_BLOCKED_RC )) && python3 -I -c \
+      'import sys; sys.path.insert(0, sys.argv[1]); from pathlib import Path; from specula.adapters.utils.transient import failed_log_has_transient_failure; raise SystemExit(0 if failed_log_has_transient_failure(Path(sys.argv[2])) else 1)' \
+      "$specula_src" "$log_file"; then
+      codex_rc="$TRANSIENT_FAILURE_RC"
+      transient_classified=true
     fi
+  fi
+
+  if (( codex_rc == TRANSIENT_FAILURE_RC )) && [[ "$transient_classified" != true ]]; then
+    # Native 74 is EX_IOERR; only a classified provider diagnostic may expose
+    # Specula's retry/resume contract to the phase runner.
+    codex_rc=1
+  fi
+
+  if [[ -n "$temporary_activity_log" ]]; then
+    rm -f "$temporary_activity_log" || true
   fi
 
   local usage_rc=0

--- a/scripts/launch/adapters/copilot-cli.sh
+++ b/scripts/launch/adapters/copilot-cli.sh
@@ -21,6 +21,7 @@
 #   --effort LEVEL         Reasoning effort; mapped to Copilot CLI's
 #                          --reasoning-effort (requires Copilot CLI 1.0.4+)
 #   --log output.log       Log file path (required)
+#   --resume-state PATH    Persist/resume the exact native Copilot session
 #   --background           Run in background, print PID to stdout (default: foreground)
 #   --help                 Show this help
 
@@ -32,9 +33,14 @@ MAX_TURNS=""
 MODEL="${COPILOT_MODEL:-}"
 EFFORT=""
 LOG_FILE=""
+RESUME_STATE=""
+RESUME_STATE_SET=false
 BACKGROUND=false
 POLICY_BLOCKED_RC=76  # Keep in sync with src/specula/adapters/utils/policy.py.
 PLAIN_POLICY_DIAGNOSTIC_RC=77  # Internal event-stream candidate; never returned to the runner.
+TRANSIENT_FAILURE_RC=74  # Keep in sync with src/specula/adapters/utils/transient.py.
+PLAIN_TRANSIENT_DIAGNOSTIC_RC=78  # Internal event-stream candidate; never returned to the runner.
+RESUME_STATE_FAILURE_RC=79  # Internal event-stream integrity failure; never returned to the runner.
 
 for arg in "$@"; do
   case "$arg" in
@@ -45,6 +51,7 @@ for arg in "$@"; do
     --claude-alias=*) : ;;
     --effort=*)      EFFORT="${arg#*=}" ;;
     --log=*)         LOG_FILE="${arg#*=}" ;;
+    --resume-state=*) RESUME_STATE="${arg#*=}"; RESUME_STATE_SET=true ;;
     --background)    BACKGROUND=true ;;
     --help|-h)
       sed -n '2,/^$/{ s/^# //; s/^#//; p }' "$0"
@@ -58,6 +65,7 @@ done
 # the environment variable before spawning Copilot so `--model=` can genuinely
 # clear an inherited COPILOT_MODEL and return to settings.json / CLI defaults.
 unset COPILOT_MODEL
+unset SPECULA_RESUME_STATE SPECULA_RESUME_MODEL SPECULA_RESUME_EFFORT
 
 # ── Validate arguments ──
 
@@ -73,6 +81,11 @@ fi
 
 if [[ -z "$LOG_FILE" ]]; then
   echo "copilot-cli adapter: --log is required" >&2
+  exit 1
+fi
+
+if [[ "$RESUME_STATE_SET" == true && -z "$RESUME_STATE" ]]; then
+  echo "copilot-cli adapter: --resume-state requires a path" >&2
   exit 1
 fi
 
@@ -118,6 +131,9 @@ load_copilot_help() {
   fi
 }
 
+ADAPTER_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPECULA_SRC="$ADAPTER_DIR/../../../src"
+
 # ── Build command ──
 #
 # Note: --background is handled by the caller (launch scripts use & directly).
@@ -130,9 +146,36 @@ if ! grep -q -- '--autopilot' <<< "$COPILOT_HELP"; then
   exit 1
 fi
 
+RESUME_SESSION_ID=""
+if [[ -n "$RESUME_STATE" ]]; then
+  if ! grep -q -- '--output-format' <<< "$COPILOT_HELP"; then
+    echo "copilot-cli adapter: --resume-state requires Copilot CLI JSON output so the exact session ID can be captured; upgrade Copilot CLI" >&2
+    exit 1
+  fi
+  if ! grep -q -- '--resume' <<< "$COPILOT_HELP" || ! grep -q -- '--session-id' <<< "$COPILOT_HELP"; then
+    echo "copilot-cli adapter: --resume-state requires Copilot CLI 1.0.51+ exact-session resume semantics; upgrade Copilot CLI" >&2
+    exit 1
+  fi
+  if ! RESUME_SESSION_ID="$(python3 -I "$SPECULA_SRC/specula/adapters/utils/resume.py" read \
+    "$RESUME_STATE" copilot-cli "$(pwd -P)" "$MODEL" "$EFFORT")"; then
+    exit 1
+  fi
+fi
+
 # Keep the scripting channel free of version-specific stats footers. Provider
 # diagnostics still go to stderr, which is captured below for policy recovery.
 CMD=(copilot -p "$PROMPT" --allow-all --autopilot --silent)
+
+if [[ -n "$RESUME_SESSION_ID" ]]; then
+  if [[ ! "$RESUME_SESSION_ID" =~ ^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$ ]]; then
+    echo "copilot-cli adapter: saved session ID is not a full UUID; refusing ambiguous resume" >&2
+    exit 1
+  fi
+  # --session-id creates a blank session when a UUID no longer exists. A full
+  # UUID passed to --resume instead fails when no stored session matches, so a
+  # stale state can never receive a context-free continuation prompt.
+  CMD+=(--resume "$RESUME_SESSION_ID")
+fi
 
 if [[ -n "$MODEL" ]]; then
   CMD+=(--model "$MODEL")
@@ -158,12 +201,25 @@ if [[ -n "$MAX_TURNS" && "$MAX_TURNS" != "0" ]]; then
 fi
 
 ACTIVITY_LOG="${SPECULA_ACTIVITY_LOG:-}"
-ADAPTER_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SPECULA_SRC="$ADAPTER_DIR/../../../src"
+TEMP_ACTIVITY_LOG=""
+if [[ -n "$RESUME_STATE" && -z "$ACTIVITY_LOG" ]]; then
+  if ! TEMP_ACTIVITY_LOG="$(mktemp "${TMPDIR:-/tmp}/specula-copilot-activity-XXXXXX.jsonl")"; then
+    echo "copilot-cli adapter: unable to create temporary activity log for session capture" >&2
+    exit 1
+  fi
+  ACTIVITY_LOG="$TEMP_ACTIVITY_LOG"
+  trap 'rm -f -- "$TEMP_ACTIVITY_LOG"' EXIT
+fi
 
 failed_log_is_policy_blocked() {
   python3 -I -c \
     'import sys; sys.path.insert(0, sys.argv[1]); from pathlib import Path; from specula.adapters.utils.policy import failed_log_has_policy_block; raise SystemExit(0 if failed_log_has_policy_block(Path(sys.argv[2])) else 1)' \
+    "$SPECULA_SRC" "$LOG_FILE"
+}
+
+failed_log_is_transient_failure() {
+  python3 -I -c \
+    'import sys; sys.path.insert(0, sys.argv[1]); from pathlib import Path; from specula.adapters.utils.transient import failed_log_has_transient_failure; raise SystemExit(0 if failed_log_has_transient_failure(Path(sys.argv[2])) else 1)' \
     "$SPECULA_SRC" "$LOG_FILE"
 }
 
@@ -175,8 +231,17 @@ if [[ -z "$ACTIVITY_LOG" ]]; then
   if (( COPILOT_RC == 75 )); then
     exit 75
   fi
+  if (( COPILOT_RC == POLICY_BLOCKED_RC )); then
+    exit "$POLICY_BLOCKED_RC"
+  fi
   if (( COPILOT_RC != 0 )) && failed_log_is_policy_blocked; then
     exit "$POLICY_BLOCKED_RC"
+  fi
+  if (( COPILOT_RC != 0 )) && failed_log_is_transient_failure; then
+    exit "$TRANSIENT_FAILURE_RC"
+  fi
+  if (( COPILOT_RC == TRANSIENT_FAILURE_RC )); then
+    exit 1
   fi
   exit "$COPILOT_RC"
 fi
@@ -196,16 +261,30 @@ if grep -q -- '--stream' <<< "$COPILOT_HELP"; then
 fi
 
 set +e
+STREAM_ARGS=("$STREAM_ADAPTER" "$ACTIVITY_LOG" "$LOG_FILE")
+if [[ -n "$RESUME_STATE" ]]; then
+  STREAM_ARGS+=("$RESUME_STATE" "$(pwd -P)" "$MODEL" "$EFFORT")
+fi
 "${CMD[@]}" 2>&1 | python3 -I -c \
   'import sys; sys.path.insert(0, sys.argv.pop(1)); from specula.adapters.utils.event_stream import main; raise SystemExit(main(sys.argv[1:]))' \
-  "$SPECULA_SRC" "$STREAM_ADAPTER" "$ACTIVITY_LOG" "$LOG_FILE"
+  "$SPECULA_SRC" "${STREAM_ARGS[@]}"
 PIPELINE_STATUS=("${PIPESTATUS[@]}")
 set -e
 
 COPILOT_RC="${PIPELINE_STATUS[0]}"
 STREAM_RC="${PIPELINE_STATUS[1]}"
+if (( STREAM_RC == RESUME_STATE_FAILURE_RC )); then
+  # Never let a retryable native exit mask a changed/malformed exact session.
+  exit 1
+fi
 if (( COPILOT_RC == 75 )); then
   exit 75
+fi
+if (( STREAM_RC == 75 )); then
+  exit 75
+fi
+if (( COPILOT_RC == POLICY_BLOCKED_RC )); then
+  exit "$POLICY_BLOCKED_RC"
 fi
 if (( STREAM_RC == POLICY_BLOCKED_RC )); then
   exit "$POLICY_BLOCKED_RC"
@@ -213,13 +292,28 @@ fi
 if (( COPILOT_RC != 0 && STREAM_RC == PLAIN_POLICY_DIAGNOSTIC_RC )); then
   exit "$POLICY_BLOCKED_RC"
 fi
+if (( STREAM_RC == TRANSIENT_FAILURE_RC )); then
+  exit "$TRANSIENT_FAILURE_RC"
+fi
+if (( COPILOT_RC != 0 && STREAM_RC == PLAIN_TRANSIENT_DIAGNOSTIC_RC )); then
+  exit "$TRANSIENT_FAILURE_RC"
+fi
 if (( COPILOT_RC != 0 )) && [[ "$COPILOT_JSON_STREAM" != true ]] && failed_log_is_policy_blocked; then
   exit "$POLICY_BLOCKED_RC"
 fi
+if (( COPILOT_RC != 0 )) && [[ "$COPILOT_JSON_STREAM" != true ]] && failed_log_is_transient_failure; then
+  exit "$TRANSIENT_FAILURE_RC"
+fi
 if (( COPILOT_RC != 0 )); then
+  if (( COPILOT_RC == TRANSIENT_FAILURE_RC )); then
+    exit 1
+  fi
   exit "$COPILOT_RC"
 fi
 if (( STREAM_RC == PLAIN_POLICY_DIAGNOSTIC_RC )); then
+  exit 0
+fi
+if (( STREAM_RC == PLAIN_TRANSIENT_DIAGNOSTIC_RC )); then
   exit 0
 fi
 exit "$STREAM_RC"

--- a/src/specula/adapters/claude_code.py
+++ b/src/specula/adapters/claude_code.py
@@ -14,6 +14,7 @@ Options:
                         CLAUDE_CONFIG_DIR=$HOME/.<NAME>. Also via CLAUDE_ALIAS env.
   --effort=LEVEL        low|medium|high|xhigh|max (default: max; via CLAUDE_EFFORT)
   --model=NAME          Model alias/name (default: profile default; via CLAUDE_MODEL)
+  --resume-state=FILE   Persist or resume the exact Claude session for this logical turn
   --log=FILE            Log file path (required)
   --background          Run in background (accepted; caller handles backgrounding)
   --help                Show this help
@@ -26,18 +27,31 @@ import shlex
 import subprocess
 import sys
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 from typing import IO, Any
 
 if __package__:
     from .utils.event_stream import stream_events
     from .utils.policy import POLICY_BLOCKED_RC, final_diagnostic_has_policy_block, looks_policy_blocked
+    from .utils.resume import ResumeStateError, capture_session_id, read_session_id
+    from .utils.transient import TRANSIENT_FAILURE_RC, final_diagnostic_has_transient_failure, looks_transient
 else:
     from utils.event_stream import stream_events  # type: ignore[import-not-found, no-redef]
     from utils.policy import (  # type: ignore[import-not-found, no-redef]
         POLICY_BLOCKED_RC,
         final_diagnostic_has_policy_block,
         looks_policy_blocked,
+    )
+    from utils.resume import (  # type: ignore[import-not-found, no-redef]
+        ResumeStateError,
+        capture_session_id,
+        read_session_id,
+    )
+    from utils.transient import (  # type: ignore[import-not-found, no-redef]
+        TRANSIENT_FAILURE_RC,
+        final_diagnostic_has_transient_failure,
+        looks_transient,
     )
 
 HELP = __doc__
@@ -190,6 +204,31 @@ def _result_policy_blocked(record: object) -> bool:
     return looks_policy_blocked(record) or looks_policy_blocked(record.get("result"))
 
 
+def _result_transient_failure(record: object) -> bool:
+    """Whether Claude's terminal result is a retryable provider failure.
+
+    The failed-envelope gate is essential: a successful report may quote the
+    same capacity or transport diagnostic while describing earlier work.
+    """
+    if not isinstance(record, dict):
+        return False
+    verdict = record.get("is_error")
+    subtype = record.get("subtype")
+    terminal_reason = record.get("terminal_reason")
+    api_status = record.get("api_error_status")
+    subtype_is_error = isinstance(subtype, str) and subtype.startswith("error")
+    if (
+        verdict is not True
+        and not subtype_is_error
+        and terminal_reason != "api_error"
+        and api_status in (None, "", 0, "0")
+    ):
+        return False
+    if api_status in (500, 502, 503, 504, 529, "500", "502", "503", "504", "529"):
+        return True
+    return looks_transient(record) or looks_transient(record.get("result"))
+
+
 def _drain(stream: IO[bytes]) -> None:
     """Read a pipe to EOF and discard it, so the child never blocks writing."""
     with contextlib.suppress(OSError):
@@ -219,14 +258,20 @@ def _extract_log(d: dict[str, Any] | None, raw_text: str, log_file: str) -> None
             print(raw_text, file=fh)
 
 
-def _extract_usage(d: dict[str, Any] | None, usage_path: str) -> None:
+def _extract_usage(d: dict[str, Any] | None, usage_path: str, fallback_session_id: str = "") -> None:
     """Usage stats -> .usage.json, fixing num_turns from the session JSONL when a
-    session_id is present. Any failure -> {"error": "parse_failed"} (mirrors the
-    bash `|| parse_failed` fallback)."""
+    session_id is present. Any failure reports ``parse_failed`` and retains a
+    known session ID so a resumable failed turn stays attributable."""
+    session_id = fallback_session_id
+    if isinstance(d, dict):
+        result_session_id = d.get("session_id")
+        if isinstance(result_session_id, str) and result_session_id:
+            session_id = result_session_id
     try:
         if d is None:
             raise ValueError("result JSON unparseable")
         usage = {
+            "session_id": session_id,
             "total_cost_usd": d.get("total_cost_usd", 0),
             "num_turns": d.get("num_turns", 0),
             "duration_ms": d.get("duration_ms", 0),
@@ -234,7 +279,6 @@ def _extract_usage(d: dict[str, Any] | None, usage_path: str) -> None:
             "usage": d.get("usage", {}),
             "model_usage": d.get("modelUsage", {}),
         }
-        session_id = d.get("session_id", "")
         if session_id:
             cwd = os.getcwd()
             proj_key = cwd.replace("/", "-").lstrip("-")
@@ -270,7 +314,10 @@ def _extract_usage(d: dict[str, Any] | None, usage_path: str) -> None:
             uf.write("\n")
     except Exception:
         with open(usage_path, "w") as uf:
-            json.dump({"error": "parse_failed"}, uf)
+            failure: dict[str, Any] = {"error": "parse_failed"}
+            if session_id:
+                failure["session_id"] = session_id
+            json.dump(failure, uf)
             uf.write("\n")
 
 
@@ -283,6 +330,8 @@ def main(argv: list[str]) -> int:
     prompt = ""
     prompt_file = ""
     max_budget = ""
+    resume_state = ""
+    resume_state_set = False
     log_file = ""
     _background = False  # accepted; caller does the backgrounding, as in bash
     # `or`: bash ${VAR:-default} treats an exported-but-empty var as unset — an
@@ -306,6 +355,9 @@ def main(argv: list[str]) -> int:
             effort = arg[len("--effort=") :]
         elif arg.startswith("--model="):
             model = arg[len("--model=") :]
+        elif arg.startswith("--resume-state="):
+            resume_state = arg[len("--resume-state=") :]
+            resume_state_set = True
         elif arg.startswith("--log="):
             log_file = arg[len("--log=") :]
         elif arg == "--background":
@@ -321,6 +373,8 @@ def main(argv: list[str]) -> int:
     # removing them here makes an explicit empty flag a real reset.
     os.environ.pop("CLAUDE_MODEL", None)
     os.environ.pop("CLAUDE_EFFORT", None)
+    for name in ("SPECULA_RESUME_STATE", "SPECULA_RESUME_MODEL", "SPECULA_RESUME_EFFORT"):
+        os.environ.pop(name, None)
 
     # ── Validate arguments ──
     if prompt and prompt_file:
@@ -329,11 +383,34 @@ def main(argv: list[str]) -> int:
         return _die("claude-code adapter: one of --prompt or --prompt-file is required")
     if not log_file:
         return _die("claude-code adapter: --log is required")
+    if resume_state_set and not resume_state:
+        return _die("claude-code adapter: --resume-state requires a path")
+
+    # A resume state belongs to one exact logical turn.  Refuse mismatched or
+    # malformed state rather than silently starting a fresh session and
+    # repeating work that Claude may already have completed.
+    resume_session_id = ""
+    if resume_state:
+        resume_state = os.path.abspath(resume_state)
+        try:
+            resume_session_id = (
+                read_session_id(
+                    resume_state,
+                    adapter="claude-code",
+                    cwd=os.getcwd(),
+                    model=model,
+                    effort=effort,
+                )
+                or ""
+            )
+        except (OSError, ResumeStateError) as e:
+            return _die(f"claude-code adapter: invalid resume state: {e}")
 
     # ── Resolve prompt ──
     # Feed prompt via stdin (not -p) to keep the process cmdline clean, so
     # `pkill -f` can't collateral-kill on strings like "tlc2.TLC".
     tmp_prompt = None
+    hidden_activity_log: str | None = None
     if prompt_file:
         if not os.path.isfile(prompt_file):
             return _die(f"claude-code adapter: prompt file not found: {prompt_file}")
@@ -351,7 +428,6 @@ def main(argv: list[str]) -> int:
         # Alias determines the config dir authoritatively (do NOT inherit an
         # ambient CLAUDE_CONFIG_DIR, which would redirect quota-sensitive runs).
         os.environ["CLAUDE_CONFIG_DIR"] = os.environ.get("HOME", "") + "/." + (claude_alias or "claude")
-
         # ── Stop gate (execution layer) ──
         # Generic gate interface: the phase launcher exports SPECULA_PHASE +
         # SPECULA_WORK_DIR (see src/specula/stop_gate.py). Parallel workers may
@@ -394,9 +470,23 @@ def main(argv: list[str]) -> int:
 
         # ── Build command ──
         activity_log = os.environ.get("SPECULA_ACTIVITY_LOG", "")
-        output_format = "stream-json" if activity_log else "json"
+        stream_activity_log = activity_log
+        if resume_state and not stream_activity_log:
+            # Exact resume state requires Claude's early system/init event even
+            # when progress display is disabled. Keep the structured stream in
+            # a private sidecar and remove it after post-processing.
+            try:
+                fd, hidden_activity_log = tempfile.mkstemp(prefix="specula-claude-activity-", suffix=".jsonl")
+            except OSError as exc:
+                return _die(f"claude-code adapter: unable to create session-capture stream: {exc}")
+            os.close(fd)
+            stream_activity_log = hidden_activity_log
+        streaming = bool(stream_activity_log)
+        output_format = "stream-json" if streaming else "json"
         cmd = ["claude", "--print", "--dangerously-skip-permissions", "--output-format", output_format]
-        if activity_log:
+        if resume_session_id:
+            cmd += ["--resume", resume_session_id]
+        if streaming:
             cmd += ["--verbose"]
         if effort and effort != "default":
             cmd += ["--effort", effort]
@@ -409,20 +499,23 @@ def main(argv: list[str]) -> int:
 
         # ── Run ──
         raw_json = _derived_path(log_file, ".raw.json")
-        capture_path = activity_log or raw_json
+        capture_path = stream_activity_log or raw_json
         cli_rc = 127
         proc: subprocess.Popen[bytes] | None = None
         activity_failed = False
         stream_failed = False
+        stream_resume_failed = False
         stream_terminal_record: object | None = None
         stream_policy_block_error: str | None = None
         stream_plain_policy_block_error: str | None = None
+        stream_transient_error: str | None = None
+        stream_plain_transient_error: str | None = None
         stream_plain_diagnostics: tuple[str, ...] = ()
         # This `try` covers the spawn ONLY. An OSError here means no agent work
         # has happened (claude missing / not executable / unreadable prompt), so
         # a conventional command-not-found status is the honest answer.
         try:
-            if activity_log:
+            if streaming:
                 with open(prompt_input) as pin:
                     proc = subprocess.Popen(cmd, stdin=pin, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             else:
@@ -430,19 +523,42 @@ def main(argv: list[str]) -> int:
                     cli_rc = subprocess.run(cmd, stdin=pin, stdout=out, stderr=subprocess.STDOUT).returncode
         except OSError as e:
             error = f"claude-code adapter: failed to run claude: {e}\n"
-            for path in (capture_path, log_file) if activity_log else (capture_path,):
+            for path in (capture_path, log_file) if streaming else (capture_path,):
                 with contextlib.suppress(OSError), open(path, "w") as out:
                     out.write(error)
 
         if proc is not None:
             if proc.stdout is not None:  # always, given stdout=PIPE
                 try:
-                    stream_status = stream_events("claude-code", Path(activity_log), Path(log_file), proc.stdout)
+                    session_capture: Callable[[str], None] | None = None
+                    if resume_state:
+
+                        def explicit_capture(session_id: str) -> None:
+                            capture_session_id(
+                                resume_state,
+                                adapter="claude-code",
+                                session_id=session_id,
+                                cwd=os.getcwd(),
+                                model=model,
+                                effort=effort,
+                            )
+
+                        session_capture = explicit_capture
+                    stream_status = stream_events(
+                        "claude-code",
+                        Path(stream_activity_log),
+                        Path(log_file),
+                        proc.stdout,
+                        session_capture=session_capture,
+                    )
                     activity_failed = not stream_status.activity_ok
                     stream_failed = not stream_status.log_ok
+                    stream_resume_failed = not stream_status.resume_ok
                     stream_terminal_record = stream_status.terminal_record
                     stream_policy_block_error = stream_status.policy_block_error
                     stream_plain_policy_block_error = stream_status.plain_policy_block_error
+                    stream_transient_error = stream_status.transient_error
+                    stream_plain_transient_error = stream_status.plain_transient_error
                     stream_plain_diagnostics = stream_status.plain_diagnostics
                 except OSError as e:
                     # Sink failures are returned after a full drain. An exception
@@ -468,21 +584,68 @@ def main(argv: list[str]) -> int:
             raw_text = _read_capture(capture_path)
 
         # ── Detect rate limit → exit 75 (EX_TEMPFAIL) so callers can wait/retry ──
-        rate_limited = cli_rc == 75 or _rate_limited(raw_text, bool(activity_log))
+        rate_limited = cli_rc == 75 or _rate_limited(raw_text, streaming)
         if rate_limited:
             print("claude-code adapter: rate limit hit", file=sys.stderr)
 
+        postprocess_failed = False
+        resume_postprocess_failed = False
         result = _parse_result(raw_text)
+        usage_session_id = resume_session_id
+        if resume_state and result is not None:
+            result_session_id = result.get("session_id")
+            if isinstance(result_session_id, str) and result_session_id:
+                usage_session_id = result_session_id
+                try:
+                    capture_session_id(
+                        resume_state,
+                        adapter="claude-code",
+                        session_id=result_session_id,
+                        cwd=os.getcwd(),
+                        model=model,
+                        effort=effort,
+                    )
+                except (OSError, ResumeStateError) as e:
+                    postprocess_failed = True
+                    resume_postprocess_failed = True
+                    print(f"claude-code adapter: resume state write failed: {e}", file=sys.stderr)
+        if resume_state and not usage_session_id:
+            # In stream-json mode Claude exposes the session in `system/init`
+            # before the terminal result. event_stream persists it immediately;
+            # read it back so usage remains tied to the same exact session even
+            # when a CLI version omits session_id from its result envelope.
+            try:
+                usage_session_id = (
+                    read_session_id(
+                        resume_state,
+                        adapter="claude-code",
+                        cwd=os.getcwd(),
+                        model=model,
+                        effort=effort,
+                    )
+                    or ""
+                )
+            except (OSError, ResumeStateError) as e:
+                postprocess_failed = True
+                resume_postprocess_failed = True
+                print(f"claude-code adapter: resume state read failed: {e}", file=sys.stderr)
         policy_blocked = stream_policy_block_error is not None or _result_policy_blocked(result)
-        if activity_log and cli_rc != 0 and stream_plain_policy_block_error is not None:
+        if streaming and cli_rc != 0 and stream_plain_policy_block_error is not None:
             policy_blocked = True
-        if not activity_log and cli_rc != 0 and result is None:
+        if not streaming and cli_rc != 0 and result is None:
             # A failed pre-stream CLI may emit only a plain provider diagnostic.
             # Never apply this scan to a successful run or to arbitrary streamed
             # assistant history, where quoting an old block is normal task text.
             policy_blocked = final_diagnostic_has_policy_block(raw_text)
-        postprocess_failed = False
-        if activity_log:
+        transient_failure = stream_transient_error is not None or _result_transient_failure(result)
+        if streaming and cli_rc != 0 and stream_plain_transient_error is not None:
+            transient_failure = True
+        if not streaming and cli_rc != 0 and result is None:
+            # As with policy diagnostics, the plain fallback is restricted to a
+            # failed CLI with no structured terminal result. Agent-authored text
+            # and successful reports are never retry signals.
+            transient_failure = final_diagnostic_has_transient_failure(raw_text)
+        if streaming:
             try:
                 with open(raw_json, "w") as out:
                     if result is not None:
@@ -493,27 +656,35 @@ def main(argv: list[str]) -> int:
             except OSError as e:
                 postprocess_failed = True
                 print(f"claude-code adapter: raw result write failed: {e}", file=sys.stderr)
-        if not activity_log:
+        if not streaming:
             try:
                 _extract_log(result, raw_text, log_file)
             except OSError as e:
                 postprocess_failed = True
                 print(f"claude-code adapter: readable log write failed: {e}", file=sys.stderr)
         try:
-            _extract_usage(result, _derived_path(log_file, ".usage.json"))
+            _extract_usage(result, _derived_path(log_file, ".usage.json"), usage_session_id)
         except OSError as e:
             postprocess_failed = True
             print(f"claude-code adapter: usage write failed: {e}", file=sys.stderr)
 
+        if stream_resume_failed or resume_postprocess_failed:
+            return 1
         if rate_limited:
             return 75
-        if policy_blocked:
+        if policy_blocked or cli_rc == POLICY_BLOCKED_RC:
             print("claude-code adapter: provider policy block", file=sys.stderr)
             return POLICY_BLOCKED_RC
+        if transient_failure:
+            print("claude-code adapter: transient provider failure", file=sys.stderr)
+            return TRANSIENT_FAILURE_RC
         if cli_rc != 0:
-            return cli_rc
+            return 1 if cli_rc == TRANSIENT_FAILURE_RC else cli_rc
         return 1 if stream_failed or postprocess_failed else 0
     finally:
+        if hidden_activity_log is not None:
+            with contextlib.suppress(OSError):
+                os.remove(hidden_activity_log)
         if tmp_prompt is not None:
             with contextlib.suppress(OSError):
                 os.remove(tmp_prompt)

--- a/src/specula/adapters/opencode.py
+++ b/src/specula/adapters/opencode.py
@@ -8,6 +8,7 @@ Options:
   --effort=LEVEL        OpenCode variant (default: OPENCODE_EFFORT)
   --model=NAME          Provider/model (default: OPENCODE_MODEL)
   --log=FILE            Log file path (required)
+  --resume-state=PATH   Persist/resume the exact native OpenCode session
   --background          Accepted; caller handles backgrounding
   --help                Show this help
 """
@@ -21,12 +22,14 @@ from pathlib import Path
 
 if __package__:
     from .utils.json_cli import AdapterArgumentError, parse_options, run_json_cli
+    from .utils.resume import ResumeStateError, read_session_id
 else:
     from utils.json_cli import (  # type: ignore[import-not-found, no-redef]
         AdapterArgumentError,
         parse_options,
         run_json_cli,
     )
+    from utils.resume import ResumeStateError, read_session_id  # type: ignore[import-not-found, no-redef]
 
 HELP = __doc__
 SPECULA_ROOT = Path(__file__).resolve().parents[3]
@@ -121,9 +124,26 @@ def main(argv: list[str]) -> int:
         print(exc, file=sys.stderr)
         return 1
 
+    try:
+        session_id = read_session_id(
+            options.resume_state,
+            adapter="opencode",
+            cwd=os.getcwd(),
+            model=options.model,
+            effort=options.effort,
+        )
+    except ResumeStateError as exc:
+        options.cleanup()
+        print(f"opencode adapter: {exc}", file=sys.stderr)
+        return 1
+
     # OpenCode auto-rejects permission prompts in non-interactive runs unless
     # this auto-approval flag is present.
     command = ["opencode", "run", "--format=json", "--thinking", "--dangerously-skip-permissions"]
+    if session_id is not None:
+        # A full stream-emitted ID is exact. Never use OpenCode's --continue,
+        # whose "last session" resolution is unsafe under parallel runs.
+        command += ["--session", session_id]
     if options.model:
         command += ["--model", options.model]
     if options.effort:

--- a/src/specula/adapters/pi.py
+++ b/src/specula/adapters/pi.py
@@ -8,22 +8,26 @@ Options:
   --effort=LEVEL        Pi thinking level (default: PI_EFFORT)
   --model=NAME          Provider/model (default: PI_MODEL)
   --log=FILE            Log file path (required)
+  --resume-state=PATH   Persist/resume the exact native Pi session
   --background          Accepted; caller handles backgrounding
   --help                Show this help
 """
 
 from __future__ import annotations
 
+import os
 import sys
 
 if __package__:
     from .utils.json_cli import AdapterArgumentError, parse_options, run_json_cli
+    from .utils.resume import ResumeStateError, read_session_id
 else:
     from utils.json_cli import (  # type: ignore[import-not-found, no-redef]
         AdapterArgumentError,
         parse_options,
         run_json_cli,
     )
+    from utils.resume import ResumeStateError, read_session_id  # type: ignore[import-not-found, no-redef]
 
 HELP = __doc__
 
@@ -43,7 +47,28 @@ def main(argv: list[str]) -> int:
         print(exc, file=sys.stderr)
         return 1
 
-    command = ["pi", "--print", "--mode", "json", "--no-session", "--approve"]
+    try:
+        session_id = read_session_id(
+            options.resume_state,
+            adapter="pi",
+            cwd=os.getcwd(),
+            model=options.model,
+            effort=options.effort,
+        )
+    except ResumeStateError as exc:
+        options.cleanup()
+        print(f"pi adapter: {exc}", file=sys.stderr)
+        return 1
+
+    command = ["pi", "--print", "--mode", "json"]
+    if options.resume_state is None:
+        # Preserve the standalone adapter's historical ephemeral behavior.
+        command.append("--no-session")
+    elif session_id is not None:
+        # Pi accepts either a session path or ID. The full ID captured from
+        # this logical turn avoids its unsafe --continue/latest selection.
+        command += ["--session", session_id]
+    command.append("--approve")
     if options.model:
         command += ["--model", options.model]
     if options.effort:

--- a/src/specula/adapters/utils/event_stream.py
+++ b/src/specula/adapters/utils/event_stream.py
@@ -23,7 +23,14 @@ from .policy import (
     final_diagnostic_has_policy_block,
     looks_policy_blocked,
 )
+from .resume import RESUME_STATE_FAILURE_RC, ResumeStateError, capture_session_id
 from .text import SUMMARY_LIMIT, readable, readable_fragment, summary, tool_summary
+from .transient import (
+    PLAIN_TRANSIENT_DIAGNOSTIC_RC,
+    TRANSIENT_FAILURE_RC,
+    final_diagnostic_has_transient_failure,
+    looks_transient,
+)
 from .usage import PiSubagentResult, UsageTotals, accumulate_usage, pi_subagent_results
 
 
@@ -31,11 +38,15 @@ from .usage import PiSubagentResult, UsageTotals, accumulate_usage, pi_subagent_
 class StreamStatus:
     activity_ok: bool
     log_ok: bool
+    resume_ok: bool
     terminal_record: object | None
     structured_error: str | None
     rate_limit_error: str | None
     policy_block_error: str | None
     plain_policy_block_error: str | None
+    transient_error: str | None
+    plain_transient_error: str | None
+    session_id: str | None
     successful_terminal: bool
     terminal_error: str | None
     plain_diagnostics: tuple[str, ...]
@@ -356,28 +367,83 @@ def _structured_rate_limit_error(adapter_name: str, record: object) -> str | Non
     """Return a diagnostic only for an explicit provider-error record."""
     if not isinstance(record, dict):
         return None
-    if adapter_name == "opencode" and record.get("type") == "error":
-        error = record.get("error")
-        if not _looks_rate_limited(error):
-            return None
-        message = _diagnostic_message(error)
-        if isinstance(error, dict):
-            message = _diagnostic_message(error.get("data")) or message
-            name = error.get("name")
-            if not message and isinstance(name, str):
-                message = name
-        return summary(message or "provider rate limit", None)
-    if adapter_name != "pi":
+
+    payload: object | None = None
+    if adapter_name == "claude-code" and _claude_result_failed(record):
+        payload = record
+    elif adapter_name == "codex" and record.get("type") == "turn.failed":
+        payload = record.get("error")
+    elif adapter_name == "copilot-cli":
+        if record.get("type") == "session.error":
+            payload = record.get("data") if record.get("data") is not None else record
+        elif record.get("type") == "result" and record.get("exitCode") not in (None, 0, "0"):
+            payload = record.get("result") if record.get("result") is not None else record
+    elif adapter_name == "opencode" and record.get("type") == "error":
+        payload = record.get("error") if record.get("error") is not None else record
+    elif adapter_name == "pi":
+        terminal_error = _pi_terminal_error(record)
+        if terminal_error is not None:
+            payload = record.get("message")
+        elif record.get("type") == "error":
+            payload = record
+
+    if payload is None or not _looks_rate_limited(payload):
         return None
-    terminal_error = _pi_terminal_error(record)
-    if terminal_error is not None and _looks_rate_limited(terminal_error):
-        return terminal_error
-    if record.get("type") == "error":
-        error = record.get("error")
-        if _looks_rate_limited(record):
-            diagnostic = _diagnostic_message(error) or _diagnostic_message(record)
-            return summary(diagnostic or "provider rate limit", None)
-    return None
+    return _policy_diagnostic(payload) or "provider rate limit"
+
+
+def _structured_transient_error(adapter_name: str, record: object) -> str | None:
+    """Return a diagnostic only for an explicit failed provider envelope."""
+    if not isinstance(record, dict):
+        return None
+
+    payload: object | None = None
+    if adapter_name == "claude-code" and _claude_result_failed(record):
+        payload = record
+    elif adapter_name == "codex" and record.get("type") == "turn.failed":
+        payload = record.get("error")
+    elif adapter_name == "copilot-cli":
+        if record.get("type") == "session.error":
+            payload = record.get("data") if record.get("data") is not None else record
+        elif record.get("type") == "result" and record.get("exitCode") not in (None, 0, "0"):
+            payload = record.get("result") if record.get("result") is not None else record
+    elif adapter_name == "opencode" and record.get("type") == "error":
+        payload = record.get("error") if record.get("error") is not None else record
+    elif adapter_name == "pi":
+        if _pi_terminal_error(record) is not None:
+            payload = record.get("message")
+        elif record.get("type") == "error":
+            payload = record
+
+    if payload is None or not looks_transient(payload):
+        return None
+    return _policy_diagnostic(payload) or "provider reported a transient failure"
+
+
+def _session_id(adapter_name: str, record: object) -> str | None:
+    """Extract only documented, unambiguous native session identifiers."""
+    if not isinstance(record, dict):
+        return None
+    value: object | None = None
+    if adapter_name == "claude-code":
+        value = record.get("session_id")
+    elif adapter_name == "codex" and record.get("type") == "thread.started":
+        value = record.get("thread_id")
+    elif adapter_name == "copilot-cli":
+        if record.get("type") == "session.start":
+            data = record.get("data")
+            if isinstance(data, dict):
+                value = data.get("sessionId")
+        elif record.get("type") == "result":
+            # Copilot prompt mode may attach its JSON listener after creating
+            # the session, so session.start is not guaranteed to be observed.
+            # The terminal result always carries the same ID at top level.
+            value = record.get("sessionId")
+    elif adapter_name == "opencode":
+        value = record.get("sessionID")
+    elif adapter_name == "pi" and record.get("type") == "session":
+        value = record.get("id")
+    return value if isinstance(value, str) and value else None
 
 
 def _terminal_error(
@@ -572,6 +638,8 @@ def stream_events(
     activity_path: Path,
     log_path: Path,
     source: Iterable[bytes] | None = None,
+    *,
+    session_capture: Callable[[str], None] | None = None,
 ) -> StreamStatus:
     """Persist both views independently and report sink health.
 
@@ -592,16 +660,20 @@ def stream_events(
     terminal_record: object | None = None
     pi_agent_ended = False
     pi_terminating_tool_completed = False
-    opencode_policy_recovery_activity = False
+    opencode_recovery_activity = False
     structured_error: str | None = None
     rate_limit_error: str | None = None
     policy_block_error: str | None = None
+    transient_error: str | None = None
     successful_terminal = False
+    captured_session_id: str | None = None
+    seen_session_ids: set[str] = set()
     final_plain_diagnostic = ""
     plain_diagnostics: list[str] = []
     subagent_results: list[PiSubagentResult] = []
     raw_failures: list[str] = []
     readable_failures: list[str] = []
+    resume_failures: list[str] = []
     raw_log: BinaryIO | None = None
     log: TextIO | None = None
 
@@ -645,8 +717,9 @@ def stream_events(
     def handle_line(raw_line: bytes, *, raw_already_written: bool) -> None:
         nonlocal fragment_active, last_event, line_open, pi_message_had_fragments
         nonlocal pi_agent_ended, pi_terminating_tool_completed
-        nonlocal opencode_policy_recovery_activity
-        nonlocal final_plain_diagnostic, policy_block_error, rate_limit_error
+        nonlocal opencode_recovery_activity
+        nonlocal captured_session_id, final_plain_diagnostic, policy_block_error, rate_limit_error
+        nonlocal transient_error
         nonlocal structured_error, successful_terminal, terminal_record
         decoded = raw_line.decode(errors="replace")
         keep, events, record = _read_line(adapter_name, decoded, concise=False, structured=structured_stream)
@@ -662,45 +735,84 @@ def stream_events(
                 # Only the final non-empty physical stream line may serve as
                 # the out-of-band fallback. A later JSON event supersedes it.
                 final_plain_diagnostic = ""
+        detected_session_id = _session_id(adapter_name, record)
+        if detected_session_id is not None and detected_session_id not in seen_session_ids:
+            seen_session_ids.add(detected_session_id)
+            if captured_session_id is None:
+                captured_session_id = detected_session_id
+            if session_capture is not None:
+                try:
+                    session_capture(detected_session_id)
+                except ResumeStateError as exc:
+                    # Keep draining the native process. Raising here would
+                    # close the pipe early and can turn a useful diagnostic
+                    # into SIGPIPE.
+                    resume_failures.append(str(exc))
+
         accumulate_usage(adapter_name, record, usage_totals)
+        detected_rate_limit = _structured_rate_limit_error(adapter_name, record)
         detected_policy_block = _structured_policy_block_error(adapter_name, record)
-        if detected_policy_block is not None:
-            policy_block_error = detected_policy_block
+        detected_transient = _structured_transient_error(adapter_name, record)
+        if detected_rate_limit is not None:
+            rate_limit_error = detected_rate_limit
+            transient_error = None
             if adapter_name == "opencode":
-                opencode_policy_recovery_activity = False
+                opencode_recovery_activity = False
+        elif detected_policy_block is not None:
+            policy_block_error = detected_policy_block
+            transient_error = None
+            if adapter_name == "opencode":
+                opencode_recovery_activity = False
+        elif detected_transient is not None:
+            transient_error = detected_transient
+            if adapter_name == "opencode":
+                opencode_recovery_activity = False
         if adapter_name == "claude-code":
             if isinstance(record, dict) and record.get("type") == "result":
                 terminal_record = record
                 successful_terminal = not _claude_result_failed(record)
                 if successful_terminal:
+                    rate_limit_error = None
                     policy_block_error = None
+                    transient_error = None
         elif adapter_name == "codex":
             if isinstance(record, dict) and record.get("type") in {"turn.completed", "turn.failed"}:
                 terminal_record = record
                 successful_terminal = record.get("type") == "turn.completed"
                 if successful_terminal:
+                    rate_limit_error = None
                     policy_block_error = None
+                    transient_error = None
         elif adapter_name == "copilot-cli":
             if isinstance(record, dict) and record.get("type") == "result":
                 terminal_record = record
                 successful_terminal = record.get("exitCode") in (0, "0")
                 if successful_terminal:
+                    rate_limit_error = None
                     policy_block_error = None
+                    transient_error = None
         elif adapter_name == "opencode":
-            detected_rate_limit = _structured_rate_limit_error(adapter_name, record)
-            if detected_rate_limit is not None:
-                rate_limit_error = detected_rate_limit
-            if policy_block_error is not None and isinstance(record, dict):
+            if any(
+                error is not None for error in (rate_limit_error, policy_block_error, transient_error)
+            ) and isinstance(record, dict):
                 part = record.get("part")
-                if isinstance(part, dict) and part.get("type") in {"text", "tool"}:
-                    opencode_policy_recovery_activity = True
+                # OpenCode may retry a failed provider request internally. A
+                # new step is sufficient recovery evidence even when the
+                # successful response is empty; text/tool activity is the
+                # equivalent evidence for older stream formats.
+                if record.get("type") == "step_start" or (
+                    isinstance(part, dict) and part.get("type") in {"text", "tool"}
+                ):
+                    opencode_recovery_activity = True
             if isinstance(record, dict) and record.get("type") == "step_finish":
                 terminal_record = record
                 part = record.get("part")
                 reason = part.get("reason") if isinstance(part, dict) else None
                 successful_terminal = isinstance(reason, str) and reason.casefold() == "stop"
-                if opencode_policy_recovery_activity and isinstance(reason, str) and reason.casefold() == "stop":
+                if opencode_recovery_activity and isinstance(reason, str) and reason.casefold() == "stop":
+                    rate_limit_error = None
                     policy_block_error = None
+                    transient_error = None
         elif adapter_name == "pi":
             if (
                 isinstance(record, dict)
@@ -712,22 +824,21 @@ def stream_events(
                 pi_agent_ended = False
                 pi_terminating_tool_completed = False
                 structured_error = _pi_terminal_error(record)
-                rate_limit_error = _structured_rate_limit_error(adapter_name, record)
                 reason = record["message"].get("stopReason")
                 successful_terminal = isinstance(reason, str) and reason.casefold() == "stop"
                 if successful_terminal:
+                    rate_limit_error = None
                     policy_block_error = None
+                    transient_error = None
             elif _pi_successful_terminating_tool(record):
                 pi_terminating_tool_completed = True
             elif isinstance(record, dict) and record.get("type") == "agent_end":
                 pi_agent_ended = True
                 if pi_terminating_tool_completed:
                     successful_terminal = True
+                    rate_limit_error = None
                     policy_block_error = None
-            elif isinstance(record, dict) and record.get("type") == "error":
-                detected_rate_limit = _structured_rate_limit_error(adapter_name, record)
-                if detected_rate_limit is not None:
-                    rate_limit_error = detected_rate_limit
+                    transient_error = None
             child_results = pi_subagent_results(record)
             subagent_results.extend(child_results)
         if keep and not raw_already_written:
@@ -807,17 +918,26 @@ def stream_events(
         print(f"adapter event stream warning: {failure}", file=sys.stderr)
     for failure in readable_failures:
         print(f"adapter event stream failed: {failure}", file=sys.stderr)
+    for failure in resume_failures:
+        print(f"adapter resume state failed: {failure}", file=sys.stderr)
     plain_policy_block_error = None
     if structured_stream and not successful_terminal and final_diagnostic_has_policy_block(final_plain_diagnostic):
         plain_policy_block_error = summary(final_plain_diagnostic, None)
+    plain_transient_error = None
+    if structured_stream and not successful_terminal and final_diagnostic_has_transient_failure(final_plain_diagnostic):
+        plain_transient_error = summary(final_plain_diagnostic, None)
     return StreamStatus(
         activity_ok=not raw_failures,
-        log_ok=not readable_failures,
+        log_ok=not readable_failures and not resume_failures,
+        resume_ok=not resume_failures,
         terminal_record=terminal_record,
         structured_error=structured_error,
         rate_limit_error=rate_limit_error,
         policy_block_error=policy_block_error,
         plain_policy_block_error=plain_policy_block_error,
+        transient_error=transient_error,
+        plain_transient_error=plain_transient_error,
+        session_id=captured_session_id,
         successful_terminal=successful_terminal,
         terminal_error=_terminal_error(
             adapter_name,
@@ -832,23 +952,59 @@ def stream_events(
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) != 3 or argv[0] not in _ADAPTER_NAMES:
+    if len(argv) not in {3, 7} or argv[0] not in _ADAPTER_NAMES:
         print(
-            "usage: python -m specula.adapters.utils.event_stream {claude|codex|copilot|opencode|pi} ACTIVITY_JSONL LOG_FILE",
+            "usage: python -m specula.adapters.utils.event_stream "
+            "{claude|codex|copilot|opencode|pi} ACTIVITY_JSONL LOG_FILE "
+            "[RESUME_STATE CWD MODEL EFFORT]",
             file=sys.stderr,
         )
         return 2
+    session_capture: Callable[[str], None] | None = None
+    if len(argv) == 7:
+        adapter_name = _ADAPTER_NAMES[argv[0]]
+
+        def explicit_capture(session_id: str) -> None:
+            capture_session_id(
+                argv[3],
+                adapter=adapter_name,
+                session_id=session_id,
+                cwd=argv[4],
+                model=argv[5],
+                effort=argv[6],
+            )
+
+        session_capture = explicit_capture
     try:
-        status = stream_events(argv[0], Path(argv[1]), Path(argv[2]))
+        status = stream_events(
+            argv[0],
+            Path(argv[1]),
+            Path(argv[2]),
+            session_capture=session_capture,
+        )
     except OSError as exc:
         print(f"adapter event stream failed: {exc}", file=sys.stderr)
         return 1
+    if not status.resume_ok:
+        return RESUME_STATE_FAILURE_RC
+    if status.rate_limit_error is not None:
+        print(
+            f"adapter event stream rate limited: {summary(status.rate_limit_error, None)}",
+            file=sys.stderr,
+        )
+        return 75
     if status.policy_block_error is not None:
         print(
             f"adapter event stream policy blocked: {summary(status.policy_block_error, None)}",
             file=sys.stderr,
         )
         return POLICY_BLOCKED_RC
+    if status.transient_error is not None:
+        print(
+            f"adapter event stream transient failure: {summary(status.transient_error, None)}",
+            file=sys.stderr,
+        )
+        return TRANSIENT_FAILURE_RC
     if not status.log_ok:
         return 1
     if status.plain_policy_block_error is not None:
@@ -857,6 +1013,12 @@ def main(argv: list[str]) -> int:
             file=sys.stderr,
         )
         return PLAIN_POLICY_DIAGNOSTIC_RC
+    if status.plain_transient_error is not None:
+        print(
+            f"adapter event stream plain transient diagnostic: {summary(status.plain_transient_error, None)}",
+            file=sys.stderr,
+        )
+        return PLAIN_TRANSIENT_DIAGNOSTIC_RC
     return 0
 
 

--- a/src/specula/adapters/utils/json_cli.py
+++ b/src/specula/adapters/utils/json_cli.py
@@ -18,7 +18,9 @@ from typing import Any
 
 from .event_stream import StreamStatus, stream_events
 from .policy import POLICY_BLOCKED_RC
+from .resume import capture_session_id
 from .text import summary
+from .transient import TRANSIENT_FAILURE_RC
 from .usage import augment_opencode_usage, augment_pi_usage
 
 RATE_LIMIT_RC = 75  # EX_TEMPFAIL; this is the scheduler contract in specula.quota.
@@ -38,6 +40,7 @@ class AdapterOptions:
     log_path: Path
     model: str
     effort: str
+    resume_state: Path | None
 
     def cleanup(self) -> None:
         if self.temporary_prompt:
@@ -58,6 +61,7 @@ def parse_options(
     log_file: str | None = None
     model: str | None = None
     effort: str | None = None
+    resume_state: str | None = None
 
     for arg in argv:
         if arg.startswith("--prompt="):
@@ -70,6 +74,8 @@ def parse_options(
             model = arg.removeprefix("--model=")
         elif arg.startswith("--effort="):
             effort = arg.removeprefix("--effort=")
+        elif arg.startswith("--resume-state="):
+            resume_state = arg.removeprefix("--resume-state=")
         elif arg.startswith("--max-turns=") or arg.startswith("--claude-alias=") or arg == "--background":
             pass
         else:
@@ -86,6 +92,8 @@ def parse_options(
         raise AdapterArgumentError(adapter_name, "one of --prompt or --prompt-file is required")
     if not log_file:
         raise AdapterArgumentError(adapter_name, "--log is required")
+    if resume_state == "":
+        raise AdapterArgumentError(adapter_name, "--resume-state requires a path")
 
     if prompt_file:
         prompt_path = Path(prompt_file).resolve()
@@ -112,6 +120,9 @@ def parse_options(
         log_path=Path(log_file),
         model=resolved_model,
         effort=resolved_effort,
+        # Do not resolve this path: resume.py deliberately uses lstat so a
+        # symlink state file is rejected rather than silently following it.
+        resume_state=Path(resume_state) if resume_state is not None else None,
     )
 
 
@@ -209,12 +220,14 @@ def run_json_cli(
     child_env: dict[str, str] | None = None,
 ) -> int:
     """Run a JSONL CLI and persist its raw, readable, and usage sidecars."""
-    effective_env = child_env
+    inherited_env = dict(child_env if child_env is not None else os.environ)
+    for key in ("SPECULA_RESUME_STATE", "SPECULA_RESUME_MODEL", "SPECULA_RESUME_EFFORT"):
+        inherited_env.pop(key, None)
+    effective_env = inherited_env
     pi_session_root: Path | None = None
     activity_path: Path | None = None
     temporary_activity = False
     process: subprocess.Popen[bytes] | None = None
-    inherited_env = child_env if child_env is not None else os.environ
     with _cleanup_on_signal(lambda: process):
         try:
             if adapter_name == "pi":
@@ -269,7 +282,27 @@ def run_json_cli(
             try:
                 if process.stdout is None:
                     raise OSError("child stdout pipe unavailable")
-                status = stream_events(adapter_name, activity_path, options.log_path, process.stdout)
+                session_capture: Callable[[str], None] | None = None
+                if options.resume_state is not None:
+
+                    def explicit_capture(session_id: str) -> None:
+                        capture_session_id(
+                            options.resume_state,
+                            adapter=adapter_name,
+                            session_id=session_id,
+                            cwd=os.getcwd(),
+                            model=options.model,
+                            effort=options.effort,
+                        )
+
+                    session_capture = explicit_capture
+                status = stream_events(
+                    adapter_name,
+                    activity_path,
+                    options.log_path,
+                    process.stdout,
+                    session_capture=session_capture,
+                )
             except OSError as exc:
                 stream_failed = True
                 print(f"{adapter_name} adapter: event stream failed: {summary(str(exc), None)}", file=sys.stderr)
@@ -286,6 +319,8 @@ def run_json_cli(
                 elif adapter_name == "opencode":
                     usage = augment_opencode_usage(usage, _opencode_database_path(inherited_env))
             usage_ok = _write_usage(options.log_path.with_suffix(".usage.json"), usage)
+            if status is not None and not status.resume_ok:
+                return 1
             if native_status == RATE_LIMIT_RC:
                 return RATE_LIMIT_RC
             if status is not None and status.rate_limit_error is not None:
@@ -293,6 +328,8 @@ def run_json_cli(
                     f"{adapter_name} adapter: rate limit hit: {summary(status.rate_limit_error, None)}", file=sys.stderr
                 )
                 return RATE_LIMIT_RC
+            if native_status == POLICY_BLOCKED_RC:
+                return POLICY_BLOCKED_RC
             if status is not None and status.policy_block_error is not None:
                 print(
                     f"{adapter_name} adapter: policy block: {summary(status.policy_block_error, None)}",
@@ -306,8 +343,24 @@ def run_json_cli(
                     file=sys.stderr,
                 )
                 return POLICY_BLOCKED_RC
+            if status is not None and status.transient_error is not None:
+                print(
+                    f"{adapter_name} adapter: transient failure: {summary(status.transient_error, None)}",
+                    file=sys.stderr,
+                )
+                return TRANSIENT_FAILURE_RC
+            if native_status != 0 and status is not None and status.plain_transient_error is not None:
+                print(
+                    f"{adapter_name} adapter: plain transient diagnostic: "
+                    f"{summary(status.plain_transient_error, None)}",
+                    file=sys.stderr,
+                )
+                return TRANSIENT_FAILURE_RC
             if native_status != 0:
-                return native_status
+                # 74 is Specula's normalized transient contract, not a native
+                # CLI passthrough. An unrelated EX_IOERR must not trigger twenty
+                # session resumes without a classified provider diagnostic.
+                return 1 if native_status == TRANSIENT_FAILURE_RC else native_status
             if stream_failed or status is None or not status.log_ok or not usage_ok:
                 return 1
             failure = status.structured_error or status.terminal_error

--- a/src/specula/adapters/utils/resume.py
+++ b/src/specula/adapters/utils/resume.py
@@ -1,0 +1,227 @@
+"""Durable native-session identity for adapter retries and resumes.
+
+The phase runner owns the state-file path for one logical agent turn.  An
+adapter records the exact native session ID emitted by that invocation and
+loads it again only when the runner deliberately reuses the same path.  The
+binding fields prevent a stale or cross-adapter state file from silently
+resuming the wrong conversation.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+MAX_STATE_BYTES = 64 * 1024
+MAX_SESSION_ID_CHARS = 1024
+# Private event-stream status. Shell adapters normalize this to a generic
+# failure before returning to the phase runner; it must never be confused with
+# native rate-limit (75) or policy (76) statuses.
+RESUME_STATE_FAILURE_RC = 79
+
+
+class ResumeStateError(ValueError):
+    """A resume-state file is unsafe, corrupt, or belongs to another run."""
+
+
+def _text(value: str | None) -> str:
+    return value or ""
+
+
+def _cwd(value: str) -> str:
+    if not value:
+        raise ResumeStateError("cwd is empty")
+    return os.path.realpath(value)
+
+
+def _validate_session_id(value: object) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ResumeStateError("session_id must be a non-empty trimmed string")
+    if len(value) > MAX_SESSION_ID_CHARS or any(ord(char) < 32 for char in value):
+        raise ResumeStateError("session_id contains invalid characters")
+    if value.startswith("-"):
+        # Every supported CLI receives this value as the operand of a resume
+        # option. Refuse option-like IDs even though wrappers use argv arrays:
+        # native parsers are not consistent about accepting them as values.
+        raise ResumeStateError("session_id must not begin with '-'")
+    return value
+
+
+def _load_payload(path: Path) -> dict[str, Any] | None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise ResumeStateError(f"cannot inspect {path}: {exc}") from exc
+    if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+        raise ResumeStateError(f"resume state is not a regular file: {path}")
+    if metadata.st_size > MAX_STATE_BYTES:
+        raise ResumeStateError(f"resume state is too large: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ResumeStateError(f"cannot read {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ResumeStateError(f"resume state must be a JSON object: {path}")
+    return payload
+
+
+def _validate_binding(
+    payload: dict[str, Any],
+    *,
+    path: Path,
+    adapter: str,
+    cwd: str,
+    model: str,
+    effort: str,
+) -> str:
+    expected = {
+        "version": SCHEMA_VERSION,
+        "adapter": adapter,
+        "cwd": _cwd(cwd),
+        "model": _text(model),
+        "effort": _text(effort),
+    }
+    for key, value in expected.items():
+        if payload.get(key) != value:
+            raise ResumeStateError(f"resume state {path} has {key}={payload.get(key)!r}; expected {value!r}")
+    return _validate_session_id(payload.get("session_id"))
+
+
+def read_session_id(
+    path: str | Path | None,
+    *,
+    adapter: str,
+    cwd: str,
+    model: str = "",
+    effort: str = "",
+) -> str | None:
+    """Return the bound native session ID, or ``None`` for a fresh turn."""
+    if path is None or not str(path):
+        return None
+    state_path = Path(path)
+    payload = _load_payload(state_path)
+    if payload is None:
+        return None
+    return _validate_binding(
+        payload,
+        path=state_path,
+        adapter=adapter,
+        cwd=cwd,
+        model=model,
+        effort=effort,
+    )
+
+
+def capture_session_id(
+    path: str | Path | None,
+    *,
+    adapter: str,
+    session_id: str,
+    cwd: str,
+    model: str = "",
+    effort: str = "",
+) -> None:
+    """Atomically bind ``path`` to one exact native session.
+
+    Re-observing the same ID is harmless.  A different ID is an integrity
+    failure: continuing would merge independent agent histories.
+    """
+    if path is None or not str(path):
+        return
+    state_path = Path(path)
+    session_id = _validate_session_id(session_id)
+
+    def accept_existing() -> bool:
+        existing = _load_payload(state_path)
+        if existing is None:
+            return False
+        bound = _validate_binding(
+            existing,
+            path=state_path,
+            adapter=adapter,
+            cwd=cwd,
+            model=model,
+            effort=effort,
+        )
+        if bound != session_id:
+            raise ResumeStateError(f"resume state {state_path} changed session ID from {bound!r} to {session_id!r}")
+        return True
+
+    if accept_existing():
+        return
+
+    payload = {
+        "version": SCHEMA_VERSION,
+        "adapter": adapter,
+        "session_id": session_id,
+        "cwd": _cwd(cwd),
+        "model": _text(model),
+        "effort": _text(effort),
+    }
+    try:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, raw_temporary = tempfile.mkstemp(prefix=f".{state_path.name}.", suffix=".tmp", dir=state_path.parent)
+        temporary = Path(raw_temporary)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as stream:
+                json.dump(payload, stream, indent=2, sort_keys=True)
+                stream.write("\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            # `replace` would let two simultaneous first events silently
+            # overwrite each other. A same-directory hard-link publishes the
+            # fully fsynced temporary inode with create-if-absent semantics.
+            # The loser then validates the winner's exact binding below.
+            try:
+                os.link(temporary, state_path, follow_symlinks=False)
+            except FileExistsError:
+                if not accept_existing():  # pragma: no cover - EEXIST guarantees an entry
+                    raise ResumeStateError(f"resume state disappeared during capture: {state_path}") from None
+            else:
+                directory_fd = os.open(
+                    state_path.parent,
+                    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+                )
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                temporary.unlink()
+    except OSError as exc:
+        raise ResumeStateError(f"cannot write {state_path}: {exc}") from exc
+
+
+def _main(argv: list[str]) -> int:
+    if len(argv) != 6 or argv[0] != "read":
+        print("usage: resume.py read PATH ADAPTER CWD MODEL EFFORT", file=sys.stderr)
+        return 2
+    _, path, adapter, cwd, model, effort = argv
+    try:
+        session_id = read_session_id(
+            path,
+            adapter=adapter,
+            cwd=cwd,
+            model=model,
+            effort=effort,
+        )
+    except ResumeStateError as exc:
+        print(f"adapter resume state failed: {exc}", file=sys.stderr)
+        return 1
+    if session_id is not None:
+        print(session_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv[1:]))

--- a/src/specula/adapters/utils/transient.py
+++ b/src/specula/adapters/utils/transient.py
@@ -1,0 +1,144 @@
+"""Narrow classification for retryable provider and transport failures.
+
+Adapters use a dedicated result code so the phase runner can resume the exact
+native session instead of replaying an entire phase.  Arbitrary agent text is
+never classified here: callers must first establish that the value came from a
+provider error envelope, or that it is the final diagnostic of a failed CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+TRANSIENT_FAILURE_RC = 74
+# Like policy's plain-diagnostic code, this is private to an adapter wrapper.
+# The wrapper may normalize it only after confirming that the native CLI failed.
+PLAIN_TRANSIENT_DIAGNOSTIC_RC = 78
+_FAILED_LOG_SCAN_BYTES = 256 * 1024
+
+_TRANSIENT_CODES = {
+    "api_connection_error",
+    "api_timeout_error",
+    "connection_error",
+    "eai_again",
+    "econnaborted",
+    "econnrefused",
+    "econnreset",
+    "ehostunreach",
+    "enetdown",
+    "enetreset",
+    "enetunreach",
+    "epipe",
+    "etimedout",
+    "engine_overloaded",
+    "fetch_failed",
+    "internal_server_error",
+    "model_at_capacity",
+    "network_error",
+    "overloaded",
+    "overloaded_error",
+    "request_timeout",
+    "server_error",
+    "service_unavailable",
+    "socket_hang_up",
+    "temporarily_unavailable",
+    "timeout",
+    "transport_error",
+    "und_err_connect_timeout",
+    "und_err_socket",
+}
+_TRANSIENT_TEXT_RE = re.compile(
+    r"(?:\bhttp(?:\s+status)?\s*[:=]?\s*(?:500|502|503|504|529)\b|"
+    r"\bstatus(?:\s+code)?\s*[:=]?\s*(?:500|502|503|504|529)\b|"
+    r"\bapi\s+error\s*[:=-]?\s*(?:500|502|503|504|529)\b|"
+    r"selected model is at capacity|model (?:is )?at capacity|"
+    r"(?:server|service|provider|model) (?:is )?(?:temporarily )?unavailable|"
+    r"internal server error|overloaded[_\s-]*error|(?:server|model) overloaded|"
+    r"upstream (?:request )?(?:timed out|timeout|connect error)|"
+    r"request (?:timed out|timeout)|gateway (?:timed out|timeout)|"
+    r"connection (?:reset|closed|refused|terminated)|"
+    r"transport (?:error|closed)|network error|socket hang up|fetch failed|"
+    r"\b(?:eai_again|econnaborted|econnrefused|econnreset|ehostunreach|"
+    r"enetdown|enetreset|enetunreach|epipe|etimedout|und_err_connect_timeout|und_err_socket)\b)",
+    re.IGNORECASE,
+)
+
+# Plain output lacks the trusted provider-error envelope available to
+# ``looks_transient``. Require the final CLI diagnostic to start like an
+# operational error, so agent prose such as "the test expects HTTP 503" cannot
+# turn an unrelated native failure into repeated resume attempts.
+_PLAIN_TRANSIENT_DIAGNOSTIC_RE = re.compile(
+    r"^\s*(?:(?:error|fatal)(?:\[[^\]]+\])?\s*[:=-]\s*)?(?:"
+    r"(?:http(?:\s+status)?|status(?:\s+code)?|api\s+error)\s*[:=]?\s*(?:500|502|503|504|529)\b|"
+    r"selected model is at capacity\b|model (?:is )?at capacity\b|"
+    r"(?:server|service|provider|model) (?:is )?(?:temporarily )?unavailable\b|"
+    r"internal server error\b|overloaded[_\s-]*error\b|(?:server|model) overloaded\b|"
+    r"upstream (?:request )?(?:timed out|timeout|connect error)\b|"
+    r"request (?:timed out|timeout)\b|gateway (?:timed out|timeout)\b|"
+    r"connection (?:reset|closed|refused|terminated)\b|"
+    r"transport (?:error|closed)\b|network error\b|socket hang up\b|fetch failed\b|"
+    r"(?:(?:read|write|connect|getaddrinfo)\s+)?(?:eai_again|econnaborted|econnrefused|econnreset|ehostunreach|"
+    r"enetdown|enetreset|enetunreach|epipe|etimedout|und_err_connect_timeout|und_err_socket)\b"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _normalized_code(value: str) -> str:
+    value = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", value)
+    value = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", value)
+    return re.sub(r"[^a-z0-9]+", "_", value.casefold()).strip("_")
+
+
+def _is_transient_code(value: str) -> bool:
+    normalized = _normalized_code(value)
+    return normalized in _TRANSIENT_CODES or normalized.removesuffix("_error") in _TRANSIENT_CODES
+
+
+def looks_transient(value: object, depth: int = 0) -> bool:
+    """Recognize a transient failure inside an identified error payload."""
+    if depth > 4:
+        return False
+    if isinstance(value, str):
+        return _is_transient_code(value) or bool(_TRANSIENT_TEXT_RE.search(value))
+    if not isinstance(value, dict):
+        return False
+
+    for key in ("statusCode", "status_code", "status"):
+        status = value.get(key)
+        if status in {500, 502, 503, 504, 529, "500", "502", "503", "504", "529"}:
+            return True
+    for key in ("code", "errorCode", "error_code", "errorType", "error_type", "name", "type"):
+        code = value.get(key)
+        if isinstance(code, str) and _is_transient_code(code):
+            return True
+    for key in ("message", "errorMessage", "error_message", "responseBody", "response_body"):
+        if looks_transient(value.get(key), depth + 1):
+            return True
+    return any(looks_transient(value.get(key), depth + 1) for key in ("data", "error", "cause", "body", "response"))
+
+
+def final_diagnostic_has_transient_failure(text: str) -> bool:
+    """Classify only a failed CLI's final non-empty, non-JSON diagnostic."""
+    diagnostic = next((line.strip() for line in reversed(text.splitlines()) if line.strip()), "")
+    if not diagnostic:
+        return False
+    try:
+        json.loads(diagnostic)
+    except (TypeError, ValueError):
+        return bool(_PLAIN_TRANSIENT_DIAGNOSTIC_RE.search(diagnostic))
+    return False
+
+
+def failed_log_has_transient_failure(path: Path) -> bool:
+    """Narrow fallback for a failed CLI run that could not emit JSON events."""
+    try:
+        with path.open("rb") as stream:
+            stream.seek(0, 2)
+            stream.seek(max(0, stream.tell() - _FAILED_LOG_SCAN_BYTES))
+            text = stream.read(_FAILED_LOG_SCAN_BYTES).decode("utf-8", errors="replace")
+    except OSError:
+        return False
+    return final_diagnostic_has_transient_failure(text)

--- a/src/specula/adapters/utils/transient.py
+++ b/src/specula/adapters/utils/transient.py
@@ -78,7 +78,8 @@ _PLAIN_TRANSIENT_DIAGNOSTIC_RE = re.compile(
     r"upstream (?:request )?(?:timed out|timeout|connect error)\b|"
     r"request (?:timed out|timeout)\b|gateway (?:timed out|timeout)\b|"
     r"connection (?:reset|closed|refused|terminated)\b|"
-    r"transport (?:error|closed)\b|network error\b|socket hang up\b|fetch failed\b|"
+    r"transport (?:error|closed)\b|network error\b|socket hang up\b|"
+    r"typeerror\s*:\s*fetch failed\s*\Z|fetch failed\b|"
     r"(?:(?:read|write|connect|getaddrinfo)\s+)?(?:eai_again|econnaborted|econnrefused|econnreset|ehostunreach|"
     r"enetdown|enetreset|enetunreach|epipe|etimedout|und_err_connect_timeout|und_err_socket)\b"
     r")",

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -683,15 +683,16 @@ def _repair_draft_warning(cfg: ConfirmConfig, f: Finding, draft: RepairDraft) ->
     return None
 
 
-def _restore_repair_draft(path: Path, body: str) -> None:
-    """Restore a usable pre-correction draft if the advisory turn damages it."""
+def _restore_repair_draft(path: Path, body: str | None) -> None:
+    """Restore the pre-correction draft state if the advisory turn damages it."""
     if path.is_symlink() or path.is_file():
         path.unlink()
     elif path.is_dir():
         shutil.rmtree(path)
     elif path.exists():
         path.unlink()
-    path.write_text(body)
+    if body is not None:
+        path.write_text(body)
 
 
 def _final_outcome(
@@ -772,6 +773,10 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
                         problem = _repair_draft_warning(cfg, f, draft)
                     except InvalidRepairRequest as exc:
                         problem = exc
+                        draft_path = f.fdir / "repair-request.body.md"
+                        if not draft_path.is_symlink() and draft_path.is_file():
+                            with contextlib.suppress(OSError, UnicodeError):
+                                original = draft_path.read_text()
 
                     if problem is None:
                         return previous_turn
@@ -804,9 +809,6 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
                     return correction_turn
                 if repair.verdict is None:
                     draft_path = f.fdir / "repair-request.body.md"
-                    if original is None:
-                        with contextlib.suppress(InvalidRepairRequest):
-                            original = _read_repair_draft(cfg, f).raw
                     try:
                         correction_verdict, _ = run_turn(
                             cfg,
@@ -822,19 +824,19 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
                         raise
                     except Exception as exc:
                         repair.disabled = True
-                        if original is None:
+                        _restore_repair_draft(draft_path, original)
+                        if original is None or not original.strip():
                             raise
                         _log(f"  WARNING: {f.id}: repair-draft correction failed ({exc}); keeping the original draft")
-                        _restore_repair_draft(draft_path, original)
                         return correction_turn
 
                     try:
                         corrected = _read_repair_draft(cfg, f)
                     except InvalidRepairRequest:
-                        if original is None:
+                        _restore_repair_draft(draft_path, original)
+                        if original is None or not original.strip():
                             raise
                         _log(f"  WARNING: {f.id}: correction removed the usable draft; keeping the original draft")
-                        _restore_repair_draft(draft_path, original)
                         corrected = _read_repair_draft(cfg, f)
 
                     corrected_warning = _repair_draft_warning(cfg, f, corrected)

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -25,6 +25,7 @@ nothing to deliver.)
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import os
@@ -41,7 +42,14 @@ from pathlib import Path
 from typing import Any
 
 from specula import quota
-from specula.phaselib import DEFAULT_POLICY_RETRIES, SPECULA_ROOT, PolicyRetryState, Workspace, run_agent_blocking
+from specula.phaselib import (
+    DEFAULT_POLICY_RETRIES,
+    DEFAULT_TRANSIENT_RESUMES,
+    SPECULA_ROOT,
+    PolicyRetryState,
+    Workspace,
+    run_agent_blocking,
+)
 from specula.prompts import render
 from specula.skill_refs import prompt_skill_ids
 
@@ -143,6 +151,39 @@ class Finding:
         return str(self.data["id"])
 
 
+@dataclass(frozen=True)
+class _CompletedTurn:
+    prompt_digest: str
+    cwd: str | None
+    verdict: str | None
+    text: str
+
+
+@dataclass
+class _RepairTurn:
+    turn_no: int
+    prompt: str
+    original: str | None = None
+    verdict: str | None = None
+    disabled: bool = False
+
+
+@dataclass
+class _FindingLease:
+    """In-process state retained only across an armed reactive rc75 replay."""
+
+    finding_dir: Path
+    repo_for_agent: str
+    cleanup: Callable[[], None]
+    initialized: bool = False
+    repair_retry_used: bool = False
+    completed_turns: dict[tuple[int, str], _CompletedTurn] = field(default_factory=dict)
+    turn_cwds: dict[tuple[int, str], Path] = field(default_factory=dict)
+    repair_turns: dict[tuple[int, str], _RepairTurn] = field(default_factory=dict)
+    _run_lock: Any = field(default_factory=threading.RLock, repr=False, compare=False)
+    _closed: bool = False
+
+
 @dataclass
 class ConfirmConfig:
     name: str
@@ -162,6 +203,7 @@ class ConfirmConfig:
     rounds: int = 5
     max_turns: str = "0"
     policy_retries: int = DEFAULT_POLICY_RETRIES
+    transient_resumes: int = DEFAULT_TRANSIENT_RESUMES
     # Runtime-only cursors survive this config's automatic rc75 retries. They
     # are deliberately absent from candidate/verdict fingerprints and disk.
     _policy_states: dict[tuple[str, ...], tuple[str, PolicyRetryState]] = field(
@@ -171,6 +213,11 @@ class ConfirmConfig:
         compare=False,
     )
     _policy_states_lock: Any = field(default_factory=threading.Lock, init=False, repr=False, compare=False)
+    _finding_leases: dict[str, _FindingLease] = field(default_factory=dict, init=False, repr=False, compare=False)
+    _finding_lease_pending: dict[str, threading.Event] = field(
+        default_factory=dict, init=False, repr=False, compare=False
+    )
+    _finding_leases_lock: Any = field(default_factory=threading.Lock, init=False, repr=False, compare=False)
 
     def policy_state(self, key: tuple[str, ...], prompt: str) -> PolicyRetryState:
         """Return the cursor for one stable logical turn in this target run."""
@@ -191,6 +238,69 @@ class ConfirmConfig:
                 return
             for key in [key for key in self._policy_states if key[: len(prefix)] == prefix]:
                 del self._policy_states[key]
+
+    def acquire_finding_lease(self, f: Finding) -> _FindingLease:
+        """Reuse one finding's worktree and completed turns during rc75 replay."""
+        finding_dir = f.fdir.absolute()
+        creator = False
+        try:
+            while True:
+                with self._finding_leases_lock:
+                    existing = self._finding_leases.get(f.id)
+                    if existing is not None:
+                        if existing.finding_dir != finding_dir:
+                            raise ConfirmationFailed(f"{f.id}: retry lease belongs to a different finding directory")
+                        return existing
+                    pending = self._finding_lease_pending.get(f.id)
+                    if pending is None:
+                        pending = threading.Event()
+                        self._finding_lease_pending[f.id] = pending
+                        creator = True
+                if creator:
+                    break
+                pending.wait()
+
+            repo_for_agent, cleanup = setup_repo(self, f)
+            candidate = _FindingLease(finding_dir, repo_for_agent, cleanup)
+            with self._finding_leases_lock:
+                self._finding_leases[f.id] = candidate
+            return candidate
+        finally:
+            if creator:
+                with self._finding_leases_lock:
+                    pending = self._finding_lease_pending.pop(f.id, None)
+                if pending is not None:
+                    pending.set()
+
+    def release_finding_lease(self, finding_id: str) -> None:
+        """Idempotently release one terminal finding's runtime-only lease."""
+        with self._finding_leases_lock:
+            lease = self._finding_leases.pop(finding_id, None)
+        if lease is None:
+            return
+        with lease._run_lock:
+            if lease._closed:
+                return
+            lease._closed = True
+            lease.completed_turns.clear()
+            lease.turn_cwds.clear()
+            lease.repair_turns.clear()
+            try:
+                lease.cleanup()
+            except BaseException as exc:
+                message = f"  WARNING: {finding_id}: retry-lease cleanup failed ({exc})"
+                try:
+                    _log(message)
+                except OSError:
+                    print(message, flush=True)
+
+    def clear_retry_runtime(self) -> None:
+        """Release every lease/cursor when no immediate reactive replay follows."""
+        with self._finding_leases_lock:
+            finding_ids = list(self._finding_leases)
+        for finding_id in finding_ids:
+            self.release_finding_lease(finding_id)
+        self.clear_policy_states()
 
 
 @dataclass
@@ -297,6 +407,7 @@ def run_turn(
     prompt: str,
     *,
     cwd: str | Path | None = None,
+    lease: _FindingLease | None = None,
 ) -> tuple[str | None, str]:
     """Run one agent turn synchronously; return (verdict, response text).
 
@@ -308,7 +419,19 @@ def run_turn(
     if cfg.dry_run:
         _log(f"    [{f.id}] [DRY] turn {turn_no} {role} → {log.name}")
         return ("REPRODUCED" if role == "A" and turn_no == 1 else None), ""
-    policy_state = cfg.policy_state(("finding", f.id, str(turn_no), role), prompt)
+    turn_key = (turn_no, role)
+    prompt_digest = hashlib.sha256(prompt.encode()).hexdigest()
+    turn_cwd = str(Path(cwd).absolute()) if cwd is not None else None
+    if lease is not None:
+        completed = lease.completed_turns.get(turn_key)
+        if completed is not None:
+            if completed.prompt_digest != prompt_digest or completed.cwd != turn_cwd:
+                raise ConfirmationFailed(f"{f.id} turn {turn_no} {role}: retry lease no longer matches the turn")
+            _log(f"    [{f.id}] turn {turn_no} {role}: completed before rate limit — reuse")
+            return completed.verdict, completed.text
+
+    state_key = ("finding", f.id, str(turn_no), role)
+    policy_state = cfg.policy_state(state_key, prompt)
     rc, text = run_agent_blocking(
         cfg.adapter,
         prompt,
@@ -323,6 +446,7 @@ def run_turn(
         model=cfg.model,
         effort=cfg.effort,
         policy_retries=cfg.policy_retries,
+        transient_resumes=cfg.transient_resumes,
         policy_state=policy_state,
     )
     if rc == 75:
@@ -331,10 +455,16 @@ def run_turn(
         raise ConfirmationFailed(f"{f.id} turn {turn_no} {role}: adapter exited {rc}")
     if not text.strip():
         raise InvalidAgentOutput(f"{f.id} turn {turn_no} {role}: empty agent output")
-    return parse_verdict(text), text
+    verdict = parse_verdict(text)
+    if lease is not None:
+        lease.completed_turns[turn_key] = _CompletedTurn(prompt_digest, turn_cwd, verdict, text)
+    # A completed turn is now represented by the lease cache; its native retry
+    # cursor is no longer needed. Only the unfinished rc75 turn keeps one.
+    cfg.clear_policy_states(state_key)
+    return verdict, text
 
 
-def _fresh_turn_cwd(f: Finding, role: str, turn_no: int) -> Path:
+def _fresh_turn_cwd(f: Finding, role: str, turn_no: int, lease: _FindingLease | None = None) -> Path:
     """Create a trusted per-turn cwd outside the untrusted source checkout.
 
     Agent prompts carry the absolute source-repo path. Keeping adapter startup
@@ -346,6 +476,12 @@ def _fresh_turn_cwd(f: Finding, role: str, turn_no: int) -> Path:
         root.unlink()
     root.mkdir(parents=True, exist_ok=True)
     cwd = root / f"turn{turn_no:02d}_{role}"
+    turn_key = (turn_no, role)
+    if lease is not None and turn_key in lease.turn_cwds:
+        expected = lease.turn_cwds[turn_key]
+        if expected != cwd or cwd.is_symlink() or not cwd.is_dir():
+            raise ConfirmationFailed(f"{f.id}: retained cwd for turn {turn_no} {role} is no longer safe")
+        return cwd
     if cwd.is_symlink():
         cwd.unlink()
     elif cwd.exists():
@@ -360,6 +496,8 @@ def _fresh_turn_cwd(f: Finding, role: str, turn_no: int) -> Path:
         )
     except (OSError, subprocess.CalledProcessError) as exc:
         raise ConfirmationFailed(f"{f.id}: could not create trusted per-turn cwd: {exc}") from exc
+    if lease is not None:
+        lease.turn_cwds[turn_key] = cwd
     return cwd
 
 
@@ -586,71 +724,123 @@ def _debate_entry(f: Finding, role: str, turn_no: int, label: str, verdict: str 
     return f"\n## {label} — VERDICT: {verdict or '(none)'}\nFull turn log (read it for the full argument): {log}\n"
 
 
-def run_finding(cfg: ConfirmConfig, f: Finding) -> Outcome:
+def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None = None) -> Outcome:
     if not f.id or set(f.id) - ID_CHARS or f.id in {".", ".."}:
         raise InvalidAgentOutput(f"unsafe finding id: {f.id!r}")
     f.fdir.mkdir(parents=True, exist_ok=True)
     repro_dir = cfg.ws.work_dir(cfg.name).absolute() / "repro"
     repro_dir.mkdir(parents=True, exist_ok=True)
-    # Fresh generations must create fresh artifacts. Completed findings in a
-    # rate-limit retry are skipped by the fingerprinted verdict cache.
-    for stale in _repro_files(cfg, f):
-        stale.unlink()
-    rr_body = f.fdir / "repair-request.body.md"
-    if rr_body.is_file():
-        rr_body.unlink()
+    owned_lease = _lease is None
+    if _lease is None:
+        repo_for_agent, cleanup = setup_repo(cfg, f)
+        lease = _FindingLease(f.fdir.absolute(), repo_for_agent, cleanup)
+    else:
+        lease = _lease
+    if lease.finding_dir != f.fdir.absolute() or lease._closed:
+        raise ConfirmationFailed(f"{f.id}: invalid retry lease")
     debate = f.fdir / "debate.md"
-    repo_for_agent, cleanup = setup_repo(cfg, f)
+    lease._run_lock.acquire()
     try:
-        turn = 1
-        repair_retry_used = False
+        with lease._run_lock:
+            if not lease.initialized:
+                # Fresh generations must create fresh artifacts. A reactive rc75
+                # continuation keeps them, its exact worktree, and its cwd.
+                for stale in _repro_files(cfg, f):
+                    stale.unlink()
+                rr_body = f.fdir / "repair-request.body.md"
+                if rr_body.is_file():
+                    rr_body.unlink()
+                lease.initialized = True
+            repo_for_agent = lease.repo_for_agent
+            turn = 1
 
-        def prepare_pending(previous_turn: int, previous_role: str = "A") -> int:
-            """Warn about a draft problem and make at most one correction turn.
+            def prepare_pending(previous_turn: int, previous_role: str = "A") -> int:
+                """Warn about a draft problem and make at most one correction turn.
 
-            A readable, non-empty draft is always usable.  If the optional
-            correction fails, retain that original draft rather than turning a
-            parser complaint into an INCOMPLETE finding.
-            """
-            nonlocal repair_retry_used
-            original: str | None = None
-            problem: Exception | str | None = None
-            try:
-                draft = _read_repair_draft(cfg, f)
-                original = draft.raw
-                problem = _repair_draft_warning(cfg, f, draft)
-            except InvalidRepairRequest as exc:
-                problem = exc
+                The lease records a correction's logical turn before invoking it.
+                Therefore a later B rate-limit replay cannot renumber B merely
+                because the already-completed correction left a valid draft.
+                """
+                repair_key = (previous_turn, previous_role)
+                repair = lease.repair_turns.get(repair_key)
+                original = repair.original if repair is not None else None
+                if repair is None:
+                    problem: Exception | str | None = None
+                    try:
+                        draft = _read_repair_draft(cfg, f)
+                        original = draft.raw
+                        problem = _repair_draft_warning(cfg, f, draft)
+                    except InvalidRepairRequest as exc:
+                        problem = exc
 
-            if problem is None:
-                return previous_turn
+                    if problem is None:
+                        return previous_turn
 
-            warning = str(problem)
-            _log(f"  WARNING: {warning}")
-            if repair_retry_used:
-                if original is None:
-                    assert isinstance(problem, Exception)
-                    raise problem
-                return previous_turn
+                    warning = str(problem)
+                    _log(f"  WARNING: {warning}")
+                    if lease.repair_retry_used:
+                        if original is None:
+                            assert isinstance(problem, Exception)
+                            raise problem
+                        return previous_turn
 
-            repair_retry_used = True
-            correction_turn = previous_turn + 1
-            draft_path = f.fdir / "repair-request.body.md"
-            try:
-                correction_verdict, _ = run_turn(
-                    cfg,
-                    f,
-                    "A-repair",
-                    correction_turn,
-                    prompt_repair_draft_retry(
-                        cfg,
-                        f,
-                        repo_for_agent,
-                        warning,
-                        f.fdir / f"turn{previous_turn:02d}_{previous_role}.log",
-                    ),
-                    cwd=_fresh_turn_cwd(f, "A-repair", correction_turn),
-                )
+                    lease.repair_retry_used = True
+                    correction_turn = previous_turn + 1
+                    repair = _RepairTurn(
+                        correction_turn,
+                        prompt_repair_draft_retry(
+                            cfg,
+                            f,
+                            repo_for_agent,
+                            warning,
+                            f.fdir / f"turn{previous_turn:02d}_{previous_role}.log",
+                        ),
+                        original,
+                    )
+                    lease.repair_turns[repair_key] = repair
+
+                correction_turn = repair.turn_no
+                if repair.disabled:
+                    return correction_turn
+                if repair.verdict is None:
+                    draft_path = f.fdir / "repair-request.body.md"
+                    if original is None:
+                        with contextlib.suppress(InvalidRepairRequest):
+                            original = _read_repair_draft(cfg, f).raw
+                    try:
+                        correction_verdict, _ = run_turn(
+                            cfg,
+                            f,
+                            "A-repair",
+                            correction_turn,
+                            repair.prompt,
+                            cwd=_fresh_turn_cwd(f, "A-repair", correction_turn, lease),
+                            lease=lease,
+                        )
+                        repair.verdict = correction_verdict
+                    except RateLimited:
+                        raise
+                    except Exception as exc:
+                        repair.disabled = True
+                        if original is None:
+                            raise
+                        _log(f"  WARNING: {f.id}: repair-draft correction failed ({exc}); keeping the original draft")
+                        _restore_repair_draft(draft_path, original)
+                        return correction_turn
+
+                    try:
+                        corrected = _read_repair_draft(cfg, f)
+                    except InvalidRepairRequest:
+                        if original is None:
+                            raise
+                        _log(f"  WARNING: {f.id}: correction removed the usable draft; keeping the original draft")
+                        _restore_repair_draft(draft_path, original)
+                        corrected = _read_repair_draft(cfg, f)
+
+                    corrected_warning = _repair_draft_warning(cfg, f, corrected)
+                    if corrected_warning is not None:
+                        _log(f"  WARNING: {corrected_warning} (continuing with the non-empty draft)")
+
                 debate.write_text(
                     debate.read_text()
                     + _debate_entry(
@@ -658,31 +848,10 @@ def run_finding(cfg: ConfirmConfig, f: Finding) -> Outcome:
                         "A-repair",
                         correction_turn,
                         "A (repair-draft correction)",
-                        correction_verdict,
+                        repair.verdict,
                     )
                 )
-            except RateLimited:
-                raise
-            except Exception as exc:
-                if original is None:
-                    raise
-                _log(f"  WARNING: {f.id}: repair-draft correction failed ({exc}); keeping the original draft")
-                _restore_repair_draft(draft_path, original)
                 return correction_turn
-
-            try:
-                corrected = _read_repair_draft(cfg, f)
-            except InvalidRepairRequest:
-                if original is None:
-                    raise
-                _log(f"  WARNING: {f.id}: correction removed the usable draft; keeping the original draft")
-                _restore_repair_draft(draft_path, original)
-                return correction_turn
-
-            corrected_warning = _repair_draft_warning(cfg, f, corrected)
-            if corrected_warning is not None:
-                _log(f"  WARNING: {corrected_warning} (continuing with the non-empty draft)")
-            return correction_turn
 
         # Turn 1 — Reproducer (neutral): investigate + reproduce.
         a_verdict, a_text = run_turn(
@@ -691,7 +860,8 @@ def run_finding(cfg: ConfirmConfig, f: Finding) -> Outcome:
             "A",
             1,
             prompt_reproduce(cfg, f, repo_for_agent),
-            cwd=_fresh_turn_cwd(f, "A", 1),
+            cwd=_fresh_turn_cwd(f, "A", 1, lease),
+            lease=lease,
         )
         debate.write_text(
             f"# Debate: {f.id}\n\nThis is an INDEX of the debate. Each entry links the turn's "
@@ -720,7 +890,8 @@ def run_finding(cfg: ConfirmConfig, f: Finding) -> Outcome:
                 "B",
                 turn,
                 prompt_challenge(cfg, f, repo_for_agent, str(debate)),
-                cwd=_fresh_turn_cwd(f, "B", turn),
+                cwd=_fresh_turn_cwd(f, "B", turn, lease),
+                lease=lease,
             )
             debate.write_text(debate.read_text() + _debate_entry(f, "B", turn, f"B (round {rnd})", b_verdict))
             _validate_turn_output(f, b_verdict, b_text)
@@ -747,7 +918,8 @@ def run_finding(cfg: ConfirmConfig, f: Finding) -> Outcome:
                 "A",
                 turn,
                 prompt_defend(cfg, f, repo_for_agent, str(debate)),
-                cwd=_fresh_turn_cwd(f, "A", turn),
+                cwd=_fresh_turn_cwd(f, "A", turn, lease),
+                lease=lease,
             )
             debate.write_text(debate.read_text() + _debate_entry(f, "A", turn, f"A (round {rnd})", a_verdict))
             _validate_turn_output(f, a_verdict, a_text)
@@ -761,7 +933,10 @@ def run_finding(cfg: ConfirmConfig, f: Finding) -> Outcome:
         _log(f"  [{f.id}] no consensus after {cfg.rounds} rounds → NEEDS MORE INFO")
         return _final_outcome(cfg, f, "NEEDS MORE INFO", False, cfg.rounds, _compose_evidence(initial_text, defenses))
     finally:
-        cleanup()
+        lease._run_lock.release()
+        if owned_lease:
+            lease._closed = True
+            lease.cleanup()
 
 
 # ── idempotent per-finding verdict cache (survives a rate-limit phase retry) ──
@@ -1108,16 +1283,20 @@ def run_finding_safe(cfg: ConfirmConfig, f: Finding) -> Outcome:
     to discard the whole target's report: the rest of the batch still delivers."""
     cached = _load_verdict(f, cfg)
     if cached is not None:
+        cfg.release_finding_lease(f.id)
         cfg.clear_policy_states(("finding", f.id))
         _log(f"  [{f.id}] cached {cached.status} — skip (idempotent)")
         return cached
     try:
-        o = run_finding(cfg, f)
+        lease = cfg.acquire_finding_lease(f)
+        o = run_finding(cfg, f, _lease=lease)
         _save_verdict(o, cfg)
+        cfg.release_finding_lease(f.id)
         cfg.clear_policy_states(("finding", f.id))
         return o
     except Exception as exc:  # RateLimited / ConfirmationFailed / anything unexpected
         if not isinstance(exc, RateLimited):
+            cfg.release_finding_lease(f.id)
             cfg.clear_policy_states(("finding", f.id))
         try:
             f.fdir.mkdir(parents=True, exist_ok=True)
@@ -2202,10 +2381,13 @@ def consolidate(cfg: ConfirmConfig) -> None:
         _log(f"  {cfg.name}: [DRY] consolidate → {out}")
         return
     spec_dir.mkdir(parents=True, exist_ok=True)
-    # Do not let a failed agent make a stale output look fresh.
-    out.unlink(missing_ok=True)
-    (spec_dir / _CANDIDATE_CACHE).unlink(missing_ok=True)
     policy_state = cfg.policy_state(("consolidate",), prompt)
+    if policy_state.invocation_attempt == 0:
+        # Do not let a fresh failed agent make stale output look fresh. An exact
+        # rc75 continuation, however, may need candidates already written by its
+        # still-live native session, so the replay must not delete them.
+        out.unlink(missing_ok=True)
+        (spec_dir / _CANDIDATE_CACHE).unlink(missing_ok=True)
     try:
         rc, _ = run_agent_blocking(
             cfg.adapter,
@@ -2219,6 +2401,7 @@ def consolidate(cfg: ConfirmConfig) -> None:
             model=cfg.model,
             effort=cfg.effort,
             policy_retries=cfg.policy_retries,
+            transient_resumes=cfg.transient_resumes,
             policy_state=policy_state,
         )
     except BaseException:
@@ -2399,7 +2582,7 @@ def load_findings(cfg: ConfirmConfig) -> list[Finding]:
     return findings
 
 
-def run_parallel_confirmation(cfg: ConfirmConfig) -> int:
+def run_parallel_confirmation(cfg: ConfirmConfig, *, retain_rate_limited_state: bool = False) -> int:
     """Drive step 0 (consolidate) → per-finding fan-out → aggregate for ONE
     target. Returns 75 for exclusively rate-limited incomplete findings and 1 for
     permanent/format/infrastructure incomplete findings while retaining their
@@ -2421,8 +2604,8 @@ def run_parallel_confirmation(cfg: ConfirmConfig) -> int:
             result = 1 if cfg.dry_run else _withhold(cfg, "confirmation driver failure — deliverable withheld")
         return result
     finally:
-        if result != quota.RATE_LIMIT_RC:
-            cfg.clear_policy_states()
+        if result != quota.RATE_LIMIT_RC or not retain_rate_limited_state:
+            cfg.clear_retry_runtime()
         _set_log_file(None)
 
 

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -35,6 +35,7 @@ if __package__ in (None, ""):
 import specula.progress as progress
 from specula import quota
 from specula.adapters.utils.policy import POLICY_BLOCKED_RC
+from specula.adapters.utils.transient import TRANSIENT_FAILURE_RC
 from specula.prompts import render
 from specula.skill_refs import materialize_skill_refs, prompt_skill_ids
 from specula.tlc_resources import (
@@ -55,23 +56,33 @@ LAUNCH_DIR = SPECULA_ROOT / "scripts" / "launch"
 AGENT_TERMINATION_GRACE_SECONDS = 2.0
 MAX_DEBATE_ROUNDS = 5
 DEFAULT_POLICY_RETRIES = 20
+DEFAULT_TRANSIENT_RESUMES = 20
+TRANSIENT_RESUME_BACKOFF_MAX_SECONDS = 60.0
 
 
 @dataclass
 class PolicyRetryState:
-    """Cursor for one logical agent turn across caller-managed rate-limit retries."""
+    """Retry cursor and exact native session for one logical agent turn."""
 
     policy_attempt: int = 0
+    transient_attempt: int = 0
+    invocation_attempt: int = 0
+    resume_state: Path | None = None
+    retry_reason: str = "fresh"
     _lock: Any = field(default_factory=threading.Lock, init=False, repr=False, compare=False)
 
 
 @dataclass(frozen=True)
 class _LaunchRequest:
-    """One scheduler request with independent quota and policy state."""
+    """One scheduler request with a single logical-turn retry ledger."""
 
     target: str
     rate_limit_attempt: int = 1
     policy_attempt: int = 0
+    transient_attempt: int = 0
+    invocation_attempt: int = 1
+    retry_reason: str = "fresh"
+    ready_at: float = 0.0
 
 
 _POLICY_RECOVERY_NOTE = """
@@ -80,6 +91,10 @@ _POLICY_RECOVERY_NOTE = """
 
 The previous invocation was interrupted because the provider blocked a response under its content policy. Continue the same legitimate formal-verification task from the existing workspace. Inspect and preserve completed work, rephrase the blocked portion in neutral formal-verification terms, and complete every required deliverable for this phase. Do not repeat work that is already complete.
 """
+
+_SESSION_RESUME_PROMPT = """Continue the current Specula task from this exact session. The previous invocation was interrupted by a temporary provider, capacity, or transport failure. Preserve completed work, inspect the current workspace, and finish every remaining deliverable. Do not restart completed analysis."""
+
+_POLICY_SESSION_RESUME_PROMPT = """Continue the same legitimate formal-verification task from this exact session. The previous response was interrupted by the provider's content policy. Preserve completed work, rephrase the interrupted portion in neutral formal-verification terms, and finish every remaining deliverable without restarting the phase."""
 
 
 def _policy_recovery_prompt(prompt: str) -> str:
@@ -92,6 +107,69 @@ def _parse_policy_retries(raw: str) -> int:
     if not re.fullmatch(r"[0-9]+", raw):
         raise ValueError("expected a non-negative integer")
     return int(raw)
+
+
+def _parse_transient_resumes(raw: str) -> int:
+    """Parse a transient native-session continuation count."""
+    if not re.fullmatch(r"[0-9]+", raw):
+        raise ValueError("expected a non-negative integer")
+    return int(raw)
+
+
+def _resume_state_path(log_file: Path) -> Path:
+    return log_file.with_suffix(".resume.json")
+
+
+def _attempt_path(path: Path, attempt: int) -> Path:
+    return path.with_name(f"{path.stem}.attempt-{attempt}{path.suffix}")
+
+
+def _archive_attempt(paths: tuple[Path, ...], attempt: int) -> None:
+    """Keep failed invocation evidence before an adapter truncates its logs."""
+    for path in paths:
+        if path.is_file():
+            with contextlib.suppress(OSError):
+                os.replace(path, _attempt_path(path, attempt))
+
+
+def _clear_attempt_archives(paths: tuple[Path, ...]) -> None:
+    """Drop stale retry evidence when a new logical turn reuses its log path."""
+    for path in paths:
+        for archived in path.parent.glob(f"{path.stem}.attempt-*{path.suffix}"):
+            with contextlib.suppress(OSError):
+                archived.unlink()
+
+
+def _clear_resume_state(path: Path) -> None:
+    """Remove an earlier logical turn's exact-session binding or fail closed."""
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise RuntimeError(f"cannot clear stale resume state {path}: {exc}") from exc
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise RuntimeError(f"cannot verify cleared resume state {path}: {exc}") from exc
+    raise RuntimeError(f"stale resume state still exists after removal: {path}")
+
+
+def _transient_resume_delay(attempt: int) -> float:
+    """Short bounded backoff; attempt is the 1-based resume number."""
+    return min(TRANSIENT_RESUME_BACKOFF_MAX_SECONDS, float(2 ** min(attempt + 1, 6)))
+
+
+def _retry_prompt(original: str, reason: str, *, resumable: bool) -> str:
+    if not resumable:
+        return _policy_recovery_prompt(original) if reason == "policy" else original
+    if reason == "policy":
+        return _POLICY_SESSION_RESUME_PROMPT
+    if reason in {"rate_limit", "transient"}:
+        return _SESSION_RESUME_PROMPT
+    return original
 
 
 # bash pathname expansion (`for d in .../*/`) orders by the locale collating
@@ -296,6 +374,7 @@ class Phase:
     _model: str | None = None
     _effort: str | None = None
     _policy_retries = DEFAULT_POLICY_RETRIES
+    _transient_resumes = DEFAULT_TRANSIENT_RESUMES
 
     # ── per-phase hooks ──
     def parse_flag(self, arg: str, extra: dict[str, str | bool]) -> bool:
@@ -467,6 +546,7 @@ class Phase:
         max_parallel: int | None = None
         max_turns = "0"
         policy_retries = DEFAULT_POLICY_RETRIES
+        transient_resumes = DEFAULT_TRANSIENT_RESUMES
         dry_run = False
         check_only = False
         agent = "claude-code"
@@ -507,6 +587,13 @@ class Phase:
                     policy_retries = _parse_policy_retries(raw)
                 except ValueError:
                     print(f"Invalid --policy-retries: '{raw}' (expected a non-negative integer)")
+                    return 1
+            elif arg.startswith("--transient-resumes="):
+                raw = arg[len("--transient-resumes=") :]
+                try:
+                    transient_resumes = _parse_transient_resumes(raw)
+                except ValueError:
+                    print(f"Invalid --transient-resumes: '{raw}' (expected a non-negative integer)")
                     return 1
             elif arg.startswith("--agent="):
                 agent = arg[len("--agent=") :]
@@ -559,6 +646,7 @@ class Phase:
         self._model = model if model is not None else (os.environ.get("SPECULA_MODEL") or None)
         self._effort = effort if effort is not None else (os.environ.get("SPECULA_EFFORT") or None)
         self._policy_retries = policy_retries
+        self._transient_resumes = transient_resumes
 
         # A direct multi-target phase command has no Pipeline.run_dir, but its
         # agents must still share one TLC budget. Preserve the scope supplied by
@@ -613,6 +701,7 @@ class Phase:
         print(f"Max parallel: {max_parallel}")
         print(f"Max turns:    {max_turns}")
         print(f"Policy retries: {policy_retries}")
+        print(f"Transient resumes: {transient_resumes}")
         print()
 
         print(self.check_header)
@@ -662,11 +751,16 @@ class Phase:
             try:
                 while pending or running:
                     while pending and len(running) < max_parallel and not pause_for_rate_limit and not stop_launching:
-                        request = pending.pop(0)
+                        now = time.monotonic()
+                        ready_index = next(
+                            (index for index, candidate in enumerate(pending) if candidate.ready_at <= now),
+                            None,
+                        )
+                        if ready_index is None:
+                            break
+                        request = pending.pop(ready_index)
                         name = self.target_name(request.target)
                         prompt = self.build_prompt(ws, request.target)
-                        if request.policy_attempt > 0:
-                            prompt = _policy_recovery_prompt(prompt)
                         self._launch(
                             ws,
                             name,
@@ -679,6 +773,9 @@ class Phase:
                             target=request.target,
                             attempt=request.rate_limit_attempt,
                             policy_attempt=request.policy_attempt,
+                            transient_attempt=request.transient_attempt,
+                            invocation_attempt=request.invocation_attempt,
+                            retry_reason=request.retry_reason,
                         )
                         print()
 
@@ -715,6 +812,38 @@ class Phase:
                                         completed_agent.target,
                                         rate_limit_attempt=completed_agent.attempt,
                                         policy_attempt=next_policy_attempt,
+                                        transient_attempt=completed_agent.transient_attempt,
+                                        invocation_attempt=completed_agent.invocation_attempt + 1,
+                                        retry_reason="policy",
+                                    ),
+                                )
+                            else:
+                                failures.append((completed_agent.name, rc))
+                            continue
+                        if rc == TRANSIENT_FAILURE_RC:
+                            if completed_agent.transient_attempt < self._transient_resumes:
+                                next_transient_attempt = completed_agent.transient_attempt + 1
+                                delay = _transient_resume_delay(next_transient_attempt)
+                                mode = (
+                                    "resuming the exact session"
+                                    if completed_agent.resume_state is not None
+                                    and completed_agent.resume_state.is_file()
+                                    else "retrying before a session was captured"
+                                )
+                                print(
+                                    f"[{_ts()}] {completed_agent.name}: temporary provider failure; {mode} "
+                                    f"({next_transient_attempt}/{self._transient_resumes}) after {delay:g}s"
+                                )
+                                pending.insert(
+                                    0,
+                                    _LaunchRequest(
+                                        completed_agent.target,
+                                        rate_limit_attempt=completed_agent.attempt,
+                                        policy_attempt=completed_agent.policy_attempt,
+                                        transient_attempt=next_transient_attempt,
+                                        invocation_attempt=completed_agent.invocation_attempt + 1,
+                                        retry_reason="transient",
+                                        ready_at=time.monotonic() + delay,
                                     ),
                                 )
                             else:
@@ -727,6 +856,9 @@ class Phase:
                                         completed_agent.target,
                                         rate_limit_attempt=completed_agent.attempt + 1,
                                         policy_attempt=completed_agent.policy_attempt,
+                                        transient_attempt=completed_agent.transient_attempt,
+                                        invocation_attempt=completed_agent.invocation_attempt + 1,
+                                        retry_reason="rate_limit",
                                     )
                                 )
                                 pause_for_rate_limit = True
@@ -768,6 +900,11 @@ class Phase:
 
                     if running:
                         time.sleep(self.progress_config.poll_seconds)
+                    elif pending and not pause_for_rate_limit and not stop_launching:
+                        next_ready = min(request.ready_at for request in pending)
+                        delay = max(0.0, next_ready - time.monotonic())
+                        if delay:
+                            time.sleep(min(self.progress_config.poll_seconds, delay))
 
                 if not dry_run:
                     print(f"[{_ts()}] All agents completed.")
@@ -939,10 +1076,32 @@ class Phase:
         target: str = "",
         attempt: int = 1,
         policy_attempt: int = 0,
+        transient_attempt: int = 0,
+        invocation_attempt: int = 1,
+        retry_reason: str = "fresh",
     ) -> progress.RunningAgent | None:
         files = self.agent_files(ws, name)
         for d in files["mkdirs"]:
             d.mkdir(parents=True, exist_ok=True)
+        resume_state = _resume_state_path(files["log"])
+        activity_sidecar = files["log"].with_suffix(".activity.jsonl")
+        attempt_files = (
+            files["prompt"],
+            files["log"],
+            _last_message_path(files["log"]),
+            activity_sidecar,
+            files["log"].with_suffix(".raw.json"),
+            files["log"].with_suffix(".usage.json"),
+        )
+        if not dry_run:
+            if invocation_attempt == 1:
+                _clear_attempt_archives(attempt_files)
+                _clear_resume_state(resume_state)
+            else:
+                _archive_attempt(attempt_files, invocation_attempt - 1)
+        resumable = resume_state.is_file()
+        prompt_reason = "policy" if policy_attempt > 0 and not resumable else retry_reason
+        prompt = _retry_prompt(prompt, prompt_reason, resumable=resumable)
         prompt = materialize_skill_refs(prompt, adapter)
         files["prompt"].write_text(prompt)
         print(f"[{_ts()}] Launching agent: {name}")
@@ -952,7 +1111,7 @@ class Phase:
             print(
                 f"  [DRY RUN] {adapter} {self.dry_prompt_flag}=<prompt> "
                 f"--max-turns={max_turns} --claude-alias={claude_alias}{tuning_text} "
-                f"--log={files['log']} --background"
+                f"--log={files['log']} --resume-state={resume_state} --background"
             )
             print(f"  Prompt saved: {files['prompt']}")
             return None
@@ -968,14 +1127,12 @@ class Phase:
         if repo_dir:
             env["SPECULA_TARGET_REPO_DIR"] = repo_dir
         work_dir = ws.work_dir(name)
-        activity_sidecar = files["log"].with_suffix(".activity.jsonl")
         with contextlib.suppress(OSError):
             activity_sidecar.unlink()
-        # SPECULA_PROGRESS=off is a full opt-out, not a mute: without the sidecar
-        # the adapters fall back to their legacy argv (`--output-format json`, no
-        # `codex --json`, no copilot `--stream on`) and the legacy result-only
-        # agent.log. A CLI that predates the streaming flags would otherwise have
-        # no escape hatch — and an adapter failure now aborts the whole run.
+        # SPECULA_PROGRESS=off disables the retained activity sidecar and live
+        # reporting. Resume-capable adapters may still consume a private
+        # structured stream so they can durably capture the exact native session
+        # ID; that temporary capture is not progress telemetry.
         env.pop("SPECULA_ACTIVITY_LOG", None)
         if progress.enabled():
             env["SPECULA_ACTIVITY_LOG"] = str(activity_sidecar)
@@ -990,6 +1147,7 @@ class Phase:
             activity_sidecar,
             files["log"].with_suffix(".raw.json"),
             files["log"].with_suffix(".usage.json"),
+            resume_state,
         )
         ignored: set[Path] = set()
         for path in runtime_files:
@@ -1011,6 +1169,7 @@ class Phase:
                     f"--claude-alias={claude_alias}",
                     *_model_effort_argv(adapter, self._model, self._effort),
                     f"--log={files['log']}",
+                    f"--resume-state={resume_state}",
                     "--background",
                 ],
                 env=env,
@@ -1032,6 +1191,9 @@ class Phase:
                 target=target,
                 attempt=attempt,
                 policy_attempt=policy_attempt,
+                transient_attempt=transient_attempt,
+                invocation_attempt=invocation_attempt,
+                resume_state=resume_state,
             )
             if owner is not None:
                 owner.append(launched)
@@ -1091,6 +1253,7 @@ def run_agent_blocking(
     model: str | None = None,
     effort: str | None = None,
     policy_retries: int = DEFAULT_POLICY_RETRIES,
+    transient_resumes: int = DEFAULT_TRANSIENT_RESUMES,
     policy_state: PolicyRetryState | None = None,
 ) -> tuple[int, str]:
     """Run an agent turn, blocking, and return (returncode, log text).
@@ -1111,13 +1274,18 @@ def run_agent_blocking(
     aggregate, never after one turn. ``stop_gate=True`` opts back into the
     original phase key and therefore its deliverable contract. Rate-limit (exit
     75) is the caller's concern. A provider policy block (exit 76) advances up
-    to ``policy_retries`` continuation levels in the same workspace. Callers
-    that automatically replay exit 75 may pass ``policy_state`` so that replay
-    resumes the same level instead of resetting the logical turn's budget. The
-    caller must discard that state after any non-75 terminal result.
+    to ``policy_retries`` continuation levels. A retryable provider/transport
+    failure (exit 74) resumes up to ``transient_resumes`` times with bounded
+    backoff. Every retry reuses the exact native session captured in a state
+    file; if the CLI failed before emitting an ID, Specula safely replays the
+    original prompt. Callers that automatically replay exit 75 may pass
+    ``policy_state`` so the native session and both budgets survive that wait.
+    The caller must discard that state after any non-75 terminal result.
     """
     if policy_retries < 0:
         raise ValueError("policy_retries must be a non-negative integer")
+    if transient_resumes < 0:
+        raise ValueError("transient_resumes must be a non-negative integer")
     caller_cwd = Path.cwd()
     adapter = adapter if adapter.is_absolute() else (caller_cwd / adapter).resolve()
     prompt_file = prompt_file if prompt_file.is_absolute() else (caller_cwd / prompt_file).resolve()
@@ -1132,6 +1300,16 @@ def run_agent_blocking(
     prompt = materialize_skill_refs(prompt, adapter)
     prompt_file.parent.mkdir(parents=True, exist_ok=True)
     last_message_file = _last_message_path(log_file)
+    resume_state = _resume_state_path(log_file)
+    activity_file = log_file.with_suffix(".activity.jsonl")
+    attempt_files = (
+        prompt_file,
+        log_file,
+        last_message_file,
+        activity_file,
+        log_file.with_suffix(".raw.json"),
+        log_file.with_suffix(".usage.json"),
+    )
     env = os.environ.copy()
     env["SPECULA_PHASE"] = phase_key if stop_gate else f"{phase_key}_turn"
     env["SPECULA_WORK_DIR"] = str(work_dir)
@@ -1162,14 +1340,32 @@ def run_agent_blocking(
         f"--claude-alias={claude_alias}",
         *_model_effort_argv(adapter, model, effort),
         f"--log={log_file}",
+        f"--resume-state={resume_state}",
     ]
     state = policy_state if policy_state is not None else PolicyRetryState()
     with state._lock:
         if not 0 <= state.policy_attempt <= policy_retries:
             raise ValueError("policy_state attempt must be within policy_retries")
+        if not 0 <= state.transient_attempt <= transient_resumes:
+            raise ValueError("policy_state transient attempt must be within transient_resumes")
+        if state.resume_state is None:
+            _clear_attempt_archives(attempt_files)
+            _clear_resume_state(resume_state)
+            state.resume_state = resume_state
+        elif state.resume_state != resume_state:
+            raise ValueError("policy_state belongs to a different logical turn")
         while True:
             policy_attempt = state.policy_attempt
-            current_prompt = prompt if policy_attempt == 0 else _policy_recovery_prompt(prompt)
+            state.invocation_attempt += 1
+            if state.invocation_attempt > 1:
+                _archive_attempt(attempt_files, state.invocation_attempt - 1)
+            resumable = resume_state.is_file()
+            prompt_reason = "policy" if policy_attempt > 0 and not resumable else state.retry_reason
+            current_prompt = _retry_prompt(
+                prompt,
+                prompt_reason,
+                resumable=resumable,
+            )
             prompt_file.write_text(current_prompt)
             with contextlib.suppress(OSError):
                 log_file.unlink()
@@ -1186,13 +1382,28 @@ def run_agent_blocking(
             # adapters' log contract remains result-only.
             result_file = last_message_file if adapter.stem == "codex" else log_file
             text = result_file.read_text(errors="replace") if result_file.is_file() else ""
-            if rc != POLICY_BLOCKED_RC or policy_attempt >= policy_retries:
-                return rc, text
-            state.policy_attempt = policy_attempt + 1
-            print(
-                f"[{_ts()}] Provider policy interrupted the agent turn; retrying with a revised request "
-                f"({state.policy_attempt}/{policy_retries})"
-            )
+            if rc == TRANSIENT_FAILURE_RC and state.transient_attempt < transient_resumes:
+                state.transient_attempt += 1
+                state.retry_reason = "transient"
+                delay = _transient_resume_delay(state.transient_attempt)
+                mode = "resuming the exact session" if resume_state.is_file() else "retrying the original request"
+                print(
+                    f"[{_ts()}] Temporary provider failure; {mode} "
+                    f"({state.transient_attempt}/{transient_resumes}) after {delay:g}s"
+                )
+                time.sleep(delay)
+                continue
+            if rc == POLICY_BLOCKED_RC and policy_attempt < policy_retries:
+                state.policy_attempt = policy_attempt + 1
+                state.retry_reason = "policy"
+                print(
+                    f"[{_ts()}] Provider policy interrupted the agent turn; retrying with a revised request "
+                    f"({state.policy_attempt}/{policy_retries})"
+                )
+                continue
+            if rc == quota.RATE_LIMIT_RC:
+                state.retry_reason = "rate_limit"
+            return rc, text
 
 
 class CodeAnalysisPhase(Phase):
@@ -1222,6 +1433,7 @@ Options:
   --max-parallel=N    Max concurrent agents (default: 1)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
   --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
+  --transient-resumes=N  Transient provider/transport session resumes (default: 20; 0 disables)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
   --model=NAME        Model forwarded to the selected adapter
@@ -1341,6 +1553,7 @@ Options:
   --max-parallel=N    Max concurrent agents (default: 1)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
   --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
+  --transient-resumes=N  Transient provider/transport session resumes (default: 20; 0 disables)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
   --model=NAME        Model forwarded to the selected adapter
@@ -1475,6 +1688,7 @@ Options:
   --max-parallel=N    Max concurrent agents (default: 1)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
   --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
+  --transient-resumes=N  Transient provider/transport session resumes (default: 20; 0 disables)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
   --model=NAME        Model forwarded to the selected adapter
@@ -1605,6 +1819,7 @@ Options:
   --max-parallel=N    Max concurrent agents (default: 1)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
   --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
+  --transient-resumes=N  Transient provider/transport session resumes (default: 20; 0 disables)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
   --model=NAME        Model forwarded to the selected adapter
@@ -1723,6 +1938,7 @@ Options:
   --max-parallel=N    Max concurrent agents (default: 1)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
   --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
+  --transient-resumes=N  Transient provider/transport session resumes (default: 20; 0 disables)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
   --model=NAME        Model forwarded to the selected adapter
@@ -1881,6 +2097,7 @@ Options:
                       --legacy-confirm (defaults: 4 in parallel mode, 1 otherwise)
   --max-turns=N       Max agent turns (default: 0 = unlimited)
   --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
+  --transient-resumes=N  Transient provider/transport session resumes (default: 20; 0 disables)
   --agent=NAME        Agent adapter to use (default: claude-code)
   --claude-alias=NAME Claude CLI profile (default: claude)
   --model=NAME        Model forwarded to the selected adapter
@@ -1980,23 +2197,32 @@ Prerequisites:
                 model=self._model,
                 effort=self._effort,
                 policy_retries=self._policy_retries,
+                transient_resumes=self._transient_resumes,
                 dry_run=dry_run,
                 prompt_extra=self._read_prompt_extra(ws, name),
             )
             attempt = 1
-            while True:
-                code = run_parallel_confirmation(cfg)
-                if (
-                    code == quota.RATE_LIMIT_RC
-                    and not failures
-                    and self._reactive_rate_limit_enabled()
-                    and attempt <= retry_limit
-                ):
-                    print(f"[{_ts()}] Rate limited: waiting before retrying {name}")
-                    self._wait_for_rate_limit()
-                    attempt += 1
-                    continue
-                break
+            try:
+                while True:
+                    will_retry_rate_limit = (
+                        not failures and self._reactive_rate_limit_enabled() and attempt <= retry_limit
+                    )
+                    code = run_parallel_confirmation(
+                        cfg,
+                        retain_rate_limited_state=will_retry_rate_limit,
+                    )
+                    if code == quota.RATE_LIMIT_RC and will_retry_rate_limit:
+                        print(f"[{_ts()}] Rate limited: waiting before retrying {name}")
+                        self._wait_for_rate_limit()
+                        attempt += 1
+                        continue
+                    break
+            finally:
+                # A quota wait can abort (or the process can be interrupted)
+                # after the confirmation driver deliberately retained its exact
+                # session/worktree. Never leak that runtime lease when no next
+                # replay will execute in this process.
+                cfg.clear_retry_runtime()
             if code != 0:
                 failures.append((name, code))
                 if code == quota.RATE_LIMIT_RC:
@@ -2221,6 +2447,7 @@ Options (after <phase>):
   --model=NAME        Model forwarded to the selected adapter
   --effort=LEVEL      Reasoning effort forwarded to the selected adapter
   --policy-retries=N  Policy-block continuation retries (default: 20; 0 disables)
+  --transient-resumes=N  Transient provider/transport session resumes (default: 20; 0 disables)
 
 Phases:
   analysis    — Review code analysis output (modeling-brief.md, analysis-report.md)
@@ -2244,6 +2471,7 @@ Output:
         model: str | None = None
         effort: str | None = None
         policy_retries = DEFAULT_POLICY_RETRIES
+        transient_resumes = DEFAULT_TRANSIENT_RESUMES
         targets: list[str] = []
         for arg in argv[1:]:
             if arg.startswith("--agent="):
@@ -2261,6 +2489,13 @@ Output:
                 except ValueError:
                     print(f"Invalid --policy-retries: '{raw}' (expected a non-negative integer)")
                     return 1
+            elif arg.startswith("--transient-resumes="):
+                raw = arg[len("--transient-resumes=") :]
+                try:
+                    transient_resumes = _parse_transient_resumes(raw)
+                except ValueError:
+                    print(f"Invalid --transient-resumes: '{raw}' (expected a non-negative integer)")
+                    return 1
             elif arg in ("--help", "-h"):
                 sys.stdout.write(self.usage)
                 return 0
@@ -2270,6 +2505,7 @@ Output:
         self._model = model if model is not None else (os.environ.get("SPECULA_MODEL") or None)
         self._effort = effort if effort is not None else (os.environ.get("SPECULA_EFFORT") or None)
         self._policy_retries = policy_retries
+        self._transient_resumes = transient_resumes
 
         if not phase or not targets:
             print(f"Usage: {SCRIPT_DIR}/phaselib.py review <analysis|specgen|validation> name [name ...]")
@@ -2287,12 +2523,12 @@ Output:
         print(f" Specula — Review Agent ({phase})")
         print("========================================")
         print(f"Policy retries: {policy_retries}")
+        print(f"Transient resumes: {transient_resumes}")
         print()
 
         with _cleanup_on_signal():
             for name in names:
-                attempt = 1
-                policy_attempt = 0
+                request = _LaunchRequest(name)
                 while True:
                     rc = self._launch_review(
                         ws,
@@ -2300,22 +2536,57 @@ Output:
                         phase,
                         adapter,
                         claude_alias,
-                        policy_attempt=policy_attempt,
+                        policy_attempt=request.policy_attempt,
+                        transient_attempt=request.transient_attempt,
+                        invocation_attempt=request.invocation_attempt,
+                        retry_reason=request.retry_reason,
                     )
                     if (
                         rc == quota.RATE_LIMIT_RC
                         and self._reactive_rate_limit_enabled()
-                        and attempt <= self._rate_limit_retries()
+                        and request.rate_limit_attempt <= self._rate_limit_retries()
                     ):
                         print(f"[{_ts()}] Rate limited: waiting before retrying {name}")
                         self._wait_for_rate_limit()
-                        attempt += 1
+                        request = _LaunchRequest(
+                            name,
+                            rate_limit_attempt=request.rate_limit_attempt + 1,
+                            policy_attempt=request.policy_attempt,
+                            transient_attempt=request.transient_attempt,
+                            invocation_attempt=request.invocation_attempt + 1,
+                            retry_reason="rate_limit",
+                        )
                         continue
-                    if rc == POLICY_BLOCKED_RC and policy_attempt < self._policy_retries:
-                        policy_attempt += 1
+                    if rc == POLICY_BLOCKED_RC and request.policy_attempt < self._policy_retries:
+                        next_policy_attempt = request.policy_attempt + 1
                         print(
                             f"[{_ts()}] {name}: provider policy interrupted the review; "
-                            f"retrying with a revised request ({policy_attempt}/{self._policy_retries})"
+                            f"retrying with a revised request ({next_policy_attempt}/{self._policy_retries})"
+                        )
+                        request = _LaunchRequest(
+                            name,
+                            rate_limit_attempt=request.rate_limit_attempt,
+                            policy_attempt=next_policy_attempt,
+                            transient_attempt=request.transient_attempt,
+                            invocation_attempt=request.invocation_attempt + 1,
+                            retry_reason="policy",
+                        )
+                        continue
+                    if rc == TRANSIENT_FAILURE_RC and request.transient_attempt < self._transient_resumes:
+                        next_transient_attempt = request.transient_attempt + 1
+                        delay = _transient_resume_delay(next_transient_attempt)
+                        print(
+                            f"[{_ts()}] {name}: temporary provider failure; resuming review "
+                            f"({next_transient_attempt}/{self._transient_resumes}) after {delay:g}s"
+                        )
+                        time.sleep(delay)
+                        request = _LaunchRequest(
+                            name,
+                            rate_limit_attempt=request.rate_limit_attempt,
+                            policy_attempt=request.policy_attempt,
+                            transient_attempt=next_transient_attempt,
+                            invocation_attempt=request.invocation_attempt + 1,
+                            retry_reason="transient",
                         )
                         continue
                     if rc != 0:
@@ -2354,6 +2625,9 @@ Output:
         claude_alias: str,
         *,
         policy_attempt: int = 0,
+        transient_attempt: int = 0,
+        invocation_attempt: int = 1,
+        retry_reason: str = "fresh",
     ) -> int:
         wd = ws.work_dir(name)
         # specgen/validation logs go under spec/ to match pipeline summary expectations
@@ -2368,12 +2642,26 @@ Output:
         else:
             print(f"Unknown phase: {phase}")
             raise SystemExit(1)
-        if policy_attempt > 0:
-            prompt = _policy_recovery_prompt(prompt)
         print(f"[{_ts()}] Reviewing {name} ({phase})...")
         log_dir.mkdir(parents=True, exist_ok=True)
         pid_file = log_dir / f"review-{phase}.pid"
         activity_log = log_file.with_suffix(".activity.jsonl")
+        resume_state = _resume_state_path(log_file)
+        attempt_files = (
+            log_file,
+            _last_message_path(log_file),
+            activity_log,
+            log_file.with_suffix(".raw.json"),
+            log_file.with_suffix(".usage.json"),
+        )
+        if invocation_attempt == 1:
+            _clear_attempt_archives(attempt_files)
+            _clear_resume_state(resume_state)
+        else:
+            _archive_attempt(attempt_files, invocation_attempt - 1)
+        resumable = resume_state.is_file()
+        prompt_reason = "policy" if policy_attempt > 0 and not resumable else retry_reason
+        prompt = _retry_prompt(prompt, prompt_reason, resumable=resumable)
         with contextlib.suppress(OSError):
             activity_log.unlink()
         env = os.environ.copy()
@@ -2391,6 +2679,7 @@ Output:
             activity_log,
             log_file.with_suffix(".raw.json"),
             log_file.with_suffix(".usage.json"),
+            resume_state,
         ):
             with contextlib.suppress(ValueError):
                 ignored.add(path.relative_to(wd))
@@ -2411,6 +2700,7 @@ Output:
                     f"--claude-alias={claude_alias}",
                     *_model_effort_argv(adapter, self._model, self._effort),
                     f"--log={log_file}",
+                    f"--resume-state={resume_state}",
                     "--background",
                 ],
                 env=env,
@@ -2431,6 +2721,9 @@ Output:
                 adapter_name=adapter.stem,
                 target=name,
                 policy_attempt=policy_attempt,
+                transient_attempt=transient_attempt,
+                invocation_attempt=invocation_attempt,
+                resume_state=resume_state,
             )
             pid_file.write_text(f"{proc.pid}\n")
             print(f"  PID={proc.pid}  Log: {log_file}")

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -41,9 +41,11 @@ if __package__ in (None, ""):
 from specula import quota as _quota
 from specula.phaselib import (
     DEFAULT_POLICY_RETRIES,
+    DEFAULT_TRANSIENT_RESUMES,
     _logical_cwd,
     _normalize_artifact_dir,
     _parse_policy_retries,
+    _parse_transient_resumes,
     _wc_l,
 )
 from specula.tlc_resources import (
@@ -110,6 +112,7 @@ Options:
                          agent at a time and per-finding bug confirmation runs up to 4 at a time
   --max-turns=N          Max agent turns (default: 0 = unlimited)
   --policy-retries=N     Policy-block continuation retries after the initial attempt (default: 20; 0 disables)
+  --transient-resumes=N  Transient provider/transport session resumes after the initial attempt (default: 20; 0 disables)
   --agent=NAME           Agent adapter to use (default: claude-code; e.g., claude-code, codex, copilot-cli, opencode, pi)
   --claude-alias=NAME    Claude CLI profile (default: claude)
   --model=NAME           Model forwarded to every agent adapter
@@ -278,6 +281,7 @@ class Pipeline:
         self.max_parallel: str | None = None
         self.max_turns = "0"  # deprecated verbatim passthrough
         self.policy_retries = DEFAULT_POLICY_RETRIES
+        self.transient_resumes = DEFAULT_TRANSIENT_RESUMES
         self.dry_run = False
         self.skip_analysis = False
         self.skip_specgen = False
@@ -370,6 +374,16 @@ class Pipeline:
                 except ValueError:
                     print(
                         f"ERROR: --policy-retries must be a non-negative integer, got '{raw}'",
+                        file=sys.stderr,
+                    )
+                    return 1
+            elif arg.startswith("--transient-resumes="):
+                raw = arg.split("=", 1)[1]
+                try:
+                    self.transient_resumes = _parse_transient_resumes(raw)
+                except ValueError:
+                    print(
+                        f"ERROR: --transient-resumes must be a non-negative integer, got '{raw}'",
                         file=sys.stderr,
                     )
                     return 1
@@ -636,6 +650,7 @@ class Pipeline:
             "model": model,
             "effort": effort,
             "policy_retries": self.policy_retries,
+            "transient_resumes": self.transient_resumes,
             "claude_alias": self.claude_alias,
             "artifact": self.artifact,
             "artifact_git_sha": artifact_sha,
@@ -1393,6 +1408,7 @@ class Pipeline:
         args += [
             f"--max-turns={self.max_turns}",
             f"--policy-retries={self.policy_retries}",
+            f"--transient-resumes={self.transient_resumes}",
             f"--agent={self.agent}",
             f"--claude-alias={self.claude_alias}",
             *self._model_effort_args(),
@@ -1512,6 +1528,7 @@ class Pipeline:
             f"--agent={self.agent}",
             f"--claude-alias={self.claude_alias}",
             f"--policy-retries={self.policy_retries}",
+            f"--transient-resumes={self.transient_resumes}",
             *self._model_effort_args(),
             *names,
         ]
@@ -1928,6 +1945,7 @@ class Pipeline:
         print(f"Max parallel: {self._max_parallel_summary()}")
         print(f"Max turns:    {self.max_turns}")
         print(f"Policy retries: {self.policy_retries}")
+        print(f"Transient resumes: {self.transient_resumes}")
         print(f"Agent:        {self.agent}  (claude-alias={self.claude_alias})")
         memory_limit = self.tlc_memory_limit or os.environ.get(MEMORY_LIMIT_ENV) or "auto (80% available)"
         worker_limit = self.tlc_worker_limit or os.environ.get(WORKER_LIMIT_ENV) or "unbounded (report only)"

--- a/src/specula/progress.py
+++ b/src/specula/progress.py
@@ -51,6 +51,9 @@ class RunningAgent:
     target: str = ""
     attempt: int = 1
     policy_attempt: int = 0
+    transient_attempt: int = 0
+    invocation_attempt: int = 1
+    resume_state: Path | None = None
 
 
 def enabled() -> bool:

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -143,7 +143,7 @@ class CliE2E(unittest.TestCase):
         self.assertIn("[DRY RUN] bash scripts/launch/launch_code_analysis.sh", out)
         self.assertIn("Pipeline completed", out)
 
-    def test_run_tuning_and_policy_retries_reach_phase_and_review_commands(self) -> None:
+    def test_run_tuning_and_retry_budgets_reach_phase_and_review_commands(self) -> None:
         for model, effort in (("gpt-5.5", "high"), ("", "")):
             with self.subTest(model=model, effort=effort):
                 root = self.specroot()
@@ -158,6 +158,7 @@ class CliE2E(unittest.TestCase):
                         f"--model={model}",
                         f"--effort={effort}",
                         "--policy-retries=100",
+                        "--transient-resumes=80",
                         "footest",
                     ],
                     cwd=work,
@@ -169,11 +170,13 @@ class CliE2E(unittest.TestCase):
                     self.assertIn(f"--model={model}", line)
                     self.assertIn(f"--effort={effort}", line)
                     self.assertIn("--policy-retries=100", line)
+                    self.assertIn("--transient-resumes=80", line)
                 self.assertIn("launch_review.sh analysis --agent=codex", review_line)
                 meta = json.loads((self.sole_run_dir(root) / "run.json").read_text())
                 self.assertEqual(meta["model"], model or None)
                 self.assertEqual(meta["effort"], effort or None)
                 self.assertEqual(meta["policy_retries"], 100)
+                self.assertEqual(meta["transient_resumes"], 80)
 
     def test_run_json_records_argv(self) -> None:
         root = self.specroot()

--- a/tests/unit/test_adapter_resume.py
+++ b/tests/unit/test_adapter_resume.py
@@ -1,0 +1,510 @@
+"""Boundary tests for exact native-session resume state and transient errors."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import tempfile
+import threading
+import unittest
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import patch
+
+from specula.adapters.utils.event_stream import stream_events
+from specula.adapters.utils.resume import ResumeStateError, capture_session_id, read_session_id
+from specula.adapters.utils.transient import (
+    failed_log_has_transient_failure,
+    final_diagnostic_has_transient_failure,
+    looks_transient,
+)
+
+
+class TestResumeState(unittest.TestCase):
+    def test_capture_is_atomic_and_round_trips_exact_binding(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            state = root / "nested" / "turn.resume.json"
+
+            capture_session_id(
+                state,
+                adapter="codex",
+                session_id="thread-123",
+                cwd=str(root),
+                model="gpt-5.5",
+                effort="high",
+            )
+
+            self.assertEqual(
+                read_session_id(
+                    state,
+                    adapter="codex",
+                    cwd=str(root),
+                    model="gpt-5.5",
+                    effort="high",
+                ),
+                "thread-123",
+            )
+            self.assertEqual(list(state.parent.glob(f".{state.name}.*.tmp")), [])
+            payload = json.loads(state.read_text(encoding="utf-8"))
+            self.assertEqual(payload["version"], 1)
+            self.assertEqual(payload["cwd"], os.path.realpath(root))
+
+    def test_failed_atomic_publish_leaves_no_state_or_temporary_file(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            state = root / "turn.resume.json"
+
+            with (
+                patch("specula.adapters.utils.resume.os.link", side_effect=OSError("disk full")),
+                self.assertRaisesRegex(ResumeStateError, "cannot write"),
+            ):
+                capture_session_id(
+                    state,
+                    adapter="codex",
+                    session_id="thread-123",
+                    cwd=str(root),
+                )
+
+            self.assertFalse(state.exists())
+            self.assertEqual(list(root.glob(f".{state.name}.*.tmp")), [])
+
+    def test_missing_state_means_fresh_turn(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self.assertIsNone(
+                read_session_id(
+                    root / "missing.resume.json",
+                    adapter="codex",
+                    cwd=str(root),
+                )
+            )
+
+    def test_malformed_state_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            state = root / "turn.resume.json"
+            state.write_text("{not-json", encoding="utf-8")
+
+            with self.assertRaisesRegex(ResumeStateError, "cannot read"):
+                read_session_id(state, adapter="codex", cwd=str(root))
+
+    def test_symlink_state_is_rejected_for_read_and_capture(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            target = root / "target.json"
+            target.write_text("{}", encoding="utf-8")
+            state = root / "turn.resume.json"
+            state.symlink_to(target)
+
+            with self.assertRaisesRegex(ResumeStateError, "not a regular file"):
+                read_session_id(state, adapter="codex", cwd=str(root))
+            with self.assertRaisesRegex(ResumeStateError, "not a regular file"):
+                capture_session_id(
+                    state,
+                    adapter="codex",
+                    session_id="thread-123",
+                    cwd=str(root),
+                )
+            self.assertEqual(target.read_text(encoding="utf-8"), "{}")
+
+    def test_option_like_session_id_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            with self.assertRaisesRegex(ResumeStateError, "must not begin"):
+                capture_session_id(
+                    root / "turn.resume.json",
+                    adapter="codex",
+                    session_id="--last",
+                    cwd=str(root),
+                )
+
+    def test_each_binding_field_must_match_exactly(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            other = root / "other"
+            other.mkdir()
+            state = root / "turn.resume.json"
+            capture_session_id(
+                state,
+                adapter="codex",
+                session_id="thread-123",
+                cwd=str(root),
+                model="gpt-5.5",
+                effort="high",
+            )
+            mismatches = (
+                {"adapter": "claude-code", "cwd": str(root), "model": "gpt-5.5", "effort": "high"},
+                {"adapter": "codex", "cwd": str(other), "model": "gpt-5.5", "effort": "high"},
+                {"adapter": "codex", "cwd": str(root), "model": "gpt-5.4", "effort": "high"},
+                {"adapter": "codex", "cwd": str(root), "model": "gpt-5.5", "effort": "medium"},
+            )
+
+            for binding in mismatches:
+                with self.subTest(binding=binding), self.assertRaises(ResumeStateError):
+                    read_session_id(state, **binding)
+
+    def test_different_session_id_fails_without_replacing_original(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            state = root / "turn.resume.json"
+            capture_session_id(state, adapter="opencode", session_id="ses-one", cwd=str(root))
+
+            with self.assertRaisesRegex(ResumeStateError, "changed session ID"):
+                capture_session_id(state, adapter="opencode", session_id="ses-two", cwd=str(root))
+
+            self.assertEqual(
+                read_session_id(state, adapter="opencode", cwd=str(root)),
+                "ses-one",
+            )
+
+    def test_concurrent_first_capture_cannot_silently_replace_another_id(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            state = root / "turn.resume.json"
+            barrier = threading.Barrier(2)
+            real_link = os.link
+
+            def racing_link(
+                source: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+                destination: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+                *,
+                follow_symlinks: bool = True,
+            ) -> None:
+                barrier.wait(timeout=2)
+                real_link(source, destination, follow_symlinks=follow_symlinks)
+
+            def capture(session_id: str) -> Exception | None:
+                try:
+                    capture_session_id(state, adapter="codex", session_id=session_id, cwd=str(root))
+                except Exception as exc:  # Return both outcomes to the parent thread for exact assertions.
+                    return exc
+                return None
+
+            with (
+                patch("specula.adapters.utils.resume.os.link", side_effect=racing_link),
+                ThreadPoolExecutor(max_workers=2) as executor,
+            ):
+                outcomes = list(executor.map(capture, ("thread-one", "thread-two")))
+
+            failures = [outcome for outcome in outcomes if outcome is not None]
+            self.assertEqual(len(failures), 1)
+            self.assertIsInstance(failures[0], ResumeStateError)
+            self.assertIn(
+                read_session_id(state, adapter="codex", cwd=str(root)),
+                {"thread-one", "thread-two"},
+            )
+
+
+class TestEventStreamSessionCapture(unittest.TestCase):
+    def test_all_structured_adapters_capture_documented_session_id(self) -> None:
+        cases = (
+            ("claude", "claude-code", {"type": "system", "subtype": "init", "session_id": "claude-1"}, "claude-1"),
+            ("codex", "codex", {"type": "thread.started", "thread_id": "codex-1"}, "codex-1"),
+            (
+                "copilot-json",
+                "copilot-cli",
+                {
+                    "type": "result",
+                    "sessionId": "11111111-1111-4111-8111-111111111111",
+                    "exitCode": 0,
+                    "usage": {},
+                },
+                "11111111-1111-4111-8111-111111111111",
+            ),
+            (
+                "opencode",
+                "opencode",
+                {"type": "text", "sessionID": "opencode-1", "part": {"type": "text", "text": "work"}},
+                "opencode-1",
+            ),
+            ("pi", "pi", {"type": "session", "id": "pi-1"}, "pi-1"),
+        )
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            previous_cwd = Path.cwd()
+            os.chdir(root)
+            try:
+                for stream_adapter, state_adapter, record, session_id in cases:
+                    with self.subTest(adapter=stream_adapter):
+                        state = root / f"{stream_adapter}.resume.json"
+
+                        def explicit_capture(
+                            value: str,
+                            *,
+                            state_path: Path = state,
+                            adapter_name: str = state_adapter,
+                        ) -> None:
+                            capture_session_id(
+                                state_path,
+                                adapter=adapter_name,
+                                session_id=value,
+                                cwd=str(root),
+                                model="test-model",
+                                effort="test-effort",
+                            )
+
+                        status = stream_events(
+                            stream_adapter,
+                            root / f"{stream_adapter}.activity.jsonl",
+                            root / f"{stream_adapter}.log",
+                            [json.dumps(record).encode() + b"\n"],
+                            session_capture=explicit_capture,
+                        )
+
+                        self.assertEqual(status.session_id, session_id)
+                        self.assertEqual(
+                            read_session_id(
+                                state,
+                                adapter=state_adapter,
+                                cwd=str(root),
+                                model="test-model",
+                                effort="test-effort",
+                            ),
+                            session_id,
+                        )
+            finally:
+                os.chdir(previous_cwd)
+
+    def test_ambient_resume_variables_do_not_enable_capture(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            state = root / "ambient.resume.json"
+            with patch.dict(
+                os.environ,
+                {
+                    "SPECULA_RESUME_STATE": str(state),
+                    "SPECULA_RESUME_MODEL": "ambient-model",
+                    "SPECULA_RESUME_EFFORT": "ambient-effort",
+                },
+                clear=False,
+            ):
+                status = stream_events(
+                    "codex",
+                    root / "agent.activity.jsonl",
+                    root / "agent.log",
+                    [b'{"type":"thread.started","thread_id":"thread-ambient"}\n'],
+                )
+
+            self.assertEqual(status.session_id, "thread-ambient")
+            self.assertTrue(status.resume_ok)
+            self.assertFalse(state.exists())
+
+    def test_session_id_change_reports_failure_but_drains_stream(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            state = root / "turn.resume.json"
+            records = (
+                {"type": "text", "sessionID": "ses-one", "part": {"type": "text", "text": "before"}},
+                {"type": "text", "sessionID": "ses-two", "part": {"type": "text", "text": "after"}},
+                {"type": "step_finish", "sessionID": "ses-two", "part": {"reason": "stop"}},
+            )
+            consumed: list[str] = []
+
+            def source() -> Iterator[bytes]:
+                for record in records:
+                    consumed.append(str(record["type"]))
+                    yield json.dumps(record).encode() + b"\n"
+
+            previous_cwd = Path.cwd()
+            os.chdir(root)
+            try:
+
+                def explicit_capture(value: str) -> None:
+                    capture_session_id(
+                        state,
+                        adapter="opencode",
+                        session_id=value,
+                        cwd=str(root),
+                    )
+
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    status = stream_events(
+                        "opencode",
+                        root / "agent.activity.jsonl",
+                        root / "agent.log",
+                        source(),
+                        session_capture=explicit_capture,
+                    )
+            finally:
+                os.chdir(previous_cwd)
+
+            self.assertEqual(consumed, ["text", "text", "step_finish"])
+            self.assertFalse(status.log_ok)
+            self.assertFalse(status.resume_ok)
+            self.assertTrue(status.successful_terminal)
+            self.assertIn("changed session ID", stderr.getvalue())
+            self.assertEqual((root / "agent.log").read_text(encoding="utf-8"), "before\nafter\n")
+            self.assertEqual(read_session_id(state, adapter="opencode", cwd=str(root)), "ses-one")
+
+
+class TestTransientFailureClassification(unittest.TestCase):
+    def test_recognizes_typed_codes_statuses_and_capacity_message(self) -> None:
+        payloads = (
+            {"code": "overloaded_error"},
+            {"statusCode": 503},
+            {"error": {"message": "Selected model is at capacity. Please try a different model."}},
+            {"cause": {"error_type": "request_timeout"}},
+            {"name": "APIConnectionError"},
+            {"errorType": "APITimeoutError"},
+            {"cause": {"name": "TransportError"}},
+            {"name": "ServiceUnavailableError"},
+            {"errorType": "RequestTimeoutError"},
+            {"code": "ECONNRESET"},
+            {"cause": {"code": "ETIMEDOUT"}},
+            {"message": "socket hang up"},
+            {"message": "fetch failed"},
+        )
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                self.assertTrue(looks_transient(payload))
+
+    def test_non_transient_client_errors_are_not_classified(self) -> None:
+        payloads = (
+            {"status": 400, "message": "invalid request"},
+            {"status": 401, "message": "invalid API key"},
+            {"status": 429, "message": "rate limited"},
+            {"code": "content_policy_violation"},
+        )
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                self.assertFalse(looks_transient(payload))
+
+    def test_structured_provider_failure_is_classified(self) -> None:
+        records = [
+            {"type": "thread.started", "thread_id": "thread-1"},
+            {"type": "turn.failed", "error": {"code": "server_error", "message": "HTTP 503"}},
+        ]
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            status = stream_events(
+                "codex",
+                root / "agent.activity.jsonl",
+                root / "agent.log",
+                [json.dumps(record).encode() + b"\n" for record in records],
+            )
+
+        self.assertIsNotNone(status.transient_error)
+        self.assertFalse(status.successful_terminal)
+
+    def test_agent_quote_is_not_a_provider_failure(self) -> None:
+        records = [
+            {"type": "thread.started", "thread_id": "thread-1"},
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "agent_message",
+                    "text": "The log says: Selected model is at capacity. Please try a different model.",
+                },
+            },
+            {"type": "turn.failed", "error": {"code": "invalid_request", "message": "bad input"}},
+        ]
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            status = stream_events(
+                "codex",
+                root / "agent.activity.jsonl",
+                root / "agent.log",
+                [json.dumps(record).encode() + b"\n" for record in records],
+            )
+
+        self.assertIsNone(status.transient_error)
+        self.assertIsNone(status.plain_transient_error)
+
+    def test_successful_terminal_clears_earlier_transient_error(self) -> None:
+        records = [
+            {"type": "turn.failed", "error": {"code": "overloaded_error", "message": "overloaded"}},
+            {"type": "turn.completed", "usage": {}},
+        ]
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            status = stream_events(
+                "codex",
+                root / "agent.activity.jsonl",
+                root / "agent.log",
+                [json.dumps(record).encode() + b"\n" for record in records],
+            )
+
+        self.assertTrue(status.successful_terminal)
+        self.assertIsNone(status.transient_error)
+
+    def test_only_final_plain_diagnostic_of_unsuccessful_stream_is_classified(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            detected = stream_events(
+                "codex",
+                root / "detected.activity.jsonl",
+                root / "detected.log",
+                [b"HTTP 503: Selected model is at capacity. Please try a different model.\n"],
+            )
+            superseded = stream_events(
+                "codex",
+                root / "superseded.activity.jsonl",
+                root / "superseded.log",
+                [
+                    b"HTTP 503: service temporarily unavailable\n",
+                    b'{"type":"turn.failed","error":{"code":"invalid_request","message":"bad input"}}\n',
+                ],
+            )
+            successful = stream_events(
+                "codex",
+                root / "successful.activity.jsonl",
+                root / "successful.log",
+                [
+                    b'{"type":"turn.completed","usage":{}}\n',
+                    b"HTTP 503: service temporarily unavailable\n",
+                ],
+            )
+
+        self.assertIsNotNone(detected.plain_transient_error)
+        self.assertIsNone(superseded.plain_transient_error)
+        self.assertIsNone(successful.plain_transient_error)
+
+    def test_failed_log_fallback_uses_only_final_non_json_line(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            log = root / "agent.log"
+            log.write_text("HTTP 503: service unavailable\n", encoding="utf-8")
+            self.assertTrue(failed_log_has_transient_failure(log))
+
+            log.write_text("HTTP 503: service unavailable\nfatal: invalid request\n", encoding="utf-8")
+            self.assertFalse(failed_log_has_transient_failure(log))
+
+            self.assertFalse(
+                final_diagnostic_has_transient_failure(
+                    '{"type":"turn.failed","error":{"message":"HTTP 503: service unavailable"}}\n'
+                )
+            )
+
+    def test_plain_http_status_must_start_like_a_cli_diagnostic(self) -> None:
+        diagnostics = (
+            "HTTP 503: service unavailable\n",
+            "Error: API error 529 overloaded\n",
+            "Error: read ECONNRESET\n",
+            "Error: getaddrinfo EAI_AGAIN registry.npmjs.org\n",
+            "Error: connect ETIMEDOUT 10.0.0.1:443\n",
+            "Error: connect ECONNREFUSED 127.0.0.1:443\n",
+            "Error: write EPIPE\n",
+            "fetch failed\n",
+        )
+        for diagnostic in diagnostics:
+            with self.subTest(diagnostic=diagnostic):
+                self.assertTrue(final_diagnostic_has_transient_failure(diagnostic))
+
+        prose = (
+            "500 tests failed\n",
+            "The implementation deliberately returns HTTP 503 in this test.\n",
+            "The test fixture contains Error: write EPIPE\n",
+            "The implementation handles connect ETIMEDOUT correctly.\n",
+        )
+        for text in prose:
+            with self.subTest(text=text):
+                self.assertFalse(final_diagnostic_has_transient_failure(text))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_adapter_resume.py
+++ b/tests/unit/test_adapter_resume.py
@@ -489,6 +489,7 @@ class TestTransientFailureClassification(unittest.TestCase):
             "Error: connect ETIMEDOUT 10.0.0.1:443\n",
             "Error: connect ECONNREFUSED 127.0.0.1:443\n",
             "Error: write EPIPE\n",
+            "TypeError: fetch failed\n",
             "fetch failed\n",
         )
         for diagnostic in diagnostics:
@@ -500,6 +501,9 @@ class TestTransientFailureClassification(unittest.TestCase):
             "The implementation deliberately returns HTTP 503 in this test.\n",
             "The test fixture contains Error: write EPIPE\n",
             "The implementation handles connect ETIMEDOUT correctly.\n",
+            "The test fixture contains TypeError: fetch failed\n",
+            "TypeError: fetch failed is expected by this test.\n",
+            "TypeError: invalid URL\n",
         )
         for text in prose:
             with self.subTest(text=text):

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -92,6 +92,9 @@ _VOLATILE = (
     "SPECULA_SANDBOX_BACKEND",
     "SPECULA_SANDBOX_CONFIG",
     "SPECULA_ACTIVITY_LOG",
+    "SPECULA_RESUME_STATE",
+    "SPECULA_RESUME_MODEL",
+    "SPECULA_RESUME_EFFORT",
     "CODEX_HOME",
     "ADAPTER_EXIT_CODE",
     "COPILOT_HELP_TEXT",
@@ -113,6 +116,7 @@ class AdapterRun(TypedDict):
     vcsenv: str
     opencode_config: str
     opencode_permission: str
+    resumeenv: str
     stdin: str | None
     base: Path
 
@@ -166,6 +170,11 @@ class AdapterCase(unittest.TestCase):
             lines.append(f'printf "%s\\n" "${{{model_var}-<unset>}}" > "${{ADAPTER_MODEL_ENV_FILE:-/dev/null}}"')
         if effort_var:
             lines.append(f'printf "%s\\n" "${{{effort_var}-<unset>}}" > "${{ADAPTER_EFFORT_ENV_FILE:-/dev/null}}"')
+        lines.append(
+            'printf "%s|%s|%s\\n" "${SPECULA_RESUME_STATE-<unset>}" '
+            '"${SPECULA_RESUME_MODEL-<unset>}" "${SPECULA_RESUME_EFFORT-<unset>}" '
+            '> "${ADAPTER_RESUME_ENV_FILE:-/dev/null}"'
+        )
         if name == "opencode":
             lines.append('printf "%s\\n" "${OPENCODE_FAKE_VCS-<unset>}" > "${ADAPTER_VCS_ENV_FILE:-/dev/null}"')
             lines.append('printf "%s\\n" "${OPENCODE_CONFIG-<unset>}" > "${ADAPTER_CONFIGDIR_FILE:-/dev/null}"')
@@ -213,8 +222,9 @@ class AdapterCase(unittest.TestCase):
         with_fake: bool = True,
         record_extra: bool = False,
         timeout: float | None = None,
+        run_dir: Path | None = None,
     ) -> AdapterRun:
-        base = self.sandbox()
+        base = run_dir or self.sandbox()
         bindir = base / "bin"
         fixture = base / "fixture.txt"
         if isinstance(fixture_text, bytes):
@@ -230,6 +240,7 @@ class AdapterCase(unittest.TestCase):
             "ADAPTER_VCS_ENV_FILE": base / "vcsenv.txt",
             "ADAPTER_OPENCODE_CONFIG_FILE": base / "opencode_config.json",
             "ADAPTER_OPENCODE_PERMISSION_FILE": base / "opencode_permission.json",
+            "ADAPTER_RESUME_ENV_FILE": base / "resumeenv.txt",
             "ADAPTER_STDIN_FILE": base / "stdin.txt",
         }
         env = {k: v for k, v in os.environ.items() if k not in _VOLATILE}
@@ -258,6 +269,7 @@ class AdapterCase(unittest.TestCase):
             "vcsenv": (read(record["ADAPTER_VCS_ENV_FILE"]) or "").strip(),
             "opencode_config": read(record["ADAPTER_OPENCODE_CONFIG_FILE"]) or "",
             "opencode_permission": (read(record["ADAPTER_OPENCODE_PERMISSION_FILE"]) or "").strip(),
+            "resumeenv": (read(record["ADAPTER_RESUME_ENV_FILE"]) or "").strip(),
             "stdin": read(record["ADAPTER_STDIN_FILE"]),
             "base": base,
         }
@@ -280,6 +292,114 @@ class ClaudeCodeAdapter(AdapterCase):
 
     def base_flags(self, base: Path) -> list[str]:
         return [self.with_prompt_file(base), f"--log={base}/out.log"]
+
+    def test_resume_state_captures_then_resumes_exact_claude_session(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        session_id = "claude-session-exact"
+        fixture = json.dumps({"type": "result", **CLAUDE_JSON, "session_id": session_id})
+        flags = [*self.base_flags(base), f"--resume-state={state}"]
+
+        fresh = self.run_adapter(
+            self.CMD,
+            flags,
+            fake_name="claude",
+            fixture_text=fixture,
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(fresh["returncode"], 0, fresh["stderr"])
+        self.assertNotIn("--resume", fresh["argv"])
+        self.assertEqual(
+            json.loads(state.read_text()),
+            {
+                "version": 1,
+                "adapter": "claude-code",
+                "session_id": session_id,
+                "cwd": str(base),
+                "model": "",
+                "effort": "max",
+            },
+        )
+
+        resumed = self.run_adapter(
+            self.CMD,
+            flags,
+            fake_name="claude",
+            fixture_text=fixture,
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(resumed["returncode"], 0, resumed["stderr"])
+        index = resumed["argv"].index("--resume")
+        self.assertEqual(resumed["argv"][index + 1], session_id)
+
+    def test_resume_state_without_progress_uses_hidden_stream_and_captures_init_id(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        session_id = "claude-init-session"
+        fixture = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "system",
+                        "subtype": "init",
+                        "session_id": session_id,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "result",
+                        **CLAUDE_JSON,
+                        "is_error": True,
+                        "terminal_reason": "api_error",
+                        "api_error_status": 503,
+                        "result": "Request failed.",
+                    }
+                ),
+            ]
+        )
+        result = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), f"--resume-state={state}"],
+            fake_name="claude",
+            fixture_text=fixture,
+            record_extra=True,
+            env_extra={"ADAPTER_EXIT_CODE": "9", "TMPDIR": str(base)},
+            run_dir=base,
+        )
+        self.assertEqual(result["returncode"], 74, result["stderr"])
+        self.assertEqual(result["argv"][result["argv"].index("--output-format") + 1], "stream-json")
+        self.assertIn("--verbose", result["argv"])
+        self.assertEqual(json.loads(state.read_text())["session_id"], session_id)
+        self.assertEqual(list(base.glob("specula-claude-activity-*.jsonl")), [])
+
+    def test_resume_state_binding_mismatch_fails_before_claude_launch(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "adapter": "claude-code",
+                    "session_id": "claude-session-exact",
+                    "cwd": str(base),
+                    "model": "old-model",
+                    "effort": "max",
+                }
+            )
+        )
+        result = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), "--model=new-model", f"--resume-state={state}"],
+            fake_name="claude",
+            fixture_text=self.FIXTURE,
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(result["returncode"], 1)
+        self.assertIn("invalid resume state", result["stderr"])
+        self.assertEqual(result["argv"], [])
 
     def test_base_command_and_default_effort(self) -> None:
         base = self.sandbox()
@@ -379,6 +499,18 @@ class ClaudeCodeAdapter(AdapterCase):
         base = self.sandbox()
         r = self.invoke(self.base_flags(base), env_extra={"CLAUDECODE": "1"})
         self.assertEqual(r["sessionenv"], "<unset>")
+
+    def test_resume_plumbing_environment_is_stripped_before_spawn(self) -> None:
+        base = self.sandbox()
+        result = self.invoke(
+            self.base_flags(base),
+            env_extra={
+                "SPECULA_RESUME_STATE": "/ambient/state",
+                "SPECULA_RESUME_MODEL": "ambient-model",
+                "SPECULA_RESUME_EFFORT": "ambient-effort",
+            },
+        )
+        self.assertEqual(result["resumeenv"], "<unset>|<unset>|<unset>")
 
     def test_log_and_usage_written(self) -> None:
         base = self.sandbox()
@@ -488,6 +620,66 @@ class ClaudeCodeAdapter(AdapterCase):
         )
         self.assertEqual(r["returncode"], 76, r["stderr"])
 
+    def test_terminal_transient_failure_exits_shared_status(self) -> None:
+        base = self.sandbox()
+        record = {
+            "type": "result",
+            **CLAUDE_JSON,
+            "is_error": True,
+            "terminal_reason": "api_error",
+            "api_error_status": 503,
+            "result": "Request failed.",
+        }
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="claude",
+            fixture_text=json.dumps(record),
+            record_extra=True,
+            env_extra={"ADAPTER_EXIT_CODE": "9"},
+        )
+        self.assertEqual(r["returncode"], 74, r["stderr"])
+
+    def test_policy_block_wins_over_transient_failure(self) -> None:
+        base = self.sandbox()
+        record = {
+            "type": "result",
+            **CLAUDE_JSON,
+            "is_error": True,
+            "terminal_reason": "api_error",
+            "api_error_status": 503,
+            "result": "Selected model is at capacity. This content was flagged for possible cybersecurity risk.",
+        }
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="claude",
+            fixture_text=json.dumps(record),
+            record_extra=True,
+            env_extra={"ADAPTER_EXIT_CODE": "9"},
+        )
+        self.assertEqual(r["returncode"], 76, r["stderr"])
+
+    def test_native_policy_status_wins_over_structured_transient_failure(self) -> None:
+        base = self.sandbox()
+        record = {
+            "type": "result",
+            **CLAUDE_JSON,
+            "is_error": True,
+            "terminal_reason": "api_error",
+            "api_error_status": 503,
+            "result": "Request failed.",
+        }
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="claude",
+            fixture_text=json.dumps(record),
+            record_extra=True,
+            env_extra={"ADAPTER_EXIT_CODE": "76"},
+        )
+        self.assertEqual(r["returncode"], 76, r["stderr"])
+
     def test_streaming_plain_policy_diagnostic_uses_failed_cli_status(self) -> None:
         fixture = "\n".join(
             [
@@ -528,12 +720,122 @@ class ClaudeCodeAdapter(AdapterCase):
         )
         self.assertEqual(r["returncode"], 9, r["stderr"])
 
+    def test_streaming_plain_transient_diagnostic_uses_failed_cli_status(self) -> None:
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "assistant", "message": {"content": [{"type": "text", "text": "working"}]}}),
+                "Selected model is at capacity. Please try again.",
+            ]
+        )
+        for native_rc, expected in (("9", 74), ("75", 75), ("76", 76), ("0", 0)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                activity = base / "out.activity.jsonl"
+                r = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="claude",
+                    fixture_text=fixture,
+                    record_extra=True,
+                    env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "ADAPTER_EXIT_CODE": native_rc},
+                )
+                self.assertEqual(r["returncode"], expected, r["stderr"])
+
+    def test_progress_off_plain_transient_diagnostic_uses_failed_cli_status(self) -> None:
+        for native_rc, expected in (("9", 74), ("75", 75), ("76", 76), ("0", 0)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                r = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="claude",
+                    fixture_text="Selected model is at capacity. Please try again.\n",
+                    record_extra=True,
+                    env_extra={"ADAPTER_EXIT_CODE": native_rc},
+                )
+                self.assertEqual(r["returncode"], expected, r["stderr"])
+
+    def test_progress_off_plain_transient_before_success_result_is_not_retryable(self) -> None:
+        base = self.sandbox()
+        fixture = "\n".join(
+            [
+                "Selected model is at capacity. Please try again.",
+                json.dumps({"type": "result", **CLAUDE_JSON}),
+            ]
+        )
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="claude",
+            fixture_text=fixture,
+            record_extra=True,
+            env_extra={"ADAPTER_EXIT_CODE": "9"},
+        )
+        self.assertEqual(r["returncode"], 9, r["stderr"])
+
+    def test_successful_stream_terminal_suppresses_later_plain_transient_diagnostic(self) -> None:
+        base = self.sandbox()
+        activity = base / "out.activity.jsonl"
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "result", **CLAUDE_JSON}),
+                "Selected model is at capacity. Please try again.",
+            ]
+        )
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="claude",
+            fixture_text=fixture,
+            record_extra=True,
+            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "ADAPTER_EXIT_CODE": "9"},
+        )
+        self.assertEqual(r["returncode"], 9, r["stderr"])
+
+    def test_structured_transient_followed_by_success_is_recovered(self) -> None:
+        base = self.sandbox()
+        activity = base / "out.activity.jsonl"
+        failed = {
+            "type": "result",
+            **CLAUDE_JSON,
+            "is_error": True,
+            "terminal_reason": "api_error",
+            "api_error_status": 503,
+            "result": "Selected model is at capacity. Please try again.",
+        }
+        fixture = "\n".join([json.dumps(failed), json.dumps({"type": "result", **CLAUDE_JSON})])
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="claude",
+            fixture_text=fixture,
+            record_extra=True,
+            env_extra={"SPECULA_ACTIVITY_LOG": str(activity)},
+        )
+        self.assertEqual(r["returncode"], 0, r["stderr"])
+
     def test_successful_result_quoting_policy_message_is_not_blocked(self) -> None:
         base = self.sandbox()
         record = {
             "type": "result",
             **CLAUDE_JSON,
             "result": "The old run said output blocked by content filtering policy; the task is now complete.",
+        }
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="claude",
+            fixture_text=json.dumps(record),
+            record_extra=True,
+        )
+        self.assertEqual(r["returncode"], 0, r["stderr"])
+
+    def test_successful_result_quoting_transient_message_is_not_retryable(self) -> None:
+        base = self.sandbox()
+        record = {
+            "type": "result",
+            **CLAUDE_JSON,
+            "result": "The old run said the selected model was at capacity; the task is now complete.",
         }
         r = self.run_adapter(
             self.CMD,
@@ -996,6 +1298,123 @@ class OpenCodeAdapter(AdapterCase):
 
     def base_flags(self, base: Path) -> list[str]:
         return [self.with_prompt_file(base), f"--log={base}/out.log"]
+
+    def test_resume_state_captures_then_resumes_exact_opencode_session(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        session_id = "ses_exact"
+        fixture = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "text",
+                        "sessionID": session_id,
+                        "part": {"type": "text", "text": "finished"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "step_finish",
+                        "sessionID": session_id,
+                        "part": {"tokens": {}, "cost": 0, "reason": "stop"},
+                    }
+                ),
+            ]
+        )
+        flags = [*self.base_flags(base), f"--resume-state={state}"]
+
+        fresh = self.run_adapter(
+            self.CMD,
+            flags,
+            fake_name="opencode",
+            fixture_text=fixture,
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(fresh["returncode"], 0, fresh["stderr"])
+        self.assertNotIn("--session", fresh["argv"])
+        self.assertEqual(json.loads(state.read_text())["session_id"], session_id)
+
+        resumed = self.run_adapter(
+            self.CMD,
+            flags,
+            fake_name="opencode",
+            fixture_text=fixture,
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(resumed["returncode"], 0, resumed["stderr"])
+        index = resumed["argv"].index("--session")
+        self.assertEqual(resumed["argv"][index + 1], session_id)
+        self.assertNotIn("--continue", resumed["argv"])
+
+    def test_resume_state_binding_mismatch_fails_before_opencode_launch(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "adapter": "opencode",
+                    "session_id": "ses_exact",
+                    "cwd": str(base),
+                    "model": "old-model",
+                    "effort": "",
+                }
+            )
+        )
+        result = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), "--model=new-model", f"--resume-state={state}"],
+            fake_name="opencode",
+            fixture_text=self.FIXTURE,
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(result["returncode"], 1)
+        self.assertIn("resume state", result["stderr"])
+        self.assertEqual(result["argv"], [])
+
+    def test_resume_state_symlink_fails_before_opencode_launch(self) -> None:
+        base = self.sandbox()
+        target = base / "target.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "adapter": "opencode",
+                    "session_id": "ses_first",
+                    "cwd": str(base),
+                    "model": "",
+                    "effort": "",
+                }
+            )
+        )
+        state = base / "resume.json"
+        state.symlink_to(target)
+        result = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), f"--resume-state={state}"],
+            fake_name="opencode",
+            fixture_text=self.FIXTURE,
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(result["returncode"], 1)
+        self.assertIn("not a regular file", result["stderr"])
+        self.assertEqual(result["argv"], [])
+
+    def test_resume_plumbing_environment_is_stripped_before_spawn(self) -> None:
+        base = self.sandbox()
+        result = self.invoke(
+            self.base_flags(base),
+            env_extra={
+                "SPECULA_RESUME_STATE": "/ambient/state",
+                "SPECULA_RESUME_MODEL": "ambient-model",
+                "SPECULA_RESUME_EFFORT": "ambient-effort",
+            },
+        )
+        self.assertEqual(result["resumeenv"], "<unset>|<unset>|<unset>")
 
     def test_command_construction_from_environment(self) -> None:
         base = self.sandbox()
@@ -1472,6 +1891,73 @@ class OpenCodeAdapter(AdapterCase):
                 )
                 self.assertEqual(result["returncode"], expected, result["stderr"])
 
+    def test_structured_transient_failure_maps_to_resume_status(self) -> None:
+        fixture = json.dumps(
+            {
+                "type": "error",
+                "sessionID": "ses_capacity",
+                "error": {
+                    "name": "APIError",
+                    "data": {
+                        "code": "model_at_capacity",
+                        "message": "Selected model is at capacity. Please try again.",
+                        "statusCode": 503,
+                    },
+                },
+            }
+        )
+        for native_rc, expected in (("0", 74), ("9", 74), ("75", 75), ("76", 76)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                result = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="opencode",
+                    fixture_text=fixture,
+                    env_extra={"ADAPTER_EXIT_CODE": native_rc},
+                    record_extra=True,
+                )
+                self.assertEqual(result["returncode"], expected, result["stderr"])
+
+    def test_camel_case_transport_error_maps_to_resume_status(self) -> None:
+        base = self.sandbox()
+        fixture = json.dumps(
+            {
+                "type": "error",
+                "sessionID": "ses_transport",
+                "error": {"name": "APIConnectionError"},
+            }
+        )
+        result = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="opencode",
+            fixture_text=fixture,
+            env_extra={"ADAPTER_EXIT_CODE": "9"},
+            record_extra=True,
+        )
+        self.assertEqual(result["returncode"], 74, result["stderr"])
+
+    def test_plain_transient_diagnostic_requires_failed_cli_status(self) -> None:
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "step_start", "sessionID": "ses_capacity", "part": {}}),
+                "Selected model is at capacity. Please try again.",
+            ]
+        )
+        for native_rc, expected in (("9", 74), ("75", 75), ("76", 76), ("0", 1)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                result = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="opencode",
+                    fixture_text=fixture,
+                    env_extra={"ADAPTER_EXIT_CODE": native_rc},
+                    record_extra=True,
+                )
+                self.assertEqual(result["returncode"], expected, result["stderr"])
+
     def test_policy_error_followed_by_new_output_and_stop_is_recovered(self) -> None:
         base = self.sandbox()
         records = [
@@ -1484,6 +1970,34 @@ class OpenCodeAdapter(AdapterCase):
                 "type": "text",
                 "sessionID": "ses_recovered",
                 "part": {"type": "text", "text": "continued successfully"},
+            },
+            {
+                "type": "step_finish",
+                "sessionID": "ses_recovered",
+                "part": {"type": "step-finish", "reason": "stop", "tokens": {}},
+            },
+        ]
+        result = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="opencode",
+            fixture_text="\n".join(json.dumps(record) for record in records) + "\n",
+            record_extra=True,
+        )
+        self.assertEqual(result["returncode"], 0, result["stderr"])
+
+    def test_transient_error_followed_by_new_empty_step_and_stop_is_recovered(self) -> None:
+        base = self.sandbox()
+        records = [
+            {
+                "type": "error",
+                "sessionID": "ses_recovered",
+                "error": {"name": "OverloadedError"},
+            },
+            {
+                "type": "step_start",
+                "sessionID": "ses_recovered",
+                "part": {"type": "step-start"},
             },
             {
                 "type": "step_finish",
@@ -1795,6 +2309,50 @@ class PiAdapter(AdapterCase):
     def base_flags(self, base: Path) -> list[str]:
         return [self.with_prompt_file(base), f"--log={base}/out.log"]
 
+    def test_resume_state_enables_persistent_then_exact_pi_session(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        session_id = "pi_session"
+        flags = [*self.base_flags(base), f"--resume-state={state}"]
+
+        fresh = self.run_adapter(
+            self.CMD,
+            flags,
+            fake_name="pi",
+            fixture_text=self.FIXTURE,
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(fresh["returncode"], 0, fresh["stderr"])
+        self.assertNotIn("--no-session", fresh["argv"])
+        self.assertNotIn("--session", fresh["argv"])
+        self.assertEqual(json.loads(state.read_text())["session_id"], session_id)
+
+        resumed = self.run_adapter(
+            self.CMD,
+            flags,
+            fake_name="pi",
+            fixture_text=self.FIXTURE,
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(resumed["returncode"], 0, resumed["stderr"])
+        self.assertNotIn("--no-session", resumed["argv"])
+        index = resumed["argv"].index("--session")
+        self.assertEqual(resumed["argv"][index + 1], session_id)
+
+    def test_resume_plumbing_environment_is_stripped_before_spawn(self) -> None:
+        base = self.sandbox()
+        result = self.invoke(
+            self.base_flags(base),
+            env_extra={
+                "SPECULA_RESUME_STATE": "/ambient/state",
+                "SPECULA_RESUME_MODEL": "ambient-model",
+                "SPECULA_RESUME_EFFORT": "ambient-effort",
+            },
+        )
+        self.assertEqual(result["resumeenv"], "<unset>|<unset>|<unset>")
+
     def test_baseline_command_uses_environment_defaults_and_stdin(self) -> None:
         base = self.sandbox()
         result = self.invoke(
@@ -2045,6 +2603,52 @@ class PiAdapter(AdapterCase):
             ]
         )
         for native_rc, expected in (("9", 76), ("75", 75)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                result = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="pi",
+                    fixture_text=fixture,
+                    env_extra={"ADAPTER_EXIT_CODE": native_rc},
+                    record_extra=True,
+                )
+                self.assertEqual(result["returncode"], expected, result["stderr"])
+
+    def test_structured_transient_failure_maps_to_resume_status(self) -> None:
+        fixture = json.dumps(
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "content": [],
+                    "stopReason": "error",
+                    "errorMessage": "Selected model is at capacity. Please try again.",
+                    "usage": {},
+                },
+            }
+        )
+        for native_rc, expected in (("0", 74), ("9", 74), ("75", 75), ("76", 76)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                result = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="pi",
+                    fixture_text=fixture,
+                    env_extra={"ADAPTER_EXIT_CODE": native_rc},
+                    record_extra=True,
+                )
+                self.assertEqual(result["returncode"], expected, result["stderr"])
+
+    def test_plain_transient_diagnostic_requires_failed_cli_status(self) -> None:
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "session", "id": "pi_capacity"}),
+                "Selected model is at capacity. Please try again.",
+            ]
+        )
+        for native_rc, expected in (("9", 74), ("75", 75), ("76", 76), ("0", 1)):
             with self.subTest(native_rc=native_rc):
                 base = self.sandbox()
                 result = self.run_adapter(
@@ -2529,6 +3133,280 @@ class CodexAdapter(AdapterCase):
         self.assertEqual(activity.read_text(), fixture)
         self.assertEqual((base / "out.log").read_text(), "running pwd\ndone\n")
 
+    def test_resume_state_forces_hidden_json_stream_and_captures_exact_id(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        session_id = "019f0000-0000-7000-8000-000000000001"
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": session_id}),
+                json.dumps({"type": "turn.completed", "usage": {}}),
+            ]
+        )
+        r = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), f"--resume-state={state}"],
+            fake_name="codex",
+            fixture_text=fixture,
+            env_extra={"TMPDIR": str(base)},
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(r["returncode"], 0, r["stderr"])
+        self.assertEqual(r["argv"][-2:], ["--json", "-"])
+        self.assertNotIn("resume", r["argv"])
+        self.assertEqual(
+            json.loads(state.read_text()),
+            {
+                "version": 1,
+                "adapter": "codex",
+                "session_id": session_id,
+                "cwd": str(base),
+                "model": "",
+                "effort": "",
+            },
+        )
+        usage = json.loads((base / "out.usage.json").read_text())
+        self.assertEqual(usage["session_id"], session_id)
+        self.assertEqual(list(base.glob("specula-codex-activity-*.jsonl")), [])
+
+    def test_resume_plumbing_environment_is_stripped_before_spawn(self) -> None:
+        base = self.sandbox()
+        result = self.invoke(
+            self.base_flags(base),
+            env_extra={
+                "SPECULA_RESUME_STATE": "/ambient/state",
+                "SPECULA_RESUME_MODEL": "ambient-model",
+                "SPECULA_RESUME_EFFORT": "ambient-effort",
+            },
+        )
+        self.assertEqual(result["resumeenv"], "<unset>|<unset>|<unset>")
+
+    def test_resume_uses_exact_id_and_only_continuation_prompt(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        session_id = "019f0000-0000-7000-8000-000000000002"
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "adapter": "codex",
+                    "session_id": session_id,
+                    "cwd": str(base),
+                    "model": "gpt-5.5",
+                    "effort": "high",
+                }
+            )
+        )
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": session_id}),
+                json.dumps({"type": "turn.completed", "usage": {}}),
+            ]
+        )
+        flags = [
+            self.with_prompt_file(base, "continue only\n"),
+            f"--log={base}/out.log",
+            "--max-turns=0",
+            "--model=gpt-5.5",
+            "--effort=high",
+            f"--resume-state={state}",
+        ]
+        r = self.run_adapter(
+            self.CMD,
+            flags,
+            fake_name="codex",
+            fixture_text=fixture,
+            env_extra={"TMPDIR": str(base)},
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(r["returncode"], 0, r["stderr"])
+        self.assertEqual(
+            r["argv"],
+            [
+                "exec",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "--output-last-message",
+                str(base / "out.last-message.txt"),
+                "-c",
+                "tool_output_token_limit=10000",
+                "-m",
+                "gpt-5.5",
+                "-c",
+                "model_reasoning_effort=high",
+                "resume",
+                session_id,
+                "--json",
+                "-",
+            ],
+        )
+        self.assertNotIn("--last", r["argv"])
+        self.assertEqual(r["stdin"], "continue only")
+        self.assertEqual(json.loads((base / "out.usage.json").read_text())["session_id"], session_id)
+        self.assertEqual(list(base.glob("specula-codex-activity-*.jsonl")), [])
+
+    def test_resume_state_mismatch_fails_before_launch(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "adapter": "codex",
+                    "session_id": "019f0000-0000-7000-8000-000000000003",
+                    "cwd": str(base),
+                    "model": "old-model",
+                    "effort": "",
+                }
+            )
+        )
+        r = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), "--model=new-model", f"--resume-state={state}"],
+            fake_name="codex",
+            fixture_text="unused",
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(r["returncode"], 1)
+        self.assertIn("invalid or incompatible resume state", r["stderr"])
+        self.assertEqual(r["argv"], [])
+
+    def test_stream_session_change_is_fail_closed_before_native_rate_limit(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        original_id = "019f0000-0000-7000-8000-000000000010"
+        changed_id = "019f0000-0000-7000-8000-000000000011"
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "adapter": "codex",
+                    "session_id": original_id,
+                    "cwd": str(base),
+                    "model": "",
+                    "effort": "",
+                }
+            )
+        )
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": changed_id}),
+                json.dumps(
+                    {
+                        "type": "turn.failed",
+                        "error": {"code": "rate_limit_exceeded", "message": "Too many requests"},
+                    }
+                ),
+            ]
+        )
+        result = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), f"--resume-state={state}"],
+            fake_name="codex",
+            fixture_text=fixture,
+            env_extra={"ADAPTER_EXIT_CODE": "75", "TMPDIR": str(base)},
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(result["returncode"], 1, result["stderr"])
+        self.assertIn("changed session ID", result["stderr"])
+        self.assertEqual(json.loads(state.read_text())["session_id"], original_id)
+
+    def test_empty_resume_state_is_rejected(self) -> None:
+        base = self.sandbox()
+        r = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), "--resume-state="],
+            fake_name="codex",
+            fixture_text="unused",
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(r["returncode"], 1)
+        self.assertIn("--resume-state requires a path", r["stderr"])
+        self.assertEqual(r["argv"], [])
+
+    def test_resume_usage_ignores_concurrent_rollout(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        session_id = "019f0000-0000-7000-8000-000000000004"
+        other_id = "019f0000-0000-7000-8000-000000000005"
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "adapter": "codex",
+                    "session_id": session_id,
+                    "cwd": str(base),
+                    "model": "",
+                    "effort": "",
+                }
+            )
+        )
+        sessions = base / ".codex" / "sessions" / "2026" / "07" / "18"
+        sessions.mkdir(parents=True)
+        exact_file = sessions / f"rollout-2026-07-18T00-00-00-{session_id}.jsonl"
+        other_file = sessions / f"rollout-2026-07-18T00-00-01-{other_id}.jsonl"
+        exact_file.write_text(json.dumps({"type": "session_meta", "payload": {"id": session_id}}) + "\n")
+        other_file.write_text(json.dumps({"type": "session_meta", "payload": {"id": other_id}}) + "\n")
+
+        bindir = base / "bin"
+        bindir.mkdir()
+        npx = bindir / "npx"
+        npx.write_text(
+            "#!/usr/bin/env bash\n"
+            + "printf '%s\\n' "
+            + json.dumps(
+                json.dumps(
+                    {
+                        "sessions": [
+                            {
+                                "sessionFile": exact_file.stem,
+                                "sessionId": session_id,
+                                "costUSD": 1.25,
+                                "inputTokens": 10,
+                                "cachedInputTokens": 4,
+                                "outputTokens": 3,
+                                "reasoningOutputTokens": 2,
+                                "totalTokens": 13,
+                            },
+                            {
+                                "sessionFile": other_file.stem,
+                                "sessionId": other_id,
+                                "costUSD": 99,
+                                "totalTokens": 999,
+                            },
+                        ]
+                    }
+                )
+            )
+            + "\n"
+        )
+        npx.chmod(npx.stat().st_mode | stat.S_IEXEC)
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": session_id}),
+                json.dumps({"type": "turn.completed", "usage": {}}),
+            ]
+        )
+        r = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), f"--resume-state={state}"],
+            fake_name="codex",
+            fixture_text=fixture,
+            env_extra={"TMPDIR": str(base)},
+            record_extra=True,
+            run_dir=base,
+        )
+        self.assertEqual(r["returncode"], 0, r["stderr"])
+        usage = json.loads((base / "out.usage.json").read_text())
+        self.assertEqual(usage["session_id"], session_id)
+        self.assertEqual(usage["session_file"], exact_file.stem)
+        self.assertEqual(usage["total_cost_usd"], 1.25)
+        self.assertEqual(usage["usage"]["total_tokens"], 13)
+
     def test_large_prompt_uses_stdin_with_activity_stream(self) -> None:
         base = self.sandbox()
         activity = base / "out.activity.jsonl"
@@ -2575,6 +3453,49 @@ class CodexAdapter(AdapterCase):
         )
         self.assertEqual(r["returncode"], 76, r["stderr"])
 
+    def test_structured_transient_failure_overrides_ordinary_native_status(self) -> None:
+        fixture = json.dumps(
+            {
+                "type": "turn.failed",
+                "error": {
+                    "code": "model_at_capacity",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            }
+        )
+        for native_rc, expected in (("9", 74), ("0", 74), ("75", 75), ("76", 76)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                activity = base / "out.activity.jsonl"
+                r = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="codex",
+                    fixture_text=fixture,
+                    env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "ADAPTER_EXIT_CODE": native_rc},
+                    record_extra=True,
+                )
+                self.assertEqual(r["returncode"], expected, r["stderr"])
+
+    def test_structured_rate_limit_keeps_highest_priority(self) -> None:
+        base = self.sandbox()
+        activity = base / "out.activity.jsonl"
+        fixture = json.dumps(
+            {
+                "type": "turn.failed",
+                "error": {"code": "rate_limit_exceeded", "message": "Too many requests"},
+            }
+        )
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="codex",
+            fixture_text=fixture,
+            env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "ADAPTER_EXIT_CODE": "9"},
+            record_extra=True,
+        )
+        self.assertEqual(r["returncode"], 75, r["stderr"])
+
     def test_streaming_plain_policy_diagnostic_uses_failed_cli_status(self) -> None:
         fixture = "\n".join(
             [
@@ -2583,6 +3504,27 @@ class CodexAdapter(AdapterCase):
             ]
         )
         for native_rc, expected in (("9", 76), ("75", 75), ("0", 0)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                activity = base / "out.activity.jsonl"
+                r = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="codex",
+                    fixture_text=fixture,
+                    env_extra={"SPECULA_ACTIVITY_LOG": str(activity), "ADAPTER_EXIT_CODE": native_rc},
+                    record_extra=True,
+                )
+                self.assertEqual(r["returncode"], expected, r["stderr"])
+
+    def test_streaming_plain_transient_diagnostic_uses_failed_cli_status(self) -> None:
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": "thread-1"}),
+                "Selected model is at capacity. Please try a different model.",
+            ]
+        )
+        for native_rc, expected in (("9", 74), ("75", 75), ("76", 76), ("0", 0)):
             with self.subTest(native_rc=native_rc):
                 base = self.sandbox()
                 activity = base / "out.activity.jsonl"
@@ -2681,6 +3623,33 @@ class CodexAdapter(AdapterCase):
             record_extra=True,
         )
         self.assertEqual(r["returncode"], 0, r["stderr"])
+
+    def test_progress_off_failed_transient_diagnostic_exits_shared_status(self) -> None:
+        base = self.sandbox()
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="codex",
+            fixture_text="Selected model is at capacity. Please try a different model.\n",
+            env_extra={"ADAPTER_EXIT_CODE": "9"},
+            record_extra=True,
+        )
+        self.assertEqual(r["returncode"], 74, r["stderr"])
+
+    def test_progress_off_transient_quote_does_not_override_policy_or_success(self) -> None:
+        fixture = "Selected model is at capacity. Please try a different model.\n"
+        for native_rc, expected in (("76", 76), ("0", 0)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                r = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="codex",
+                    fixture_text=fixture,
+                    env_extra={"ADAPTER_EXIT_CODE": native_rc},
+                    record_extra=True,
+                )
+                self.assertEqual(r["returncode"], expected, r["stderr"])
 
     def test_structured_turn_failure_is_logged_but_cli_owns_status(self) -> None:
         base = self.sandbox()
@@ -2918,6 +3887,243 @@ class CopilotAdapter(AdapterCase):
 
     def base_flags(self, base: Path) -> list[str]:
         return [self.with_prompt_file(base), f"--log={base}/out.log"]
+
+    def test_resume_state_captures_result_id_then_uses_fail_closed_resume(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        session_id = "11111111-1111-4111-8111-111111111111"
+        fixture = json.dumps({"type": "result", "sessionId": session_id, "exitCode": 0, "usage": {}})
+        flags = [*self.base_flags(base), f"--resume-state={state}"]
+        env = {
+            "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream\n--session-id\n--resume",
+            "TMPDIR": str(base),
+        }
+
+        fresh = self.run_adapter(
+            self.CMD,
+            flags,
+            fake_name="copilot",
+            fixture_text=fixture,
+            env_extra=env,
+            run_dir=base,
+        )
+        self.assertEqual(fresh["returncode"], 0, fresh["stderr"])
+        self.assertNotIn("--session-id", fresh["argv"])
+        self.assertNotIn("--resume", fresh["argv"])
+        self.assertNotIn("--continue", fresh["argv"])
+        self.assertEqual(json.loads(state.read_text())["session_id"], session_id)
+
+        resumed = self.run_adapter(
+            self.CMD,
+            flags,
+            fake_name="copilot",
+            fixture_text=fixture,
+            env_extra=env,
+            run_dir=base,
+        )
+        self.assertEqual(resumed["returncode"], 0, resumed["stderr"])
+        index = resumed["argv"].index("--resume")
+        self.assertEqual(resumed["argv"][index + 1], session_id)
+        self.assertNotIn("--session-id", resumed["argv"])
+        self.assertNotIn("--continue", resumed["argv"])
+
+    def test_result_only_transient_failure_captures_session_before_resume_status(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        session_id = "22222222-2222-4222-8222-222222222222"
+        fixture = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "session.error",
+                        "data": {
+                            "errorType": "model_at_capacity",
+                            "message": "Selected model is at capacity. Please try again.",
+                            "statusCode": 503,
+                        },
+                    }
+                ),
+                json.dumps({"type": "result", "sessionId": session_id, "exitCode": 1, "usage": {}}),
+            ]
+        )
+        result = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), f"--resume-state={state}"],
+            fake_name="copilot",
+            fixture_text=fixture,
+            env_extra={
+                "ADAPTER_EXIT_CODE": "9",
+                "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream\n--session-id\n--resume",
+                "TMPDIR": str(base),
+            },
+            run_dir=base,
+        )
+        self.assertEqual(result["returncode"], 74, result["stderr"])
+        self.assertEqual(json.loads(state.read_text())["session_id"], session_id)
+
+    def test_resume_plumbing_environment_is_stripped_before_spawn(self) -> None:
+        base = self.sandbox()
+        result = self.invoke(
+            self.base_flags(base),
+            env_extra={
+                "SPECULA_RESUME_STATE": "/ambient/state",
+                "SPECULA_RESUME_MODEL": "ambient-model",
+                "SPECULA_RESUME_EFFORT": "ambient-effort",
+            },
+        )
+        self.assertEqual(result["resumeenv"], "<unset>|<unset>|<unset>")
+
+    def test_resume_only_uses_full_id_never_session_id_or_continue(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        session_id = "33333333-3333-4333-8333-333333333333"
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "adapter": "copilot-cli",
+                    "session_id": session_id,
+                    "cwd": str(base),
+                    "model": "",
+                    "effort": "",
+                }
+            )
+        )
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "session.start", "data": {"sessionId": session_id}}),
+                json.dumps({"type": "result", "sessionId": session_id, "exitCode": 0}),
+            ]
+        )
+        result = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), f"--resume-state={state}"],
+            fake_name="copilot",
+            fixture_text=fixture,
+            env_extra={
+                "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream\n--session-id\n--resume",
+                "TMPDIR": str(base),
+            },
+            run_dir=base,
+        )
+        self.assertEqual(result["returncode"], 0, result["stderr"])
+        index = result["argv"].index("--resume")
+        self.assertEqual(result["argv"][index + 1], session_id)
+        self.assertNotIn("--session-id", result["argv"])
+        self.assertNotIn("--continue", result["argv"])
+
+    def test_resume_state_rejects_non_uuid_before_copilot_launch(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "adapter": "copilot-cli",
+                    "session_id": "session-name-or-prefix",
+                    "cwd": str(base),
+                    "model": "",
+                    "effort": "",
+                }
+            )
+        )
+        result = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), f"--resume-state={state}"],
+            fake_name="copilot",
+            fixture_text="unused",
+            env_extra={
+                "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--session-id\n--resume",
+            },
+            run_dir=base,
+        )
+        self.assertEqual(result["returncode"], 1)
+        self.assertIn("not a full UUID", result["stderr"])
+        self.assertEqual(result["argv"], [])
+
+    def test_resume_capability_and_binding_fail_closed_before_copilot_launch(self) -> None:
+        cases = [
+            ("missing-json", "--autopilot\n--resume", "", "JSON output"),
+            ("missing-exact-resume", "--autopilot\n--output-format", "", "exact-session resume"),
+            ("legacy-resume-only", "--autopilot\n--output-format\n--resume", "", "1.0.51+"),
+            ("session-id-only", "--autopilot\n--output-format\n--session-id", "", "1.0.51+"),
+            (
+                "binding-mismatch",
+                "--autopilot\n--output-format\n--session-id\n--resume",
+                "--model=new-model",
+                "resume state failed",
+            ),
+        ]
+        for name, help_text, extra_flag, diagnostic in cases:
+            with self.subTest(name=name):
+                base = self.sandbox()
+                state = base / "resume.json"
+                state.write_text(
+                    json.dumps(
+                        {
+                            "version": 1,
+                            "adapter": "copilot-cli",
+                            "session_id": "44444444-4444-4444-8444-444444444444",
+                            "cwd": str(base),
+                            "model": "old-model" if extra_flag else "",
+                            "effort": "",
+                        }
+                    )
+                )
+                flags = [*self.base_flags(base)]
+                if extra_flag:
+                    flags.append(extra_flag)
+                flags.append(f"--resume-state={state}")
+                result = self.run_adapter(
+                    self.CMD,
+                    flags,
+                    fake_name="copilot",
+                    fixture_text="unused",
+                    env_extra={"COPILOT_HELP_TEXT": help_text},
+                    run_dir=base,
+                )
+                self.assertEqual(result["returncode"], 1)
+                self.assertIn(diagnostic, result["stderr"])
+                self.assertEqual(result["argv"], [])
+
+    def test_stream_session_change_is_fail_closed_before_native_rate_limit(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        original_id = "55555555-5555-4555-8555-555555555555"
+        changed_id = "66666666-6666-4666-8666-666666666666"
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "adapter": "copilot-cli",
+                    "session_id": original_id,
+                    "cwd": str(base),
+                    "model": "",
+                    "effort": "",
+                }
+            )
+        )
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "session.start", "data": {"sessionId": changed_id}}),
+                json.dumps({"type": "session.error", "data": {"statusCode": 429}}),
+            ]
+        )
+        result = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), f"--resume-state={state}"],
+            fake_name="copilot",
+            fixture_text=fixture,
+            env_extra={
+                "ADAPTER_EXIT_CODE": "75",
+                "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream\n--session-id\n--resume",
+                "TMPDIR": str(base),
+            },
+            run_dir=base,
+        )
+        self.assertEqual(result["returncode"], 1, result["stderr"])
+        self.assertIn("changed session ID", result["stderr"])
+        self.assertEqual(json.loads(state.read_text())["session_id"], original_id)
 
     def test_command_construction(self) -> None:
         base = self.sandbox()
@@ -3247,6 +4453,34 @@ class CopilotAdapter(AdapterCase):
         )
         self.assertEqual(r["returncode"], 76, r["stderr"])
 
+    def test_transient_session_error_maps_to_resume_status(self) -> None:
+        fixture = json.dumps(
+            {
+                "type": "session.error",
+                "data": {
+                    "errorType": "model_at_capacity",
+                    "message": "Selected model is at capacity. Please try again.",
+                    "statusCode": 503,
+                },
+            }
+        )
+        for native_rc, expected in (("0", 74), ("9", 74), ("75", 75), ("76", 76)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                activity = base / "out.activity.jsonl"
+                r = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="copilot",
+                    fixture_text=fixture,
+                    env_extra={
+                        "SPECULA_ACTIVITY_LOG": str(activity),
+                        "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream",
+                        "ADAPTER_EXIT_CODE": native_rc,
+                    },
+                )
+                self.assertEqual(r["returncode"], expected, r["stderr"])
+
     def test_json_stream_plain_policy_diagnostic_uses_failed_cli_status(self) -> None:
         fixture = "\n".join(
             [
@@ -3270,6 +4504,60 @@ class CopilotAdapter(AdapterCase):
                     },
                 )
                 self.assertEqual(r["returncode"], expected, r["stderr"])
+
+    def test_json_stream_plain_transient_diagnostic_uses_failed_cli_status(self) -> None:
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "session.start", "data": {"sessionId": "session-1"}}),
+                "Selected model is at capacity. Please try again.",
+            ]
+        )
+        for native_rc, expected in (("9", 74), ("75", 75), ("76", 76), ("0", 0)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                activity = base / "out.activity.jsonl"
+                r = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="copilot",
+                    fixture_text=fixture,
+                    env_extra={
+                        "SPECULA_ACTIVITY_LOG": str(activity),
+                        "COPILOT_HELP_TEXT": "--autopilot\n--output-format\n--stream",
+                        "ADAPTER_EXIT_CODE": native_rc,
+                    },
+                )
+                self.assertEqual(r["returncode"], expected, r["stderr"])
+
+    def test_nonstream_transient_failure_uses_failed_log_fallback(self) -> None:
+        base = self.sandbox()
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="copilot",
+            fixture_text="Selected model is at capacity. Please try again.\n",
+            env_extra={
+                "COPILOT_HELP_TEXT": "--autopilot",
+                "ADAPTER_EXIT_CODE": "9",
+            },
+        )
+        self.assertEqual(r["returncode"], 74, r["stderr"])
+
+    def test_old_stream_transient_failure_uses_failed_log_fallback(self) -> None:
+        base = self.sandbox()
+        activity = base / "out.activity.jsonl"
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="copilot",
+            fixture_text="Selected model is at capacity. Please try again.\n",
+            env_extra={
+                "SPECULA_ACTIVITY_LOG": str(activity),
+                "COPILOT_HELP_TEXT": "--autopilot\n--stream",
+                "ADAPTER_EXIT_CODE": "9",
+            },
+        )
+        self.assertEqual(r["returncode"], 74, r["stderr"])
 
     def test_successful_stream_terminal_suppresses_later_plain_policy_diagnostic(self) -> None:
         base = self.sandbox()

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -4543,6 +4543,20 @@ class CopilotAdapter(AdapterCase):
         )
         self.assertEqual(r["returncode"], 74, r["stderr"])
 
+    def test_nonstream_typeerror_fetch_failure_uses_failed_log_fallback(self) -> None:
+        base = self.sandbox()
+        r = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="copilot",
+            fixture_text="TypeError: fetch failed\n",
+            env_extra={
+                "COPILOT_HELP_TEXT": "--autopilot",
+                "ADAPTER_EXIT_CODE": "9",
+            },
+        )
+        self.assertEqual(r["returncode"], 74, r["stderr"])
+
     def test_old_stream_transient_failure_uses_failed_log_fallback(self) -> None:
         base = self.sandbox()
         activity = base / "out.activity.jsonl"

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -744,6 +744,52 @@ class TestDriver(ConfirmCase):
         rr = ws.work_dir("T") / "spec" / "repair-requests" / "RR-001.md"
         self.assertIn("original nonempty draft", rr.read_text())
 
+    def test_repair_correction_rate_replay_preserves_missing_or_empty_original(self) -> None:
+        for label, original in (("missing", None), ("empty", ""), ("whitespace", " \n")):
+            with self.subTest(original=label):
+                name = f"T-{label}"
+                ws = self.seed(
+                    name,
+                    [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}],
+                )
+                cfg = self.cfg(ws, name, max_parallel=1, debate=True, rounds=2)
+                fdir = ws.work_dir(name) / "confirmation" / "MC-1"
+                draft = fdir / "repair-request.body.md"
+                calls: list[str] = []
+
+                def agent(
+                    *args: object,
+                    _calls: list[str] = calls,
+                    _draft: Path = draft,
+                    _original: str | None = original,
+                    **_kwargs: object,
+                ) -> tuple[int, str]:
+                    turn = Path(str(args[2])).stem
+                    _calls.append(turn)
+                    if turn == "turn01_A.prompt":
+                        if _original is not None:
+                            _draft.write_text(_original)
+                        return 0, _response("PENDING REPAIR")
+                    if turn == "turn02_A-repair.prompt" and _calls.count(turn) == 1:
+                        _draft.write_text("partial bytes from interrupted correction")
+                        return 75, ""
+                    if turn == "turn02_A-repair.prompt":
+                        return 1, ""
+                    raise AssertionError(f"unexpected logical turn {turn}")
+
+                with mock.patch.object(C, "run_agent_blocking", agent):
+                    first_rc = C.run_parallel_confirmation(cfg, retain_rate_limited_state=True)
+                    second_rc = C.run_parallel_confirmation(cfg)
+
+                self.assertEqual((first_rc, second_rc), (75, 1))
+                self.assertEqual(calls, ["turn01_A.prompt", "turn02_A-repair.prompt", "turn02_A-repair.prompt"])
+                if original is None:
+                    self.assertFalse(draft.exists())
+                else:
+                    self.assertEqual(draft.read_text(), original)
+                rr_dir = ws.work_dir(name) / "spec" / "repair-requests"
+                self.assertFalse(any(rr_dir.glob("RR-*.md")))
+
     def test_unarmed_rate_limit_clears_finding_lease_and_native_cursor(self) -> None:
         ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
         cfg = self.cfg(ws, "T", max_parallel=1)

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -26,6 +26,7 @@ from typing import Any
 from unittest import mock
 
 from specula import confirmlib as C
+from specula import phaselib as PhaseLib
 from specula import pipelinelib as PL
 from specula import prompts as P
 from specula.phaselib import Workspace
@@ -90,6 +91,29 @@ def _scripted_policy_adapter(root: Path, returncodes: list[int]) -> tuple[Path, 
     )
     adapter.chmod(0o755)
     return adapter, count
+
+
+def _git_repo(path: Path) -> Path:
+    path.mkdir()
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    (path / "tracked.txt").write_text("base\n")
+    subprocess.run(["git", "-C", str(path), "add", "tracked.txt"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(path),
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-qm",
+            "initial",
+        ],
+        check=True,
+    )
+    return path
 
 
 class ConfirmCase(unittest.TestCase):
@@ -498,7 +522,7 @@ class TestDriver(ConfirmCase):
         }
 
         with mock.patch.dict(os.environ, env, clear=False):
-            first_rc = C.run_parallel_confirmation(cfg)
+            first_rc = C.run_parallel_confirmation(cfg, retain_rate_limited_state=True)
             second_rc = C.run_parallel_confirmation(cfg)
 
         self.assertEqual((first_rc, second_rc), (75, 1))
@@ -522,7 +546,7 @@ class TestDriver(ConfirmCase):
         }
 
         with mock.patch.dict(os.environ, env, clear=False):
-            first_rc = C.run_parallel_confirmation(cfg)
+            first_rc = C.run_parallel_confirmation(cfg, retain_rate_limited_state=True)
             second_rc = C.run_parallel_confirmation(cfg)
 
         self.assertEqual((first_rc, second_rc), (75, 0))
@@ -545,17 +569,195 @@ class TestDriver(ConfirmCase):
         }
 
         with mock.patch.dict(os.environ, env, clear=False):
-            first_rc = C.run_parallel_confirmation(cfg)
+            first_rc = C.run_parallel_confirmation(cfg, retain_rate_limited_state=True)
             second_rc = C.run_parallel_confirmation(cfg)
 
         self.assertEqual((first_rc, second_rc), (75, 0))
-        self.assertEqual(count.read_text(), "xxxxx")
+        # Completed A is cached across the outer replay; only unfinished B is
+        # invoked again, with its own rate-limit cursor.
+        self.assertEqual(count.read_text(), "xxxx")
         marker = "Continue After Provider Policy Interruption"
         self.assertNotIn(marker, (root / "prompt-1.md").read_text())
         self.assertIn(marker, (root / "prompt-2.md").read_text())
         self.assertNotIn(marker, (root / "prompt-3.md").read_text())
-        self.assertIn(marker, (root / "prompt-4.md").read_text())
-        self.assertNotIn(marker, (root / "prompt-5.md").read_text())
+        self.assertEqual((root / "prompt-4.md").read_text(), (root / "prompt-3.md").read_text())
+        self.assertFalse((root / "prompt-5.md").exists())
+
+    def test_outer_rate_replay_reuses_completed_a_and_resumes_b_in_same_lease(self) -> None:
+        ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
+        root = Path(self.tmp)
+        repo = _git_repo(root / "repo")
+        adapter = root / "resume-debate.sh"
+        adapter.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            "prompt= log= resume=\n"
+            'for arg do case "$arg" in\n'
+            "  --prompt-file=*) prompt=${arg#*=} ;;\n"
+            "  --log=*) log=${arg#*=} ;;\n"
+            "  --resume-state=*) resume=${arg#*=} ;;\n"
+            "esac; done\n"
+            'case "$(basename "$prompt")" in\n'
+            "  turn01_A.prompt.md)\n"
+            '    printf x >> "$CAPTURE/a-count"\n'
+            "    repo=$(sed -n 's/^- Source repo (build\\/run here): //p' \"$prompt\" | head -n 1)\n"
+            '    printf \'%s\\n\' "$repo" > "$CAPTURE/repo-path"\n'
+            '    printf retained > "$repo/lease-marker"\n'
+            '    printf \'%s\\n\' "$ADAPTER_SUCCESS_TEXT" > "$log"\n'
+            "    ;;\n"
+            "  turn02_B.prompt.md)\n"
+            '    printf x >> "$CAPTURE/b-count"\n'
+            '    attempt=$(wc -c < "$CAPTURE/b-count")\n'
+            '    pwd >> "$CAPTURE/b-cwds"\n'
+            '    repo=$(cat "$CAPTURE/repo-path")\n'
+            '    test -f "$repo/lease-marker"\n'
+            '    if [ "$attempt" -eq 1 ]; then\n'
+            "      printf retained > cwd-marker\n"
+            '      printf exact-b-session > "$resume"\n'
+            "      printf 'rate limited\\n' > \"$log\"\n"
+            "      exit 75\n"
+            "    fi\n"
+            '    test "$(cat "$resume")" = exact-b-session\n'
+            "    test -f cwd-marker\n"
+            '    cp "$prompt" "$CAPTURE/b-resume-prompt"\n'
+            '    printf passed > "$CAPTURE/resume-check"\n'
+            '    printf \'%s\\n\' "$ADAPTER_SUCCESS_TEXT" > "$log"\n'
+            "    ;;\n"
+            "  *) exit 97 ;;\n"
+            "esac\n"
+        )
+        adapter.chmod(0o755)
+        cfg = C.ConfirmConfig(
+            name="T",
+            ws=ws,
+            adapter=adapter,
+            repo_dir=str(repo),
+            worktree=True,
+            max_parallel=1,
+            debate=True,
+            rounds=1,
+        )
+        with mock.patch.dict(
+            os.environ,
+            {"CAPTURE": str(root), "ADAPTER_SUCCESS_TEXT": _response("ENV_LIMITED")},
+            clear=False,
+        ):
+            self.assertEqual(C.run_parallel_confirmation(cfg, retain_rate_limited_state=True), 75)
+            leased_repo = Path((root / "repo-path").read_text().strip())
+            self.assertTrue((leased_repo / "lease-marker").is_file())
+            self.assertEqual(set(cfg._finding_leases), {"MC-1"})
+            self.assertEqual(C.run_parallel_confirmation(cfg), 0)
+
+        self.assertEqual((root / "a-count").read_text(), "x")
+        self.assertEqual((root / "b-count").read_text(), "xx")
+        self.assertEqual(len(set((root / "b-cwds").read_text().splitlines())), 1)
+        self.assertEqual((root / "b-resume-prompt").read_text(), PhaseLib._SESSION_RESUME_PROMPT)
+        self.assertEqual((root / "resume-check").read_text(), "passed")
+        self.assertEqual(cfg._finding_leases, {})
+        self.assertEqual(cfg._policy_states, {})
+        self.assertFalse(leased_repo.exists())
+
+    def test_repair_correction_keeps_later_turn_number_across_rate_replay(self) -> None:
+        ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
+        cfg = self.cfg(ws, "T", max_parallel=1, debate=True, rounds=2)
+        calls: list[str] = []
+        b_states: list[object] = []
+        b_cwds: list[Path] = []
+
+        def agent(*args: object, **kwargs: object) -> tuple[int, str]:
+            prompt_file = Path(str(args[2]))
+            turn = prompt_file.stem
+            calls.append(turn)
+            fdir = prompt_file.parent
+            if turn == "turn01_A.prompt":
+                return 0, _response("REPRODUCED")
+            if turn == "turn02_B.prompt":
+                return 0, _response("FALSE POSITIVE")
+            if turn == "turn03_A.prompt":
+                (fdir / "repair-request.body.md").write_text("bad draft")
+                return 0, _response("PENDING REPAIR")
+            if turn == "turn04_A-repair.prompt":
+                (fdir / "repair-request.body.md").write_text(TestMergeRR.AGENT_BODY)
+                return 0, _response("PENDING REPAIR")
+            if turn == "turn05_B.prompt":
+                state = kwargs["policy_state"]
+                assert isinstance(state, PhaseLib.PolicyRetryState)
+                cwd = Path(str(kwargs["cwd"]))
+                b_states.append(state)
+                b_cwds.append(cwd)
+                if len(b_states) == 1:
+                    state.resume_state = fdir / "turn05_B.resume.json"
+                    state.resume_state.write_text("b-session")
+                    (cwd / "retained-marker").write_text("yes")
+                    return 75, ""
+                self.assertIs(b_states[0], state)
+                self.assertTrue((cwd / "retained-marker").is_file())
+                return 0, _response("PENDING REPAIR")
+            raise AssertionError(f"unexpected logical turn {turn}")
+
+        with mock.patch.object(C, "run_agent_blocking", agent):
+            self.assertEqual(C.run_parallel_confirmation(cfg, retain_rate_limited_state=True), 75)
+            self.assertEqual(C.run_parallel_confirmation(cfg), 0)
+
+        self.assertEqual(
+            calls,
+            [
+                "turn01_A.prompt",
+                "turn02_B.prompt",
+                "turn03_A.prompt",
+                "turn04_A-repair.prompt",
+                "turn05_B.prompt",
+                "turn05_B.prompt",
+            ],
+        )
+        self.assertEqual(len(set(b_cwds)), 1)
+        self.assertEqual(cfg._finding_leases, {})
+        self.assertEqual(cfg._policy_states, {})
+
+    def test_repair_correction_rate_replay_restores_original_draft_after_failure(self) -> None:
+        ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
+        cfg = self.cfg(ws, "T", max_parallel=1)
+        fdir = ws.work_dir("T") / "confirmation" / "MC-1"
+        draft = fdir / "repair-request.body.md"
+        calls: list[str] = []
+
+        def agent(*args: object, **_kwargs: object) -> tuple[int, str]:
+            turn = Path(str(args[2])).stem
+            calls.append(turn)
+            if turn == "turn01_A.prompt":
+                draft.write_text("original nonempty draft")
+                return 0, _response("PENDING REPAIR")
+            if turn == "turn02_A-repair.prompt" and calls.count(turn) == 1:
+                draft.write_text("damaged during interrupted correction")
+                return 75, ""
+            if turn == "turn02_A-repair.prompt":
+                draft.unlink()
+                return 1, ""
+            raise AssertionError(f"unexpected logical turn {turn}")
+
+        with mock.patch.object(C, "run_agent_blocking", agent):
+            self.assertEqual(C.run_parallel_confirmation(cfg, retain_rate_limited_state=True), 75)
+            self.assertEqual(C.run_parallel_confirmation(cfg), 0)
+
+        self.assertEqual(calls, ["turn01_A.prompt", "turn02_A-repair.prompt", "turn02_A-repair.prompt"])
+        self.assertEqual(draft.read_text(), "original nonempty draft")
+        rr = ws.work_dir("T") / "spec" / "repair-requests" / "RR-001.md"
+        self.assertIn("original nonempty draft", rr.read_text())
+
+    def test_unarmed_rate_limit_clears_finding_lease_and_native_cursor(self) -> None:
+        ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
+        cfg = self.cfg(ws, "T", max_parallel=1)
+
+        def rate_limited(*_args: object, **kwargs: object) -> tuple[int, str]:
+            state = kwargs["policy_state"]
+            assert isinstance(state, PhaseLib.PolicyRetryState)
+            state.resume_state = Path(self.tmp) / "retained-state"
+            return 75, ""
+
+        with mock.patch.object(C, "run_agent_blocking", rate_limited):
+            self.assertEqual(C.run_parallel_confirmation(cfg), 75)
+        self.assertEqual(cfg._finding_leases, {})
+        self.assertEqual(cfg._policy_states, {})
 
     def test_consolidate_prompt_invokes_installed_skill_without_path(self) -> None:
         ws = Workspace(["T"])
@@ -600,7 +802,7 @@ class TestDriver(ConfirmCase):
         }
 
         with mock.patch.dict(os.environ, env, clear=False):
-            first_rc = C.run_parallel_confirmation(cfg)
+            first_rc = C.run_parallel_confirmation(cfg, retain_rate_limited_state=True)
             second_rc = C.run_parallel_confirmation(cfg)
 
         self.assertEqual((first_rc, second_rc), (75, 1))
@@ -611,6 +813,70 @@ class TestDriver(ConfirmCase):
         self.assertIn(marker, prompts[1])
         self.assertEqual(prompts[2], prompts[1])
         self.assertFalse((root / "prompt-4.md").exists())
+
+    def test_consolidate_rate_resume_keeps_partial_candidates_and_exact_session(self) -> None:
+        ws = Workspace(["T"])
+        root = Path(self.tmp)
+        wd = ws.work_dir("T")
+        spec = wd / "spec"
+        counterexample = spec / "output" / "MC-1.out"
+        counterexample.parent.mkdir(parents=True)
+        counterexample.write_text("State 1\n")
+        findings = {
+            "findings": [
+                {
+                    "id": "MC-1",
+                    "source": "model-checking",
+                    "title": "candidate",
+                    "summary": "summary",
+                    "invariant": "Inv",
+                    "config": "MC.cfg",
+                    "counterexample": "spec/output/MC-1.out",
+                }
+            ]
+        }
+        (spec / "findings.json").write_text(json.dumps(findings))
+        adapter = root / "resume-consolidate.sh"
+        adapter.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            "prompt= log= resume=\n"
+            'for arg do case "$arg" in\n'
+            "  --prompt-file=*) prompt=${arg#*=} ;;\n"
+            "  --log=*) log=${arg#*=} ;;\n"
+            "  --resume-state=*) resume=${arg#*=} ;;\n"
+            "esac; done\n"
+            'printf x >> "$CAPTURE/consolidate-count"\n'
+            'attempt=$(wc -c < "$CAPTURE/consolidate-count")\n'
+            'cp "$prompt" "$CAPTURE/consolidate-prompt-$attempt"\n'
+            'if [ "$attempt" -eq 1 ]; then\n'
+            '  printf PARTIAL-CANDIDATES > "$CANDIDATES"\n'
+            '  printf consolidate-session > "$resume"\n'
+            "  printf 'rate limited\\n' > \"$log\"\n"
+            "  exit 75\n"
+            "fi\n"
+            'test "$(cat "$CANDIDATES")" = PARTIAL-CANDIDATES\n'
+            'test "$(cat "$resume")" = consolidate-session\n'
+            'printf \'{"generated_by":"consolidate","findings":[]}\\n\' > "$CANDIDATES"\n'
+            "printf 'continued\\n' > \"$log\"\n"
+        )
+        adapter.chmod(0o755)
+        cfg = self.cfg(ws, "T", adapter=adapter)
+        with mock.patch.dict(
+            os.environ,
+            {"CAPTURE": str(root), "CANDIDATES": str(spec / "candidates.json")},
+            clear=False,
+        ):
+            self.assertEqual(C.run_parallel_confirmation(cfg, retain_rate_limited_state=True), 75)
+            self.assertEqual((spec / "candidates.json").read_text(), "PARTIAL-CANDIDATES")
+            self.assertEqual(C.run_parallel_confirmation(cfg), 0)
+
+        self.assertEqual((root / "consolidate-count").read_text(), "xx")
+        self.assertEqual(
+            (root / "consolidate-prompt-2").read_text(),
+            PhaseLib._SESSION_RESUME_PROMPT,
+        )
+        self.assertEqual(cfg._policy_states, {})
 
     def test_consolidate_failure_withholds_not_raises(self) -> None:
         # No candidates.json → consolidate runs the agent. A non-75 failure that

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -50,6 +50,7 @@ import specula.progress as progress_module  # noqa: E402
 import specula.quota as quota  # noqa: E402
 from specula import phaselib  # noqa: E402
 from specula.adapters.utils.policy import POLICY_BLOCKED_RC  # noqa: E402
+from specula.adapters.utils.transient import TRANSIENT_FAILURE_RC  # noqa: E402
 from specula.progress import ProgressConfig, RunningAgent  # noqa: E402
 from specula.skill_refs import CODEX_PLUGIN_NAME, prompt_skill_ids  # noqa: E402
 
@@ -476,7 +477,7 @@ class TestDryRunCommand(PhaseCase):
 
         seen: list[tuple[int, str]] = []
 
-        def fake_confirmation(cfg: confirmlib.ConfirmConfig) -> int:
+        def fake_confirmation(cfg: confirmlib.ConfirmConfig, **_kwargs: object) -> int:
             seen.append((cfg.max_parallel, cfg.max_turns))
             return 0
 
@@ -614,6 +615,14 @@ class TestArgErrors(PhaseCase):
                 self.assertIn("Invalid --policy-retries", out)
                 self.assertIn("non-negative integer", out)
 
+    def test_transient_resumes_rejects_non_decimal_values(self) -> None:
+        for value in ("", "-1", "1.5", "bad", "+1"):
+            with self.subTest(value=value):
+                rc, out = self.run_phase("code_analysis", [f"--transient-resumes={value}", NAME])
+                self.assertEqual(rc, 1)
+                self.assertIn("Invalid --transient-resumes", out)
+                self.assertIn("non-negative integer", out)
+
     def test_help_prints_usage(self) -> None:
         for spec in PHASES:
             with self.subTest(phase=spec["key"]):
@@ -626,6 +635,7 @@ class TestArgErrors(PhaseCase):
                 self.assertIn("--model=NAME", out)
                 self.assertIn("--effort=LEVEL", out)
                 self.assertIn("--policy-retries=N", out)
+                self.assertIn("--transient-resumes=N", out)
                 self.assertIn("default: 20", out)
 
 
@@ -635,7 +645,7 @@ class TestBugConfirmationAlternate(PhaseCase):
 
         calls: list[tuple[int, str]] = []
 
-        def fake_confirmation(cfg: confirmlib.ConfirmConfig) -> int:
+        def fake_confirmation(cfg: confirmlib.ConfirmConfig, **_kwargs: object) -> int:
             calls.append((cfg.max_parallel, cfg.max_turns))
             return codes[min(len(calls) - 1, len(codes) - 1)]
 
@@ -671,12 +681,82 @@ class TestBugConfirmationAlternate(PhaseCase):
         self.assertEqual(len(calls), 2)
         self.assertEqual(waits, [1])
 
+    def test_confirmation_arms_runtime_lease_only_for_an_actual_outer_retry(self) -> None:
+        from specula import confirmlib
+
+        retained: list[bool] = []
+
+        def fake_confirmation(
+            _cfg: confirmlib.ConfirmConfig,
+            *,
+            retain_rate_limited_state: bool = False,
+        ) -> int:
+            retained.append(retain_rate_limited_state)
+            return quota.RATE_LIMIT_RC
+
+        self.patch_attr(confirmlib, "run_parallel_confirmation", fake_confirmation)
+        self.patch_attr(phaselib.Phase, "_wait_for_rate_limit", lambda _self: None)
+        self.set_env("SPECULA_RATE_LIMIT_REACTIVE", "1")
+        self.set_env("SPECULA_RATE_LIMIT_RETRIES", "1")
+
+        rc, out = self.dry_run(BY_KEY["bug_confirmation"])
+
+        self.assertEqual(rc, quota.RATE_LIMIT_RC, out)
+        self.assertEqual(retained, [True, False])
+
+    def test_confirmation_does_not_arm_runtime_lease_without_reactive_retry(self) -> None:
+        from specula import confirmlib
+
+        retained: list[bool] = []
+
+        def fake_confirmation(
+            _cfg: confirmlib.ConfirmConfig,
+            *,
+            retain_rate_limited_state: bool = False,
+        ) -> int:
+            retained.append(retain_rate_limited_state)
+            return quota.RATE_LIMIT_RC
+
+        self.patch_attr(confirmlib, "run_parallel_confirmation", fake_confirmation)
+
+        rc, out = self.dry_run(BY_KEY["bug_confirmation"])
+
+        self.assertEqual(rc, quota.RATE_LIMIT_RC, out)
+        self.assertEqual(retained, [False])
+
+    def test_confirmation_clears_retained_runtime_when_quota_wait_aborts(self) -> None:
+        from specula import confirmlib
+
+        def fake_confirmation(
+            _cfg: confirmlib.ConfirmConfig,
+            *,
+            retain_rate_limited_state: bool = False,
+        ) -> int:
+            self.assertTrue(retain_rate_limited_state)
+            return quota.RATE_LIMIT_RC
+
+        def abort_wait(_self: phaselib.Phase) -> None:
+            raise RuntimeError("quota wait aborted")
+
+        self.patch_attr(confirmlib, "run_parallel_confirmation", fake_confirmation)
+        self.patch_attr(phaselib.Phase, "_wait_for_rate_limit", abort_wait)
+        self.set_env("SPECULA_RATE_LIMIT_REACTIVE", "1")
+        self.set_env("SPECULA_RATE_LIMIT_RETRIES", "1")
+
+        with (
+            mock.patch.object(confirmlib.ConfirmConfig, "clear_retry_runtime", autospec=True) as clear,
+            self.assertRaisesRegex(RuntimeError, "quota wait aborted"),
+        ):
+            self.dry_run(BY_KEY["bug_confirmation"])
+
+        clear.assert_called_once()
+
     def test_policy_retry_budget_reaches_parallel_confirmation(self) -> None:
         from specula import confirmlib
 
         seen: list[int] = []
 
-        def fake_confirmation(cfg: confirmlib.ConfirmConfig) -> int:
+        def fake_confirmation(cfg: confirmlib.ConfirmConfig, **_kwargs: object) -> int:
             seen.append(cfg.policy_retries)
             return 0
 
@@ -692,7 +772,7 @@ class TestBugConfirmationAlternate(PhaseCase):
         self.seed(BY_KEY["bug_confirmation"]["inputs"])
         self.patch_attr(phaselib.Phase, "_acceptance", lambda _self, _ws, _names: None)
 
-        def fake_confirmation(cfg: confirmlib.ConfirmConfig) -> int:
+        def fake_confirmation(cfg: confirmlib.ConfirmConfig, **_kwargs: object) -> int:
             return 0
 
         self.patch_attr(confirmlib, "run_parallel_confirmation", fake_confirmation)
@@ -708,7 +788,7 @@ class TestBugConfirmationAlternate(PhaseCase):
         self.seed(BY_KEY["bug_confirmation"]["inputs"])
         self.patch_attr(phaselib.Phase, "_acceptance", lambda _self, _ws, _names: None)
 
-        def fake_confirmation(cfg: confirmlib.ConfirmConfig) -> int:
+        def fake_confirmation(cfg: confirmlib.ConfirmConfig, **_kwargs: object) -> int:
             report = cfg.ws.work_dir(cfg.name) / "spec" / "confirmed-bugs.md"
             report.parent.mkdir(parents=True, exist_ok=True)
             report.write_text("# Confirmed Bugs\n")
@@ -884,6 +964,95 @@ class TestHandoffGate(PhaseCase):
         self.assertEqual(rc, POLICY_BLOCKED_RC, out)
         self.assertEqual(count.read_text(), "x")
         self.assertNotIn("retrying with a revised request", out)
+
+    def test_transient_failure_resumes_exact_session_with_lightweight_prompt(self) -> None:
+        count = self.tmp() / "count"
+        captures = self.tmp()
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("CAPTURE_DIR", str(captures))
+        self.patch_attr(phaselib, "_transient_resume_delay", lambda _attempt: 0.0)
+        self.write_adapter(
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            'for arg do case "$arg" in '
+            "--prompt-file=*) prompt=${arg#*=} ;; "
+            "--log=*) log=${arg#*=} ;; "
+            "--resume-state=*) resume=${arg#*=} ;; "
+            "esac; done\n"
+            'cp "$prompt" "$CAPTURE_DIR/prompt-$attempt.md"\n'
+            'printf "%s\\n" "$resume" >> "$CAPTURE_DIR/resume-paths"\n'
+            'if [ "$attempt" -eq 1 ]; then\n'
+            '  printf "session-exact-123\\n" > "$resume"\n'
+            '  printf "temporary failure\\n" > "$log"\n'
+            "  exit 74\n"
+            "fi\n"
+            '[ "$(cat "$resume")" = "session-exact-123" ]\n'
+            'printf "continued in session-exact-123\\n" > "$log"\n'
+            'printf "brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
+        )
+
+        rc, out = self.run_analysis(options=["--transient-resumes=1"])
+
+        self.assertEqual(rc, 0, out)
+        self.assertEqual(count.read_text(), "xx")
+        first_prompt = (captures / "prompt-1.md").read_text()
+        resumed_prompt = (captures / "prompt-2.md").read_text()
+        self.assertIn("modeling-brief.md", first_prompt)
+        self.assertEqual(resumed_prompt, phaselib._SESSION_RESUME_PROMPT)
+        self.assertLess(len(resumed_prompt), len(first_prompt))
+        resume_paths = (captures / "resume-paths").read_text().splitlines()
+        self.assertEqual(resume_paths, [str(self.work_dir() / "agent.resume.json")] * 2)
+        self.assertEqual((self.work_dir() / "agent.attempt-1.log").read_text(), "temporary failure\n")
+        self.assertEqual((self.work_dir() / "agent.log").read_text(), "continued in session-exact-123\n")
+        self.assertIn("resuming the exact session (1/1)", out)
+
+    def test_default_transient_resume_budget_stops_after_twenty_continuations(self) -> None:
+        count = self.tmp() / "count"
+        self.set_env("COUNT_FILE", str(count))
+        self.patch_attr(phaselib, "_transient_resume_delay", lambda _attempt: 0.0)
+        self.write_adapter('printf x >> "$COUNT_FILE"\nexit 74\n')
+
+        rc, out = self.run_analysis()
+
+        self.assertEqual(rc, TRANSIENT_FAILURE_RC, out)
+        self.assertEqual(count.read_text(), "x" * 21)
+        self.assertIn("temporary provider failure", out)
+        self.assertIn("(20/20)", out)
+        self.assertNotIn("(21/20)", out)
+        self.assertIn(f"adapter exited {TRANSIENT_FAILURE_RC}", out)
+
+    def test_zero_transient_resumes_disables_continuation(self) -> None:
+        count = self.tmp() / "count"
+        self.set_env("COUNT_FILE", str(count))
+        self.patch_attr(phaselib, "_transient_resume_delay", lambda _attempt: 0.0)
+        self.write_adapter('printf x >> "$COUNT_FILE"\nexit 74\n')
+
+        rc, out = self.run_analysis(options=["--transient-resumes=0"])
+
+        self.assertEqual(rc, TRANSIENT_FAILURE_RC, out)
+        self.assertEqual(count.read_text(), "x")
+        self.assertNotIn("temporary provider failure", out)
+
+    def test_transient_resume_budget_exhaustion_preserves_each_attempt_log(self) -> None:
+        count = self.tmp() / "count"
+        self.set_env("COUNT_FILE", str(count))
+        self.patch_attr(phaselib, "_transient_resume_delay", lambda _attempt: 0.0)
+        self.write_adapter(
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            'for arg do case "$arg" in --log=*) log=${arg#*=} ;; esac; done\n'
+            'printf "failure-%s\\n" "$attempt" > "$log"\n'
+            "exit 74\n"
+        )
+
+        rc, out = self.run_analysis(options=["--transient-resumes=2"])
+
+        self.assertEqual(rc, TRANSIENT_FAILURE_RC, out)
+        self.assertEqual(count.read_text(), "xxx")
+        self.assertEqual((self.work_dir() / "agent.attempt-1.log").read_text(), "failure-1\n")
+        self.assertEqual((self.work_dir() / "agent.attempt-2.log").read_text(), "failure-2\n")
+        self.assertEqual((self.work_dir() / "agent.log").read_text(), "failure-3\n")
+        self.assertIn("(2/2)", out)
 
     def test_policy_and_rate_limit_retry_budgets_are_independent(self) -> None:
         count = self.tmp() / "count"
@@ -1394,6 +1563,158 @@ class TestRunAgentBlocking(PhaseCase):
 
         self.assertEqual(rc, POLICY_BLOCKED_RC)
         self.assertEqual(count.read_text(), "x")
+
+    def test_fresh_blocking_turn_fails_if_stale_resume_state_cannot_be_cleared(self) -> None:
+        marker = self.tmp() / "launched"
+        adapter = self.tmp() / "adapter.sh"
+        adapter.write_text(f'#!/bin/sh\ntouch "{marker}"\n')
+        adapter.chmod(0o755)
+        log_file = self.tmp() / "turn.log"
+        log_file.with_suffix(".resume.json").mkdir()
+        state = phaselib.PolicyRetryState()
+
+        for _ in range(2):
+            with self.assertRaisesRegex(RuntimeError, "cannot clear stale resume state"):
+                phaselib.run_agent_blocking(
+                    adapter,
+                    "fresh prompt",
+                    self.tmp() / "prompt.md",
+                    log_file,
+                    phase_key="bug_confirmation",
+                    work_dir=self.work_dir(),
+                    claude_alias="profile",
+                    policy_state=state,
+                )
+            self.assertIsNone(state.resume_state)
+
+        self.assertFalse(marker.exists())
+
+    def test_transient_failure_resumes_blocking_turn_in_exact_session(self) -> None:
+        adapter = self.tmp() / "adapter.sh"
+        count = self.tmp() / "count"
+        captures = self.tmp()
+        adapter.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            'for arg do case "$arg" in '
+            "--prompt-file=*) prompt=${arg#*=} ;; "
+            "--log=*) log=${arg#*=} ;; "
+            "--resume-state=*) resume=${arg#*=} ;; "
+            "esac; done\n"
+            'cp "$prompt" "$CAPTURE_DIR/prompt-$attempt.md"\n'
+            'printf "%s\\n" "$resume" >> "$CAPTURE_DIR/resume-paths"\n'
+            'if [ "$attempt" -eq 1 ]; then\n'
+            '  printf "blocking-session-456\\n" > "$resume"\n'
+            '  printf "capacity failure\\n" > "$log"\n'
+            "  exit 74\n"
+            "fi\n"
+            '[ "$(cat "$resume")" = "blocking-session-456" ]\n'
+            'printf "continued answer\\n" > "$log"\n'
+        )
+        adapter.chmod(0o755)
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("CAPTURE_DIR", str(captures))
+        prompt_file = captures / "prompt.md"
+        log_file = captures / "turn.log"
+
+        with mock.patch("specula.phaselib.time.sleep") as sleep:
+            rc, text = phaselib.run_agent_blocking(
+                adapter,
+                "original blocking prompt with detailed evidence",
+                prompt_file,
+                log_file,
+                phase_key="bug_confirmation",
+                work_dir=self.work_dir(),
+                claude_alias="profile",
+                transient_resumes=1,
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(text, "continued answer\n")
+        self.assertEqual(count.read_text(), "xx")
+        sleep.assert_called_once_with(phaselib._transient_resume_delay(1))
+        self.assertEqual((captures / "prompt-1.md").read_text(), "original blocking prompt with detailed evidence")
+        self.assertEqual((captures / "prompt-2.md").read_text(), phaselib._SESSION_RESUME_PROMPT)
+        self.assertEqual((captures / "resume-paths").read_text().splitlines(), [str(captures / "turn.resume.json")] * 2)
+        self.assertEqual((captures / "turn.attempt-1.log").read_text(), "capacity failure\n")
+        self.assertEqual(log_file.read_text(), "continued answer\n")
+
+    def test_rate_limit_replay_preserves_exact_session_and_spent_retry_budgets(self) -> None:
+        adapter = self.tmp() / "adapter.sh"
+        count = self.tmp() / "count"
+        captures = self.tmp()
+        adapter.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            'for arg do case "$arg" in '
+            "--prompt-file=*) prompt=${arg#*=} ;; "
+            "--log=*) log=${arg#*=} ;; "
+            "--resume-state=*) resume=${arg#*=} ;; "
+            "esac; done\n"
+            'if [ ! -f "$resume" ]; then printf "shared-session-789\\n" > "$resume"; fi\n'
+            '[ "$(cat "$resume")" = "shared-session-789" ]\n'
+            'cp "$prompt" "$CAPTURE_DIR/prompt-$attempt.md"\n'
+            'cat "$resume" >> "$CAPTURE_DIR/sessions"\n'
+            'printf "attempt-%s\\n" "$attempt" > "$log"\n'
+            'case "$attempt" in\n'
+            "  1) exit 74 ;;\n"
+            "  2) exit 76 ;;\n"
+            "  3) exit 75 ;;\n"
+            "  4) exit 76 ;;\n"
+            "  *) exit 99 ;;\n"
+            "esac\n"
+        )
+        adapter.chmod(0o755)
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("CAPTURE_DIR", str(captures))
+        state = phaselib.PolicyRetryState()
+        prompt_file = captures / "prompt.md"
+        log_file = captures / "turn.log"
+        with mock.patch("specula.phaselib.time.sleep") as sleep:
+            first_rc, first_text = phaselib.run_agent_blocking(
+                adapter,
+                "original prompt",
+                prompt_file,
+                log_file,
+                phase_key="bug_confirmation",
+                work_dir=self.work_dir(),
+                claude_alias="profile",
+                policy_retries=1,
+                transient_resumes=1,
+                policy_state=state,
+            )
+            second_rc, second_text = phaselib.run_agent_blocking(
+                adapter,
+                "original prompt",
+                prompt_file,
+                log_file,
+                phase_key="bug_confirmation",
+                work_dir=self.work_dir(),
+                claude_alias="profile",
+                policy_retries=1,
+                transient_resumes=1,
+                policy_state=state,
+            )
+
+        self.assertEqual((first_rc, first_text), (quota.RATE_LIMIT_RC, "attempt-3\n"))
+        self.assertEqual((second_rc, second_text), (POLICY_BLOCKED_RC, "attempt-4\n"))
+        self.assertEqual(count.read_text(), "xxxx")
+        sleep.assert_called_once_with(phaselib._transient_resume_delay(1))
+        self.assertEqual(state.policy_attempt, 1)
+        self.assertEqual(state.transient_attempt, 1)
+        self.assertEqual(state.invocation_attempt, 4)
+        self.assertEqual(state.resume_state, captures / "turn.resume.json")
+        self.assertEqual((captures / "sessions").read_text().splitlines(), ["shared-session-789"] * 4)
+        self.assertEqual((captures / "prompt-1.md").read_text(), "original prompt")
+        self.assertEqual((captures / "prompt-2.md").read_text(), phaselib._SESSION_RESUME_PROMPT)
+        self.assertEqual((captures / "prompt-3.md").read_text(), phaselib._POLICY_SESSION_RESUME_PROMPT)
+        self.assertEqual((captures / "prompt-4.md").read_text(), phaselib._SESSION_RESUME_PROMPT)
+        self.assertEqual((captures / "turn.attempt-3.log").read_text(), "attempt-3\n")
+        self.assertEqual(log_file.read_text(), "attempt-4\n")
 
     def test_turn_phase_scopes_stop_gate_sets_cwd_and_removes_stale_log(self) -> None:
         adapter = self.tmp() / "adapter.sh"
@@ -2364,6 +2685,22 @@ class TestModelEffortLiveLaunch(PhaseCase):
         self.assertNotIn("--model=env-model", argv)
         self.assertNotIn("--effort=high", argv)
 
+    def test_fresh_phase_fails_if_stale_resume_state_cannot_be_cleared(self) -> None:
+        marker = self.tmp() / "launched"
+        adapter = self.adapters / "codex.sh"
+        adapter.write_text(f'#!/usr/bin/env sh\ntouch "{marker}"\n')
+        adapter.chmod(0o755)
+        state = self.work_dir() / "agent.resume.json"
+        state.mkdir(parents=True)
+
+        with self.assertRaisesRegex(RuntimeError, "cannot clear stale resume state"):
+            self.run_phase(
+                "code_analysis",
+                ["--agent=codex", self.artifact_flag(), NAME],
+            )
+
+        self.assertFalse(marker.exists())
+
 
 class TestReviewPhase(PhaseCase):
     """The review agent overrides run() wholesale; its contract is the prompt it
@@ -2440,6 +2777,23 @@ class TestReviewPhase(PhaseCase):
                 self.assertEqual(rc, 1)
                 self.assertIn("Invalid --policy-retries", out)
                 self.assertIn("non-negative integer", out)
+
+    def test_fresh_review_fails_if_stale_resume_state_cannot_be_cleared(self) -> None:
+        marker = self.tmp() / "launched"
+        adapter = self.install_adapter("codex", f'touch "{marker}"\n')
+        state = self.work_dir() / "review-analysis.resume.json"
+        state.mkdir(parents=True)
+
+        with self.assertRaisesRegex(RuntimeError, "cannot clear stale resume state"):
+            self.review()._launch_review(
+                phaselib.Workspace([NAME]),
+                NAME,
+                "analysis",
+                adapter,
+                "profile",
+            )
+
+        self.assertFalse(marker.exists())
 
     def test_review_streams_activity_through_shared_monitor(self) -> None:
         event = json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "reviewing"}})

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -688,6 +688,32 @@ class TestParsing(TmpCwd):
                 self.assertEqual(rc, 1)
                 self.assertIn("--policy-retries must be a non-negative integer", err.getvalue())
 
+    def test_transient_resume_default_and_explicit_value_are_forwarded(self) -> None:
+        default = pl.Pipeline()
+        self.assertIsNone(default.parse_args(["t|g|l|r"]))
+        self.assertEqual(default.transient_resumes, 20)
+        self.assertIn("--transient-resumes=20", default._phase_args(["t"]))
+
+        explicit = pl.Pipeline()
+        self.assertIsNone(explicit.parse_args(["--transient-resumes=100", "t|g|l|r"]))
+        self.assertEqual(explicit.transient_resumes, 100)
+        self.assertIn("--transient-resumes=100", explicit._phase_args(["t"]))
+
+        disabled = pl.Pipeline()
+        self.assertIsNone(disabled.parse_args(["--transient-resumes=0", "t|g|l|r"]))
+        self.assertEqual(disabled.transient_resumes, 0)
+        self.assertIn("--transient-resumes=0", disabled._phase_args(["t"]))
+
+    def test_invalid_transient_resume_budget_is_rejected_at_parse(self) -> None:
+        for value in ("", "-1", "1.5", "bad", "+1"):
+            with self.subTest(value=value):
+                p = pl.Pipeline()
+                err = io.StringIO()
+                with contextlib.redirect_stderr(err):
+                    rc = p.parse_args([f"--transient-resumes={value}", "t|g|l|r"])
+                self.assertEqual(rc, 1)
+                self.assertIn("--transient-resumes must be a non-negative integer", err.getvalue())
+
     def test_max_parallel_summary_reports_per_finding_default(self) -> None:
         p = pl.Pipeline()
         self.assertIsNone(p.parse_args(["t|g|l|r"]))
@@ -759,6 +785,7 @@ class TestParsing(TmpCwd):
         self.assertIn("--model=NAME", out)
         self.assertIn("--effort=LEVEL", out)
         self.assertIn("--policy-retries=N", out)
+        self.assertIn("--transient-resumes=N", out)
         self.assertIn("default: 20", out)
 
     def test_default_target_is_cwd_basename(self) -> None:
@@ -829,6 +856,7 @@ class TestRunReview(TmpCwd):
         model: str | None = None,
         effort: str | None = None,
         policy_retries: int = 20,
+        transient_resumes: int = 20,
     ) -> list[str]:
         p = make_pipeline(
             ["footest|foo/bar|Go|ref"],
@@ -836,6 +864,7 @@ class TestRunReview(TmpCwd):
             model=model,
             effort=effort,
             policy_retries=policy_retries,
+            transient_resumes=transient_resumes,
         )
         seen: list[list[str]] = []
         p._phase = lambda banner, script, args: seen.append(args)  # type: ignore[method-assign]
@@ -854,11 +883,16 @@ class TestRunReview(TmpCwd):
         self.assertIn("--agent=claude-code", args)
         self.assertIn("--claude-alias=claude", args)
         self.assertIn("--policy-retries=20", args)
+        self.assertIn("--transient-resumes=20", args)
         self.assertEqual(args[-1], "footest")
 
     def test_explicit_policy_retry_budget_reaches_review(self) -> None:
         args = self._capture("analysis", policy_retries=100)
         self.assertIn("--policy-retries=100", args)
+
+    def test_explicit_transient_resume_budget_reaches_review(self) -> None:
+        args = self._capture("analysis", transient_resumes=100)
+        self.assertIn("--transient-resumes=100", args)
 
     def test_model_effort_values_and_empty_are_forwarded(self) -> None:
         args = self._capture("analysis", model="gpt-5.5", effort="high")

--- a/tests/unit/test_workspace_isolation.py
+++ b/tests/unit/test_workspace_isolation.py
@@ -291,6 +291,7 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
         self.assertIsNone(meta["model"])
         self.assertEqual(meta["effort"], "max")
         self.assertEqual(meta["policy_retries"], 20)
+        self.assertEqual(meta["transient_resumes"], 20)
         self.assertIsNone(meta["artifact_git_sha"])  # no artifact given
         self.assertIn("created", meta)
         # env exported for the phase subprocesses


### PR DESCRIPTION
## Summary

- add configurable recovery for capacity, provider 5xx, and transport failures through `--transient-resumes`, defaulting to 20, including common Node `read|write|connect|getaddrinfo` diagnostics
- persist and validate exact native session IDs, then resume Claude Code, Codex, Copilot, OpenCode, and Pi without replaying the original task
- capture fresh Copilot IDs from terminal `result.sessionId` and use full-UUID `--resume` on Copilot CLI 1.0.51+, so stale state fails closed instead of creating a blank session
- preserve retry budgets, completed confirmation turns, worktrees, original repair drafts, and per-attempt logs across policy, transient, and rate-limit recovery
- fail closed on corrupt, mismatched, stale, or unsafe resume state and document the recovery guarantees and limitations