### PR TITLE
Clarify Codex plugin installation scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ Open your coding agent in the Specula directory. The workflow is a sequence of s
 
 (Codex uses `$code-analysis`, `$spec-generation`, etc. after choosing `y` in `specula setup`, or `$specula-codex:code-analysis`, `$specula-codex:spec-generation`, etc. in plugin mode.)
 
-Codex plugin installation applies to the active Codex profile and makes the plugin available across projects. Codex does not currently support project-scoped plugin installation, so setup asks for confirmation before installing it.
-
 To start, tell the agent your target and invoke the first skill:
 
 ```

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Open your coding agent in the Specula directory. The workflow is a sequence of s
 
 (Codex uses `$code-analysis`, `$spec-generation`, etc. after choosing `y` in `specula setup`, or `$specula-codex:code-analysis`, `$specula-codex:spec-generation`, etc. in plugin mode.)
 
+Codex plugin installation applies to the active Codex profile and makes the plugin available across projects. Codex does not currently support project-scoped plugin installation, so setup asks for confirmation before installing it.
+
 To start, tell the agent your target and invoke the first skill:
 
 ```

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -74,7 +74,7 @@ Install with `-e` (editable): the `specula` command dispatches to scripts inside
 
 Setup downloads the TLA+ JARs, builds the CFA tool, prepares the MCP tool environments, and offers integration for each supported agent CLI found on `PATH`. It reports and skips any missing agent CLI instead of prompting for it. Setup prompts for global or project-local skill installation when that choice applies.
 
-For Codex, choose `y` to install skills and register MCP servers separately. Choose `plugin` to bundle the skills and MCP tools as `specula-codex@specula`, with cleaner namespacing and easier removal. Rerun `specula setup` and choose `plugin` again to update it.
+For Codex, choose `y` to install skills and register MCP servers separately. Choose `plugin` to bundle the skills and MCP tools as `specula-codex@specula`, with cleaner namespacing and easier removal. Codex currently installs plugins into the active Codex profile, making them available across all projects that use that profile; setup asks for confirmation before making this profile-wide change. Codex does not currently support project-scoped plugin installation. Rerun `specula setup` and choose `plugin` again to update it.
 
 More precisely, setup manages:
 
@@ -84,10 +84,10 @@ More precisely, setup manages:
 | CFA transformer | Builds it with Maven |
 | MCP Python packages | Creates tool-specific virtual environments and installs `mcp` and `jsonschema` where required |
 | Claude Code | Installs skills and registers all three MCP servers |
-| Codex | `y` installs skills and MCP servers separately; `plugin` generates or updates `specula-codex@specula` |
+| Codex | `y` installs skills and MCP servers separately; `plugin` generates or updates `specula-codex@specula` for the active Codex profile |
 | GitHub Copilot CLI | Installs skills and, with Copilot CLI 1.0.21+, registers all three MCP servers |
 
-Copilot MCP registration is user-level and follows `COPILOT_HOME`; the global/local setup choice controls only where skills are installed. Setup leaves an existing same-named MCP server unchanged and reports the conflict instead of overwriting it. Older Copilot CLI versions still install the skills, but MCP registration is skipped with an upgrade warning.
+For Codex, the global/local choice applies only to skills installed separately with `y`; separate MCP registration and plugin installation use the active Codex profile. Copilot MCP registration is user-level and follows `COPILOT_HOME`; its global/local setup choice also controls only where skills are installed. Setup leaves an existing same-named MCP server unchanged and reports the conflict instead of overwriting it. Older Copilot CLI versions still install the skills, but MCP registration is skipped with an upgrade warning.
 
 Setup does **not** install `uv`, Python, a JDK, Maven, Git, `gh`, an agent CLI, target-language dependencies, GNU coreutils, or the optional sandbox dependencies. It does not install the `specula` command either; that is the `uv tool install -e .` step above.
 

--- a/scripts/infra/setup.sh
+++ b/scripts/infra/setup.sh
@@ -93,6 +93,7 @@ ask_codex_install() {
   local answer
   echo "  y: install skills and register MCP servers separately." >&2
   echo "  plugin: bundle skills and MCP tools as specula-codex@specula for cleaner namespacing and easier removal." >&2
+  echo "          Codex installs plugins for the current profile, making them available across projects." >&2
   echo "          Rerun specula setup and choose plugin again to update it." >&2
   while true; do
     read -rp "$(echo -e "${BLUE}[?]${NC} Install Specula for Codex? (y/n/plugin): ")" answer
@@ -425,7 +426,13 @@ case "$codex_install" in
     done
     ;;
   plugin)
-    setup_codex_plugin "$PROJECT_ROOT" "$CODEX_PLUGIN_ROOT"
+    print_warning "Codex does not currently support project-scoped plugin installation."
+    if ask_yn "Continue with profile-wide Codex plugin installation?"; then
+      setup_codex_plugin "$PROJECT_ROOT" "$CODEX_PLUGIN_ROOT"
+    else
+      print_status "Skipped Codex plugin installation."
+      print_status "For project-local skills, rerun specula setup, choose 'y', then choose 'local'."
+    fi
     ;;
   skip)
     print_status "Skipped Codex."

--- a/tests/unit/test_setup_security.py
+++ b/tests/unit/test_setup_security.py
@@ -299,16 +299,42 @@ printf '\\n' >> "$FAKE_COMMAND_LOG"
         self.assertNotIn("setup_codex_plugin.py", commands)
         self.assertEqual(commands.count("codex\tmcp\tadd"), 3)
 
-    def test_codex_plugin_keeps_explanation_out_of_branch_value(self) -> None:
+    def test_codex_y_supports_project_local_skills(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            result, commands = self.run_setup(Path(tmp), {"codex"}, "plugin\n")
+            root = Path(tmp)
+            result, commands = self.run_setup(root, {"codex"}, "y\nlocal\n")
 
         self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(f"--target\t{root / '.agents/skills'}", commands)
+        self.assertNotIn("setup_codex_plugin.py", commands)
+        self.assertEqual(commands.count("codex\tmcp\tadd"), 3)
+        self.assertIn("Local skills are discoverable only when the agent starts in", result.stdout)
+
+    def test_codex_plugin_keeps_explanation_out_of_branch_value(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result, commands = self.run_setup(Path(tmp), {"codex"}, "plugin\ny\n")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Codex installs plugins for the current profile", result.stderr)
+        self.assertIn("Codex does not currently support project-scoped plugin installation.", result.stdout)
+        self.assertIn('ask_yn "Continue with profile-wide Codex plugin installation?"', SETUP_SCRIPT.read_text())
         self.assertIn("setup_codex_plugin.py", commands)
         self.assertNotIn("src/specula/skill_install.py", commands)
         self.assertNotIn("codex\tmcp\tadd", commands)
         self.assertIn("Codex plugin configured: specula-codex@specula", result.stdout)
         self.assertIn("Rerun specula setup and choose 'plugin' again", result.stdout)
+
+    def test_codex_plugin_can_be_declined_without_profile_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result, commands = self.run_setup(Path(tmp), {"codex"}, "plugin\nn\n")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Codex does not currently support project-scoped plugin installation.", result.stdout)
+        self.assertIn("Skipped Codex plugin installation.", result.stdout)
+        self.assertIn("choose 'y', then choose 'local'", result.stdout)
+        self.assertNotIn("setup_codex_plugin.py", commands)
+        self.assertNotIn("src/specula/skill_install.py", commands)
+        self.assertNotIn("codex\tmcp", commands)
 
 
 class TestSetupPythonIsolation(unittest.TestCase):


### PR DESCRIPTION
## Summary

- make Codex plugin setup state that installation applies to the active Codex profile and is available across projects
- require explicit confirmation before the profile-wide plugin install
- preserve the existing `y` then `global/local` skills path and make declining the plugin side-effect-free
- document the distinction between separately installed skills and profile-wide plugins/MCP registration
