### PR TITLE
Move final bug reports out of spec

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -220,8 +220,8 @@ Most users should run `specula run`, which executes every step in order. The com
 | `specgen` | Converts the modeling brief into code-faithful TLA+ specifications | Source and `modeling-brief.md` | `spec/base.tla`, `spec/MC.tla`, `spec/Trace.tla`, configs, and `instrumentation-spec.md` |
 | `harness` | Instruments the implementation and runs scenarios to collect execution traces | Source and generated specifications | `harness/` and `traces/*.ndjson` |
 | `validate` | Checks real traces against the specification, runs TLC, and investigates counterexamples | Source, specifications, harness, and traces | `spec/bug-report.md`, `spec/findings.json`, TLC output, and `spec/changelog.md` |
-| `confirm` | Audits and reproduces each candidate bug against the real implementation | Source, modeling brief, and bug report | `spec/confirmed-bugs.md`, reproduction tests, and any repair requests |
-| `classify` | Assigns severity to reproduced bugs and finding-tier entries; records other dispositions without severity | `spec/confirmed-bugs.md` | `spec/bug-severity.md` |
+| `confirm` | Audits and reproduces each candidate bug against the real implementation | Source, modeling brief, and bug report | `confirmed-bugs.md`, reproduction tests, and any repair requests |
+| `classify` | Assigns severity to reproduced bugs and finding-tier entries; records other dispositions without severity | `confirmed-bugs.md` | `bug-severity.md` |
 
 For example, run only the code analysis with Codex:
 

--- a/skills/bug-classification/guide.md
+++ b/skills/bug-classification/guide.md
@@ -4,8 +4,8 @@ Assign a Severity tier to each impact-bearing entry in `confirmed-bugs.md` (prod
 
 ## Scope
 
-- **Input**: `<work_dir>/spec/confirmed-bugs.md` — every entry already has a Phase 4 Status and supporting evidence.
-- **Output**: `<work_dir>/spec/bug-severity.md` — a single table with one row per input entry.
+- **Input**: `<work_dir>/confirmed-bugs.md` — every entry already has a Phase 4 Status and supporting evidence.
+- **Output**: `<work_dir>/bug-severity.md` — a single table with one row per input entry.
 - **You do not**: write new bug analysis, change reproduction status, reject bugs, re-do investigation, or modify `confirmed-bugs.md`.
 
 Classify each status exactly as follows:
@@ -52,7 +52,7 @@ Do not re-do Phase 4a's investigation. If you find that Phase 4a's Status is wro
 
 ## Output schema
 
-Write to `<work_dir>/spec/bug-severity.md` with exactly this structure:
+Write to `<work_dir>/bug-severity.md` with exactly this structure:
 
 ```markdown
 # Severity Classification — <case>
@@ -61,7 +61,7 @@ Write to `<work_dir>/spec/bug-severity.md` with exactly this structure:
 
 - Total entries: N
 - Reproduced bugs: N
-- Findings: N
+- Severity-bearing findings: N
 - Critical: N
 - High: N
 - Medium: N
@@ -70,21 +70,21 @@ Write to `<work_dir>/spec/bug-severity.md` with exactly this structure:
 
 ## Per-entry classification
 
-| Bug | Title | Status | Severity | Reasoning |
-|-----|-------|--------|----------|-----------|
-| 1   | <title from confirmed-bugs.md ## Bug 1: header> | REPRODUCED | High | <worst consequence + reachability> |
-| 2   | <title from ## Bug 2> | ENV_LIMITED | Critical | <production consequence + named environment limit> |
-| 3   | <title from ## Bug 3> | MASKED | Medium | <consequence + named mask> |
-| 4   | <title from ## Bug 4> | FALSE POSITIVE | — | <non-severity disposition> |
+| Entry | Finding | Status | Severity | Reasoning |
+|-------|---------|--------|----------|-----------|
+| 1     | MC-1 | REPRODUCED | High | <worst consequence + reachability> |
+| 2     | MC-2 | ENV_LIMITED | Critical | <production consequence + named environment limit> |
+| 3     | MC-3 | MASKED | Medium | <consequence + named mask> |
+| 4     | MC-4 | FALSE POSITIVE | — | <non-severity disposition> |
 ```
 
-- **Bug** column: integer matching `## Bug N:` headers in `confirmed-bugs.md`. One row per entry, no merging, no skipping.
-- **Title** column: copy the title from the `## Bug N:` header verbatim. Truncate to ~60 chars if needed; preserve enough to identify the bug.
+- **Entry** column: integer matching `## Entry N:` headers in `confirmed-bugs.md`. One row per entry, no merging, no skipping.
+- **Finding** column: copy the stable finding id from the matching `Finding` table row or `- **Finding ID**:` field.
 - **Status** column: copy the entry's `Status` field verbatim, including an RR suffix or defer reason when present. Categorize it by its leading canonical status token.
 - **Severity** column: one of `Critical` / `High` / `Medium` / `Low` for `REPRODUCED`, `ENV_LIMITED`, and `MASKED`; exactly `—` for every disposition status.
 - **Reasoning** column: for a bug/finding, name the consequence and trigger surface; for a disposition, briefly state why it has no severity. Avoid restating the entry verbatim.
 
-The Summary section at the top is mandatory. `Total entries = Reproduced bugs + Findings + No-severity dispositions`, and `Critical + High + Medium + Low = Reproduced bugs + Findings`.
+The Summary section at the top is mandatory. `Total entries = Reproduced bugs + Severity-bearing findings + No-severity dispositions`, and `Critical + High + Medium + Low = Reproduced bugs + Severity-bearing findings`.
 
 ## What NOT to do
 
@@ -101,16 +101,16 @@ The Summary section at the top is mandatory. `Total entries = Reproduced bugs + 
 - **Byzantine-only bugs**: in BFT systems, a bug exploitable only by a Byzantine node within the threat model is still High / Critical depending on impact. Honest-only failure modes typically rank lower.
 - **Liveness vs safety**: a liveness violation (deadlock, livelock, starvation) under realistic load is at least High. A safety violation is at least High (often Critical).
 - **Documented design vs bug**: if Phase 4a set `FALSE POSITIVE`, use `—`; if Phase 4a kept it `REPRODUCED`, classify on its actual impact and let Reasoning note the disagreement.
-- **Entry count mismatch**: if `confirmed-bugs.md` has 8 `## Bug N:` headers, the output table must have 8 rows. Preserve the input identifiers; do not silently repair the Phase 4 report.
+- **Entry count mismatch**: if `confirmed-bugs.md` has 8 `## Entry N:` headers, the output table must have 8 rows. Preserve the input identifiers; do not silently repair the Phase 4 report.
 
 ## Output validation checklist
 
 Before finishing, verify:
 
-- One row per `## Bug N:` header in `confirmed-bugs.md` (no missing, no extra).
+- One row per `## Entry N:` header in `confirmed-bugs.md` (no missing, no extra).
 - Every Severity is one of `Critical` / `High` / `Medium` / `Low` / `—`.
 - Every `REPRODUCED`, `ENV_LIMITED`, or `MASKED` row has a four-tier Severity.
 - Every `FALSE POSITIVE`, `NEEDS MORE INFO`, `DROPPED`, `PENDING REPAIR`, `DEFERRED`, or `INCOMPLETE` row has Severity `—`.
 - Every non-`—` Reasoning names at least one consequence (what goes wrong) and one surface (where it's triggerable from).
-- Summary entry classes add up to Total entries, and severity counts add up to reproduced bugs plus findings.
+- Summary entry classes add up to Total entries, and severity counts add up to reproduced bugs plus severity-bearing findings.
 - `confirmed-bugs.md` is unchanged (mtime not bumped, content not edited).

--- a/skills/workflow-overview.md
+++ b/skills/workflow-overview.md
@@ -152,7 +152,8 @@ After all applicable phases have run, assign a Report Tier (A/B/C) based on the 
 
 ### Output
 
-- `spec/confirmed-bugs.md` — Final report with reproduction results
+- `confirmed-bugs.md` — Final confirmation report with reproduction results and dispositions
+- `bug-severity.md` — Severity classification for the confirmation report
 - `repro/test_bug*` — Executable reproduction tests
 
 ---
@@ -184,6 +185,8 @@ Pauses when API usage exceeds threshold, waits for reset, resumes automatically.
 ├── analysis-report.md           # Phase 1
 ├── modeling-brief.md            # Phase 1 → Phase 2 handoff
 ├── .prompt-extra.md             # Target-specific instructions for pipeline agents
+├── confirmed-bugs.md            # Phase 4 final confirmation report
+├── bug-severity.md              # Phase 4b severity classification
 ├── spec/
 │   ├── base.tla + base.cfg     # Phase 2
 │   ├── MC.tla + MC.cfg         # Phase 2
@@ -191,7 +194,6 @@ Pauses when API usage exceeds threshold, waits for reset, resumes automatically.
 │   ├── Trace.tla + Trace.cfg   # Phase 2
 │   ├── instrumentation-spec.md # Phase 2
 │   ├── bug-report.md           # Phase 3
-│   ├── confirmed-bugs.md       # Phase 4
 │   ├── changelog.md            # Phase 3
 │   └── output/                 # TLC output files
 ├── harness/

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -311,7 +311,7 @@ class Outcome:
     rounds: int
     body: str  # initial A evidence plus any later A defenses
     rr: str | None = None  # assigned RR-NNN when status is PENDING REPAIR
-    bug_no: int = 0  # 1-based index in confirmed-bugs.md (the "## Bug N:" number)
+    bug_no: int = 0  # 1-based index in confirmed-bugs.md (the "## Entry N:" number)
     # Normalized phase return code for an INCOMPLETE outcome: 75 means the
     # scheduler may retry after rate limiting; 1 means a permanent/format/infra
     # failure. Canonical outcomes leave this at zero.
@@ -1699,8 +1699,10 @@ def _atomic_create_rr(path: Path, text: str) -> None:
         tmp.unlink(missing_ok=True)
 
 
-_REPORT_RR_ROW_RE = re.compile(r"(?m)^\|\s*(\d+)\s*\|\s*([^|\s]+)\s*\|\s*([^|]+?)\s*\|\s*$")
-_REPORT_DETAIL_RE = re.compile(r"(?m)^##\s+Bug\s+(\d+)\s*:")
+_REPORT_RR_ROW_RE = re.compile(
+    r"(?m)^\|\s*(\d+)\s*\|\s*([^|\s]+)\s*\|\s*([^|]+?)\s*\|(?:\s*[^|]*\s*\|)?\s*$"
+)
+_REPORT_DETAIL_RE = re.compile(r"(?m)^##\s+(?:Bug|Entry)\s+(\d+)\s*:")
 
 
 def _legacy_rr_report_identity(
@@ -1717,7 +1719,7 @@ def _legacy_rr_report_identity(
     independently name the same stable Finding ID. Anything less fails closed
     so switching confirmation modes cannot silently create a duplicate OPEN.
     """
-    report = cfg.ws.work_dir(cfg.name) / "spec" / "confirmed-bugs.md"
+    report = cfg.ws.work_dir(cfg.name) / "confirmed-bugs.md"
     if report.is_symlink():
         raise InvalidRepairRequest(f"cannot migrate legacy repair {rid}: confirmed-bugs.md is missing or unsafe")
     if not report.is_file():
@@ -1864,7 +1866,7 @@ def _ensure_rr_stable_identities(
 
 def validate_report_repair_references(cfg: ConfirmConfig) -> None:
     """Validate canonical report links against RR location and lifecycle state."""
-    report = cfg.ws.work_dir(cfg.name) / "spec" / "confirmed-bugs.md"
+    report = cfg.ws.work_dir(cfg.name) / "confirmed-bugs.md"
     if report.is_symlink() or not report.is_file():
         raise InvalidRepairRequest("confirmed-bugs.md is missing or unsafe")
     text = report.read_text()
@@ -1880,7 +1882,7 @@ def validate_report_repair_references(cfg: ConfirmConfig) -> None:
         if pending is None and deferred is None:
             if refs or rendered_status.startswith(("PENDING REPAIR", "DEFERRED")):
                 raise InvalidRepairRequest(
-                    f"report Bug {bug_no} has an RR reference with invalid status {rendered_status!r}"
+                    f"report Entry {bug_no} has an RR reference with invalid status {rendered_status!r}"
                 )
             continue
         match = pending or deferred
@@ -1897,7 +1899,7 @@ def validate_report_repair_references(cfg: ConfirmConfig) -> None:
             end = details[index + 1].start() if index + 1 < len(details) else len(text)
             detail_statuses.extend(re.findall(r"(?m)^- \*\*Status\*\*:\s*(.+?)\s*$", text[detail.end() : end]))
         if detail_statuses != [rendered_status]:
-            raise InvalidRepairRequest(f"report Bug {bug_no} table/detail repair status is inconsistent")
+            raise InvalidRepairRequest(f"report Entry {bug_no} table/detail repair status is inconsistent")
 
         matches = list(rr_dir.rglob(f"{rid}.md")) if rr_dir.is_dir() and not rr_dir.is_symlink() else []
         if len(matches) != 1:
@@ -2130,8 +2132,8 @@ def allocate_rr(cfg: ConfirmConfig, o: Outcome) -> str:
         nums = [int(m.group(1)) for p in rr_dir.rglob("RR-*.md") if (m := re.fullmatch(r"RR-(\d+)\.md", p.name))]
         next_num = max(nums, default=0) + 1
         cx = str(o.finding.data.get("counterexample") or "")
-        # bug_id points at the confirmed-bugs.md heading (## Bug N:) used by the
-        # report and ledger; finding_id separately preserves the stable raw id.
+        # bug_id is the legacy report display label used by the RR ledger;
+        # finding_id separately preserves the stable raw id.
         rid = f"RR-{next_num:03d}"
         merged = _merge_rr(
             rid,
@@ -2460,7 +2462,7 @@ def _report_body(body: str) -> str:
     for line in body.splitlines():
         if re.match(r"^\s*VERDICT\s*:", line, re.I):
             continue
-        if re.match(r"^##\s+Bug\s+\d+\s*:", line, re.I):
+        if re.match(r"^##\s+(?:Bug|Entry)\s+\d+\s*:", line, re.I):
             line = "\\" + line
         lines.append(line)
     return "\n".join(lines).strip()
@@ -2470,10 +2472,10 @@ def aggregate(cfg: ConfirmConfig, outcomes: list[Outcome]) -> None:
     """Write the phase's confirmed-bugs.md from the per-finding outcomes. This is
     the canonical Phase-4 deliverable the classification phase (Phase 4b) and the
     repair loop read; A/B isolation is handled by the run dir, not by a separate
-    filename. Headers are ``## Bug N:`` (integer N, table order) so Phase 4b's
-    "one row per ``## Bug N:`` header" parsing aligns; the finding id (MC-1 / CR-2)
-    is carried as a body field and a table column."""
-    report = cfg.ws.work_dir(cfg.name) / "spec" / "confirmed-bugs.md"
+    filename. Headers are ``## Entry N:`` (integer N, table order) so Phase 4b's
+    "one row per entry header" parsing aligns; the finding id (MC-1 / CR-2) is
+    carried as a body field and a table column."""
+    report = cfg.ws.work_dir(cfg.name) / "confirmed-bugs.md"
 
     def effective_status(outcome: Outcome) -> str:
         if outcome.status != "PENDING REPAIR" or outcome.rr is None:
@@ -2503,9 +2505,9 @@ def aggregate(cfg: ConfirmConfig, outcomes: list[Outcome]) -> None:
     env_limited = [o for o, status in effective if status == "ENV_LIMITED"]
     masked = [o for o, status in effective if status == "MASKED"]
 
-    lines = [f"# Confirmed Bugs — {cfg.name}", ""]
+    lines = [f"# Confirmation Report — {cfg.name}", "", "## Final Result", ""]
     split = (
-        f"Reproduced: {len(reproduced)} = {n_new} NEW + {n_known_unfixed} KNOWN-unfixed"
+        f"Reproduced bugs: {len(reproduced)} = {n_new} NEW + {n_known_unfixed} KNOWN-unfixed"
         f" + {n_known_fixed} KNOWN-fixed + {n_unknown} UNKNOWN"
     )
     lines.append(split)
@@ -2513,7 +2515,15 @@ def aggregate(cfg: ConfirmConfig, outcomes: list[Outcome]) -> None:
     # only triggerable in production (env-limited), or a real anomaly whose
     # consequence a safeguard currently masks. Reported separately so they are
     # neither miscounted as bugs nor lost as false positives.
-    lines.append(f"Findings: {len(env_limited) + len(masked)} = {len(env_limited)} env-limited + {len(masked)} masked")
+    lines.append(f"Masked live findings: {len(masked)}")
+    lines.append(f"Env-limited findings: {len(env_limited)}")
+    lines.append(f"False positives: {status_counts['FALSE POSITIVE']}")
+    lines.append(f"Dropped: {status_counts['DROPPED']}")
+    lines.append(f"Needs more info: {status_counts['NEEDS MORE INFO']}")
+    lines.append(f"Pending repair: {status_counts['PENDING REPAIR']}")
+    lines.append(f"Incomplete: {len(incomplete)}")
+    lines.append(f"Deferred: {deferred_count}")
+    lines.append(f"Total disposition entries: {len(outcomes)}")
     lines.append(
         f"Dispositions: {len(outcomes)} total = {status_counts['REPRODUCED']} reproduced"
         f" + {status_counts['ENV_LIMITED']} env-limited + {status_counts['MASKED']} masked"
@@ -2522,15 +2532,16 @@ def aggregate(cfg: ConfirmConfig, outcomes: list[Outcome]) -> None:
         f" + {len(incomplete)} incomplete + {deferred_count} deferred"
     )
     lines.append("")
-    lines.append("| Bug | Finding | Status |")
-    lines.append("|---|---|---|")
+    lines.append("| Entry | Finding | Status | Counts as final bug? |")
+    lines.append("|---|---|---|---|")
     for o, status in effective:
         if status == "DEFERRED":
             rendered_status = f"DEFERRED (repair loop exhausted; {o.rr} in deferred/)"
         else:
             rr = f" ({o.rr})" if o.rr else ""
             rendered_status = f"{status}{rr}"
-        lines.append(f"| {o.bug_no} | {o.finding.id} | {rendered_status} |")
+        counts = "yes" if status == "REPRODUCED" else "no"
+        lines.append(f"| {o.bug_no} | {o.finding.id} | {rendered_status} | {counts} |")
     lines.append("")
     for o, status in effective:
         if status == "DEFERRED":
@@ -2539,7 +2550,7 @@ def aggregate(cfg: ConfirmConfig, outcomes: list[Outcome]) -> None:
             rr = f" ({o.rr})" if o.rr else ""
             rendered_status = f"{status}{rr}"
         title = re.sub(r"[\r\n]+", " ", str(o.finding.data.get("title", ""))).strip()
-        lines.append(f"## Bug {o.bug_no}: {title}")
+        lines.append(f"## Entry {o.bug_no}: {title}")
         lines.append("")
         lines.append(f"- **Finding ID**: {o.finding.id}")
         lines.append(f"- **Status**: {rendered_status}")
@@ -2613,12 +2624,17 @@ def run_parallel_confirmation(cfg: ConfirmConfig, *, retain_rate_limited_state: 
 
 def _withhold(cfg: ConfirmConfig, reason: str, code: int = 1) -> int:
     """Remove a stale deliverable and return an actionable failure code."""
-    report = cfg.ws.work_dir(cfg.name) / "spec" / "confirmed-bugs.md"
-    if not cfg.dry_run and report.is_file():
-        try:
-            report.unlink()
-        except OSError as exc:
-            print(f"failed to remove stale {report}: {exc}", flush=True)
+    reports = [
+        cfg.ws.work_dir(cfg.name) / "confirmed-bugs.md",
+        cfg.ws.work_dir(cfg.name) / "spec" / "confirmed-bugs.md",
+    ]
+    if not cfg.dry_run:
+        for report in reports:
+            if report.is_file():
+                try:
+                    report.unlink()
+                except OSError as exc:
+                    print(f"failed to remove stale {report}: {exc}", flush=True)
     try:
         _log(reason)
     except OSError:
@@ -2779,7 +2795,7 @@ def _drive_confirmation(cfg: ConfirmConfig) -> int:
     order = {f.id: i for i, f in enumerate(findings)}
     outcomes.sort(key=lambda o: order[o.finding.id])
     for i, o in enumerate(outcomes, 1):
-        o.bug_no = i  # the "## Bug N:" number, in table order (drives aggregate + the RR bug_id)
+        o.bug_no = i  # the "## Entry N:" number, in table order (drives aggregate + the RR bug_id)
     try:
         for o in outcomes:
             if o.status.startswith("PENDING REPAIR") and o.rr is None and not cfg.dry_run:

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -1700,7 +1700,8 @@ def _atomic_create_rr(path: Path, text: str) -> None:
 
 
 _REPORT_RR_ROW_RE = re.compile(
-    r"(?m)^\|\s*(\d+)\s*\|\s*([^|\s]+)\s*\|\s*([^|]+?)\s*\|(?:\s*[^|]*\s*\|)?\s*$"
+    r"(?m)^\|\s*(\d+)\s*\|\s*([^|\s]+)\s*\|\s*([^|]+?)\s*\|"
+    r"(?:\s*[^|]*\s*\|)?\s*$"
 )
 _REPORT_DETAIL_RE = re.compile(r"(?m)^##\s+(?:Bug|Entry)\s+(\d+)\s*:")
 

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -1826,7 +1826,7 @@ Options:
   --effort=LEVEL      Reasoning effort forwarded to the selected adapter
 
 Prerequisites:
-  - Confirmed bug report at <name>/spec/confirmed-bugs.md (from Phase 4a)
+  - Confirmed bug report at <name>/confirmed-bugs.md (from Phase 4a)
 
 """
     check_header = "Checking prerequisites..."
@@ -1834,14 +1834,14 @@ Prerequisites:
     accepts_artifact = False  # this launcher takes no --artifact
     artifact_rejection_message = (
         "ERROR: classify does not accept --artifact; this phase reads the existing "
-        ".specula-output/spec/confirmed-bugs.md and does not inspect source code."
+        ".specula-output/confirmed-bugs.md and does not inspect source code."
     )
     dry_prompt_flag = "--prompt-file"  # its dry-run line shows --prompt-file=<prompt>
 
     def check(self, ws: Workspace, names: list[str]) -> bool:
         ok = True
         for name in names:
-            cb = ws.work_dir(name) / "spec" / "confirmed-bugs.md"
+            cb = ws.work_dir(name) / "confirmed-bugs.md"
             line = f"  {name:<20}"
             if cb.is_file() and cb.stat().st_size > 0:
                 line += "confirmed-bugs OK"
@@ -1863,18 +1863,18 @@ Prerequisites:
     def build_prompt(self, ws: Workspace, target: str) -> str:
         # NOTE: bash bug_classification generate_prompt does NOT inject .prompt-extra.
         name = self.target_name(target)
-        spec_dir = ws.work_dir(name) / "spec"
+        wd = ws.work_dir(name)
         return f"""# Bug Classification Task: {name}
 
 You are classifying the Phase 4 entries for **{name}**.
 
 ## Input
 
-- **Confirmed bug report (from Phase 4a)**: {spec_dir}/confirmed-bugs.md
+- **Confirmed bug report (from Phase 4a)**: {wd}/confirmed-bugs.md
 
 ## Output
 
-- **Severity classification**: {spec_dir}/bug-severity.md (you create this file)
+- **Severity classification**: {wd}/bug-severity.md (you create this file)
 
 ## Methodology
 
@@ -1889,12 +1889,12 @@ Do everything the skill specifies. Do not add, relax, or override any step here.
         print(" Results")
         print("========================================")
         for name in names:
-            report = ws.work_dir(name) / "spec" / "bug-severity.md"
+            report = ws.work_dir(name) / "bug-severity.md"
             if report.is_file() and report.stat().st_size > 0:
                 text = report.read_text(errors="replace")  # bash grep is byte-safe
                 total = _grep_num(text, "- Total entries:")
                 bugs = _grep_num(text, "- Reproduced bugs:")
-                findings = _grep_num(text, "- Findings:")
+                findings = _grep_num(text, "- Severity-bearing findings:")
                 critical = _grep_num(text, "- Critical:")
                 high = _grep_num(text, "- High:")
                 medium = _grep_num(text, "- Medium:")
@@ -2397,7 +2397,7 @@ Prerequisites:
             repo=repo_dir,
             spec_dir=str(spec_dir),
             repro_dir=str(wd / "repro"),
-            report=str(spec_dir / "confirmed-bugs.md"),
+            report=str(wd / "confirmed-bugs.md"),
             bug_confirmation_skill=prompt_skill_ids("bug-confirmation"),
         )
         return self._with_extra(ws, name, prompt)
@@ -2409,7 +2409,7 @@ Prerequisites:
         print("========================================")
         for name in names:
             wd = ws.work_dir(name)
-            report = wd / "spec" / "confirmed-bugs.md"
+            report = wd / "confirmed-bugs.md"
             repro_dir = wd / "repro"
             repro_count = len([p for p in repro_dir.rglob("test_bug*") if p.is_file()]) if repro_dir.is_dir() else 0
             if report.is_file() and report.stat().st_size > 0:

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -1227,7 +1227,7 @@ class Pipeline:
         in_table = False
         for line in text.splitlines():
             cells = line.split("|")
-            if len(cells) >= 5 and cells[1].strip() == "Bug" and cells[3].strip() == "Status":
+            if len(cells) >= 5 and cells[1].strip() in {"Bug", "Entry"} and cells[3].strip() == "Status":
                 in_table = True
                 continue
             if not in_table:
@@ -1274,7 +1274,7 @@ class Pipeline:
                     self._atomic_replace_text(f, text)
                     log(f"  reconciled legacy deferred status: {f}")
 
-            report = Path(self.get_work_dir(n)) / "spec" / "confirmed-bugs.md"
+            report = Path(self.get_work_dir(n)) / "confirmed-bugs.md"
             if not report.is_file():
                 continue
             old_text = report.read_text()
@@ -1736,7 +1736,7 @@ class Pipeline:
         if self.dry_run:
             return
         for n in self.extract_names():
-            cb = Path(self.get_work_dir(n)) / "spec" / "confirmed-bugs.md"
+            cb = Path(self.get_work_dir(n)) / "confirmed-bugs.md"
             if cb.is_file():
                 (cb.parent / f"confirmed-bugs-round-{round_}.md").write_text(cb.read_text())
 
@@ -1852,7 +1852,7 @@ class Pipeline:
 
             out.append(self._review_line("Validation Review", spec_dir / "review-validation.md"))
 
-            confirmed = spec_dir / "confirmed-bugs.md"
+            confirmed = work_dir / "confirmed-bugs.md"
             if confirmed.is_file() and confirmed.stat().st_size > 0:
                 out.append(f"- **Phase 4a (Bug Confirmation)**: confirmed-bugs.md written ({_wc_l(confirmed)} lines)")
             elif confirmed.is_file():
@@ -1878,7 +1878,7 @@ class Pipeline:
                     line += f", {rr_invalid} invalid"
                 out.append(line)
 
-            severity = spec_dir / "bug-severity.md"
+            severity = work_dir / "bug-severity.md"
             if severity.is_file() and severity.stat().st_size > 0:
                 out.append(f"- **Phase 4b (Bug Classification)**: bug-severity.md written ({_wc_l(severity)} lines)")
             elif severity.is_file():

--- a/src/specula/prompts/confirmation/orchestrate.md
+++ b/src/specula/prompts/confirmation/orchestrate.md
@@ -38,9 +38,9 @@ Never let an individual finding allocate while it is being investigated.
 
 Every published RR MUST contain `finding_id: <candidate-id>` copied exactly from
 that candidate's stable input `id`. This is the request's immutable identity.
-`bug_id: Bug N` is only the current report display label and MUST NOT be used to
+`bug_id: Bug N` is only the legacy report display label and MUST NOT be used to
 identify or reuse a request; it may change when candidates are reordered. Before
-publishing, cross-check that the table row, `## Bug N` detail, RR link, and
+publishing, cross-check that the table row, `## Entry N` detail, RR link, and
 `finding_id` all refer to the same candidate. If that cannot be proved, do not
 publish the request or silently allocate another id; mark the entry `INCOMPLETE`.
 
@@ -65,11 +65,20 @@ Write every finding's entry to {{report}} (one `repro/` test per non-dropped
 finding under {{repro_dir}}). The report is consumed by Phase 4b and the repair
 loop, so use this canonical structure exactly:
 
-- `Reproduced: <N> = <NEW> NEW + <KU> KNOWN-unfixed + <KF> KNOWN-fixed + <U> UNKNOWN`
-- `Findings: <N> = <E> env-limited + <M> masked`
+- Title `# Confirmation Report — <case>`, then `## Final Result`
+- `Reproduced bugs: <N> = <NEW> NEW + <KU> KNOWN-unfixed + <KF> KNOWN-fixed + <U> UNKNOWN`
+- `Masked live findings: <M>`
+- `Env-limited findings: <E>`
+- `False positives: <FP>`
+- `Dropped: <D>`
+- `Needs more info: <NMI>`
+- `Pending repair: <PR>`
+- `Incomplete: <I>`
+- `Deferred: <DEF>`
+- `Total disposition entries: <N>`
 - `Dispositions: <N> total = <R> reproduced + <E> env-limited + <M> masked + <FP> false-positive + <NMI> needs-more-info + <D> dropped + <PR> pending-repair + <I> incomplete + <DEF> deferred`
-- A table headed exactly `| Bug | Finding | Status |`, followed by one row per entry.
-- One detail section per table row, headed `## Bug N: <title>`. Number sections consecutively from 1, keep table and section order identical, and emit exactly one row and one section for each entry.
+- A table headed exactly `| Entry | Finding | Status | Counts as final bug? |`, followed by one row per entry.
+- One detail section per table row, headed `## Entry N: <title>`. Number sections consecutively from 1, keep table and section order identical, and emit exactly one row and one section for each entry.
 
 Use zero for absent disposition categories; never omit `incomplete` or `deferred`
 from the `Dispositions:` line.

--- a/src/specula/stop_gate.py
+++ b/src/specula/stop_gate.py
@@ -66,7 +66,7 @@ STATE_DIRNAME = ".stop-gate"
 # background-job check above applies to every phase regardless.
 CONTRACTS: dict[str, str] = {
     "spec_validation": "spec/bug-report.md",
-    "bug_confirmation": "spec/confirmed-bugs.md",
+    "bug_confirmation": "confirmed-bugs.md",
 }
 
 # Where an agent may declare it cannot finish (checked in order).

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -348,7 +348,7 @@ class TestDriver(ConfirmCase):
         with mock.patch.object(C, "run_agent_blocking", _fake_turn(_response("FALSE POSITIVE"))):
             rc = C.run_parallel_confirmation(self.cfg(ws, "T"))
         self.assertEqual(rc, 0)
-        cb = ws.work_dir("T") / "spec" / "confirmed-bugs.md"
+        cb = ws.work_dir("T") / "confirmed-bugs.md"
         self.assertTrue(cb.is_file() and cb.stat().st_size > 0)
 
     def test_configured_max_parallel_reaches_executor(self) -> None:
@@ -416,7 +416,7 @@ class TestDriver(ConfirmCase):
 
         self.assertEqual(rc, 75)
         self.assertEqual(calls, ["MC-1"])
-        report = (ws.work_dir("T") / "spec" / "confirmed-bugs.md").read_text()
+        report = (ws.work_dir("T") / "confirmed-bugs.md").read_text()
         self.assertIn("| 2 | MC-2 | INCOMPLETE |", report)
         self.assertIn("not started because another finding was rate-limited", report)
         self.assertIn("| 3 | MC-3 | NEEDS MORE INFO |", report)
@@ -468,7 +468,7 @@ class TestDriver(ConfirmCase):
 
         self.assertEqual(rc, 75)
         self.assertEqual(set(calls), {"MC-1", "MC-2"})
-        report = (ws.work_dir("T") / "spec" / "confirmed-bugs.md").read_text()
+        report = (ws.work_dir("T") / "confirmed-bugs.md").read_text()
         self.assertIn("| 2 | MC-2 | NEEDS MORE INFO |", report)
         self.assertIn("| 3 | MC-3 | INCOMPLETE |", report)
         self.assertIn("| 4 | MC-4 | INCOMPLETE |", report)
@@ -483,7 +483,7 @@ class TestDriver(ConfirmCase):
         with mock.patch.object(C, "run_agent_blocking", _fake_turn("", rc=75)):
             rc = C.run_parallel_confirmation(self.cfg(ws, "T"))
         self.assertEqual(rc, 75)
-        cb = ws.work_dir("T") / "spec" / "confirmed-bugs.md"
+        cb = ws.work_dir("T") / "confirmed-bugs.md"
         self.assertTrue(cb.is_file())  # delivered, not withheld
         self.assertIn("INCOMPLETE", cb.read_text())
         self.assertFalse((ws.work_dir("T") / "confirmation" / "MC-1" / "verdict.json").is_file())  # not cached
@@ -501,7 +501,7 @@ class TestDriver(ConfirmCase):
         # A prior run's confirmed-bugs.md is overwritten by the fresh (partial) report
         # rather than left stale: the rate-limited finding shows up as INCOMPLETE.
         ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
-        stale = ws.work_dir("T") / "spec" / "confirmed-bugs.md"
+        stale = ws.work_dir("T") / "confirmed-bugs.md"
         stale.write_text("# STALE REPORT from a prior run\n")
         with mock.patch.object(C, "run_agent_blocking", _fake_turn("", rc=75)):
             rc = C.run_parallel_confirmation(self.cfg(ws, "T"))
@@ -929,11 +929,11 @@ class TestDriver(ConfirmCase):
         # yields no valid candidates.json must withhold and return failure.
         ws = Workspace(["T"])
         (ws.work_dir("T") / "spec").mkdir(parents=True, exist_ok=True)
-        (ws.work_dir("T") / "spec" / "confirmed-bugs.md").write_text("# stale\n")
+        (ws.work_dir("T") / "confirmed-bugs.md").write_text("# stale\n")
         with mock.patch.object(C, "run_agent_blocking", _fake_turn("", rc=1)):
             rc = C.run_parallel_confirmation(self.cfg(ws, "T"))
         self.assertEqual(rc, 1)
-        self.assertFalse((ws.work_dir("T") / "spec" / "confirmed-bugs.md").is_file())  # stale removed too
+        self.assertFalse((ws.work_dir("T") / "confirmed-bugs.md").is_file())  # stale removed too
 
     def test_mixed_failures_all_deliver_as_incomplete(self) -> None:
         # A permanent failure + a simultaneous rate limit no longer withhold; both
@@ -948,7 +948,7 @@ class TestDriver(ConfirmCase):
         with mock.patch.object(C, "run_agent_blocking", agent):
             rc = C.run_parallel_confirmation(self.cfg(ws, "T"))
         self.assertEqual(rc, 1)  # permanent failure wins over the simultaneous rate limit
-        cb = ws.work_dir("T") / "spec" / "confirmed-bugs.md"
+        cb = ws.work_dir("T") / "confirmed-bugs.md"
         self.assertTrue(cb.is_file())
         self.assertIn("2 incomplete", cb.read_text())  # both marked in the disposition summary
 
@@ -956,7 +956,7 @@ class TestDriver(ConfirmCase):
         # A _save_verdict failure (disk full) makes the finding INCOMPLETE and still
         # delivers the report — never discards it.
         ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
-        report = ws.work_dir("T") / "spec" / "confirmed-bugs.md"
+        report = ws.work_dir("T") / "confirmed-bugs.md"
         report.write_text("stale\n")
         with (
             mock.patch.object(C, "run_agent_blocking", _fake_turn(_response("FALSE POSITIVE"))),
@@ -990,7 +990,7 @@ class TestDriver(ConfirmCase):
         self.assertFalse((fdir / "repair-request.body.md").exists())
         rr = ws.work_dir("T") / "spec" / "repair-requests" / "RR-001.md"
         self.assertFalse(rr.exists())
-        self.assertIn("INCOMPLETE", (ws.work_dir("T") / "spec" / "confirmed-bugs.md").read_text())
+        self.assertIn("INCOMPLETE", (ws.work_dir("T") / "confirmed-bugs.md").read_text())
         self.assertFalse((fdir / "verdict.json").exists())
 
     def test_empty_pending_repair_draft_retries_once_then_is_incomplete(self) -> None:
@@ -1135,7 +1135,7 @@ class TestDriver(ConfirmCase):
             calls,
             ["# Confirm ONE finding: MC-1", "# Best-effort repair-draft correction: MC-1"],
         )
-        report = (ws.work_dir("T") / "spec" / "confirmed-bugs.md").read_text()
+        report = (ws.work_dir("T") / "confirmed-bugs.md").read_text()
         self.assertIn("| 1 | MC-1 | INCOMPLETE |", report)
         self.assertIn("| 2 | MC-2 | INCOMPLETE |", report)
         self.assertIn("not started because another finding was rate-limited", report)
@@ -1171,7 +1171,7 @@ class TestDriver(ConfirmCase):
 
     def test_log_tee_failure_does_not_block_stale_deliverable_cleanup(self) -> None:
         ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
-        report = ws.work_dir("T") / "spec" / "confirmed-bugs.md"
+        report = ws.work_dir("T") / "confirmed-bugs.md"
         report.write_text("stale\n")
         with mock.patch.object(C, "_log", side_effect=OSError("log disk full")):
             self.assertEqual(C.run_parallel_confirmation(self.cfg(ws, "T")), 1)
@@ -1216,7 +1216,7 @@ class TestDriver(ConfirmCase):
         with mock.patch.object(C, "run_agent_blocking", _boom):
             self.assertEqual(C.run_parallel_confirmation(self.cfg(ws, "T")), 0)
         self.assertEqual([p.name for p in rr_dir.glob("RR-*.md")], ["RR-001.md"])
-        self.assertIn("PENDING REPAIR (RR-001)", (spec / "confirmed-bugs.md").read_text())
+        self.assertIn("PENDING REPAIR (RR-001)", (spec.parent / "confirmed-bugs.md").read_text())
 
 
 class TestDebateGate(ConfirmCase):
@@ -1357,8 +1357,8 @@ class TestDebateGate(ConfirmCase):
         self.assertIn("Challenger verified the prior fix", outcome.body)
         outcome.bug_no = 1
         C.aggregate(cfg, [outcome])
-        report = (ws.work_dir("T") / "spec" / "confirmed-bugs.md").read_text()
-        self.assertIn("Reproduced: 1 = 0 NEW + 0 KNOWN-unfixed + 1 KNOWN-fixed + 0 UNKNOWN", report)
+        report = (ws.work_dir("T") / "confirmed-bugs.md").read_text()
+        self.assertIn("Reproduced bugs: 1 = 0 NEW + 0 KNOWN-unfixed + 1 KNOWN-fixed + 0 UNKNOWN", report)
 
 
 class TestAggregate(ConfirmCase):
@@ -1370,18 +1370,18 @@ class TestAggregate(ConfirmCase):
         )
         with mock.patch.object(C, "run_agent_blocking", runner):
             C.run_parallel_confirmation(self.cfg(ws, name))
-        return (ws.work_dir(name) / "spec" / "confirmed-bugs.md").read_text()
+        return (ws.work_dir(name) / "confirmed-bugs.md").read_text()
 
-    def test_heading_is_bug_n_not_finding_id(self) -> None:
+    def test_heading_is_entry_n_not_finding_id(self) -> None:
         cb = self._confirmed_bugs("- **Novelty**: NEW\nVERDICT: REPRODUCED")
-        self.assertIn("## Bug 1: the bug", cb)  # Phase 4b parses integer "## Bug N:"
+        self.assertIn("## Entry 1: the bug", cb)  # Phase 4b parses integer "## Entry N:"
         self.assertNotIn("## MC-1:", cb)
         self.assertIn("- **Finding ID**: MC-1", cb)  # id carried as a body field
         self.assertIn("| 1 | MC-1 |", cb)  # and a table column
 
     def test_novelty_split_counts_known_unfixed(self) -> None:
         cb = self._confirmed_bugs("- **Novelty**: KNOWN (cite: http://x; fix-status: unfixed)\nVERDICT: REPRODUCED")
-        self.assertIn("Reproduced: 1 = 0 NEW + 1 KNOWN-unfixed + 0 KNOWN-fixed + 0 UNKNOWN", cb)
+        self.assertIn("Reproduced bugs: 1 = 0 NEW + 1 KNOWN-unfixed + 0 KNOWN-fixed + 0 UNKNOWN", cb)
 
     def test_novelty_known_fixed_flagged_separately(self) -> None:
         cb = self._confirmed_bugs("- **Novelty**: KNOWN (cite: http://x; fix-status: fixed)\nVERDICT: REPRODUCED")
@@ -1390,17 +1390,19 @@ class TestAggregate(ConfirmCase):
 
     def test_missing_novelty_stays_unknown(self) -> None:
         cb = self._confirmed_bugs("VERDICT: REPRODUCED")
-        self.assertIn("Reproduced: 1 = 0 NEW + 0 KNOWN-unfixed + 0 KNOWN-fixed + 1 UNKNOWN", cb)
+        self.assertIn("Reproduced bugs: 1 = 0 NEW + 0 KNOWN-unfixed + 0 KNOWN-fixed + 1 UNKNOWN", cb)
 
     def test_masked_is_a_finding_not_a_reproduced_bug(self) -> None:
         cb = self._confirmed_bugs("VERDICT: MASKED")
-        self.assertIn("Reproduced: 0 = 0 NEW + 0 KNOWN-unfixed", cb)  # masked is NOT a bug
-        self.assertIn("Findings: 1 = 0 env-limited + 1 masked", cb)  # it is a finding
+        self.assertIn("Reproduced bugs: 0 = 0 NEW + 0 KNOWN-unfixed", cb)  # masked is NOT a bug
+        self.assertIn("Masked live findings: 1", cb)  # it is a finding
+        self.assertIn("Env-limited findings: 0", cb)
         self.assertIn("| 1 | MC-1 | MASKED |", cb)
 
     def test_env_limited_counted_as_finding(self) -> None:
         cb = self._confirmed_bugs("VERDICT: ENV_LIMITED")
-        self.assertIn("Findings: 1 = 1 env-limited + 0 masked", cb)
+        self.assertIn("Env-limited findings: 1", cb)
+        self.assertIn("Masked live findings: 0", cb)
 
     def test_disposition_summary_is_exhaustive(self) -> None:
         ws = self.seed("T", [])
@@ -1413,7 +1415,7 @@ class TestAggregate(ConfirmCase):
             )
             outcomes.append(C.Outcome(finding, status, True, 0, EVIDENCE, bug_no=index))
         C.aggregate(self.cfg(ws, "T"), outcomes)
-        report = (ws.work_dir("T") / "spec" / "confirmed-bugs.md").read_text()
+        report = (ws.work_dir("T") / "confirmed-bugs.md").read_text()
         self.assertIn(
             "Dispositions: 7 total = 1 reproduced + 1 env-limited + 1 masked + 1 false-positive "
             "+ 1 needs-more-info + 1 dropped + 1 pending-repair + 0 incomplete + 0 deferred",
@@ -1438,7 +1440,7 @@ class TestPromptExtraAndLog(ConfirmCase):
         self.assertIn("finding_id: <candidate-id>", prompt)
         self.assertIn("immutable identity", prompt)
         self.assertIn("bug_id: Bug N", prompt)
-        self.assertIn("only the current report display label", prompt)
+        self.assertIn("only the legacy report display label", prompt)
         self.assertIn("do not publish the request or silently allocate another id", re.sub(r"\s+", " ", prompt))
 
     def test_level_two_or_three_requires_positive_reachability_evidence(self) -> None:
@@ -1534,7 +1536,7 @@ class TestPromptExtraAndLog(ConfirmCase):
         o = C.Outcome(f, "PENDING REPAIR", True, 0, "body", bug_no=3)
         rid = C.allocate_rr(self.cfg(ws, "T"), o)
         rr = (ws.work_dir("T") / "spec" / "repair-requests" / f"{rid}.md").read_text()
-        self.assertIn("bug_id: Bug 3", rr)  # points at the "## Bug 3:" heading, not MC-1
+        self.assertIn("bug_id: Bug 3", rr)  # legacy display label, not the stable MC-1 id
 
 
 class TestCacheContracts(ConfirmCase):
@@ -1618,7 +1620,7 @@ class TestCacheContracts(ConfirmCase):
             (spec / "confirmation-generation.json").write_text('{"generation": 1}\n')
             self.assertEqual(C.run_parallel_confirmation(cfg), 0)
 
-        report = (spec / "confirmed-bugs.md").read_text()
+        report = (spec.parent / "confirmed-bugs.md").read_text()
         self.assertIn("MC-2", report)
         self.assertNotIn("MC-1", report)
         self.assertEqual(calls, ["consolidate", "MC-1", "consolidate", "MC-2"])
@@ -1815,7 +1817,7 @@ class TestCacheContracts(ConfirmCase):
 
         self.assertFalse(active.exists())
         self.assertEqual(list(rr_dir.rglob("RR-*.md")), [deferred])
-        report = (ws.work_dir("T") / "spec" / "confirmed-bugs.md").read_text()
+        report = (ws.work_dir("T") / "confirmed-bugs.md").read_text()
         self.assertIn("| 1 | MC-1 | DEFERRED (repair loop exhausted; RR-001 in deferred/) |", report)
         self.assertIn("+ 0 pending-repair + 0 incomplete + 1 deferred", report)
 
@@ -1933,11 +1935,11 @@ class TestCacheContracts(ConfirmCase):
 class TestValidationContracts(ConfirmCase):
     @staticmethod
     def _write_repair_report(spec: Path, status: str, *, bug_no: int = 1, finding_id: str = "MC-1") -> None:
-        (spec / "confirmed-bugs.md").write_text(
-            "| Bug | Finding | Status |\n"
-            "|---|---|---|\n"
-            f"| {bug_no} | {finding_id} | {status} |\n\n"
-            f"## Bug {bug_no}: one\n\n"
+        (spec.parent / "confirmed-bugs.md").write_text(
+            "| Entry | Finding | Status | Counts as final bug? |\n"
+            "|---|---|---|---|\n"
+            f"| {bug_no} | {finding_id} | {status} | no |\n\n"
+            f"## Entry {bug_no}: one\n\n"
             f"- **Finding ID**: {finding_id}\n"
             f"- **Status**: {status}\n"
         )
@@ -2060,7 +2062,7 @@ class TestValidationContracts(ConfirmCase):
         ]
         ws = self.seed("T", current)
         spec = ws.work_dir("T") / "spec"
-        (spec / "confirmed-bugs.md").write_text(
+        (spec.parent / "confirmed-bugs.md").write_text(
             "# Confirmed Bugs — T\n\n"
             "| Bug | Finding | Status |\n"
             "|---|---|---|\n"
@@ -2096,7 +2098,7 @@ class TestValidationContracts(ConfirmCase):
     def test_legacy_missing_identity_ignores_stale_bug_label_and_refreshes_it_from_report(self) -> None:
         ws = self.seed("T", [])
         spec = ws.work_dir("T") / "spec"
-        (spec / "confirmed-bugs.md").write_text(
+        (spec.parent / "confirmed-bugs.md").write_text(
             "| Bug | Finding | Status |\n"
             "|---|---|---|\n"
             "| 1 | MC-1 | PENDING REPAIR (RR-001) |\n\n"
@@ -2121,7 +2123,7 @@ class TestValidationContracts(ConfirmCase):
     def test_terminal_stable_identity_preserves_historical_bug_id_after_reorder(self) -> None:
         ws = self.seed("T", [])
         spec = ws.work_dir("T") / "spec"
-        (spec / "confirmed-bugs.md").write_text(
+        (spec.parent / "confirmed-bugs.md").write_text(
             "| Bug | Finding | Status |\n"
             "|---|---|---|\n"
             "| 2 | MC-1 | PENDING REPAIR (RR-001) |\n\n"
@@ -2229,7 +2231,7 @@ class TestValidationContracts(ConfirmCase):
     def test_report_validation_rejects_unlinked_active_request(self) -> None:
         ws = self.seed("T", [])
         spec = ws.work_dir("T") / "spec"
-        (spec / "confirmed-bugs.md").write_text(
+        (spec.parent / "confirmed-bugs.md").write_text(
             "| Bug | Finding | Status |\n|---|---|---|\n| 1 | MC-1 | FALSE POSITIVE |\n"
         )
         rr_dir = spec / "repair-requests"
@@ -2342,7 +2344,7 @@ class TestValidationContracts(ConfirmCase):
         data = {"id": "MC-1", "source": "model-checking", "title": "one", "summary": "s"}
         ws = self.seed("T", [data])
         spec = ws.work_dir("T") / "spec"
-        (spec / "confirmed-bugs.md").write_text(
+        (spec.parent / "confirmed-bugs.md").write_text(
             "# Confirmed Bugs — T\n\n"
             "| Bug | Finding | Status |\n"
             "|---|---|---|\n"
@@ -2366,8 +2368,8 @@ class TestValidationContracts(ConfirmCase):
         ):
             self.assertEqual(C.run_parallel_confirmation(self.cfg(ws, "T")), 1)
 
-        new_report = (spec / "confirmed-bugs.md").read_text()
-        self.assertIn("| 1 | MC-1 | FALSE POSITIVE |", new_report)
+        new_report = (spec.parent / "confirmed-bugs.md").read_text()
+        self.assertIn("| 1 | MC-1 | FALSE POSITIVE | no |", new_report)
         self.assertNotIn("RR-001", new_report)
         migrated = request.read_text()
         self.assertEqual(C._rr_field_text(migrated, "finding_id"), ["MC-1"])
@@ -2393,7 +2395,7 @@ class TestValidationContracts(ConfirmCase):
         with mock.patch.object(C, "consolidate", return_value=None):
             self.assertEqual(C.run_parallel_confirmation(self.cfg(ws, "T")), 1)
 
-        report = (spec / "confirmed-bugs.md").read_text()
+        report = (spec.parent / "confirmed-bugs.md").read_text()
         self.assertIn("Dispositions: 0 total", report)
         self.assertNotIn("RR-001", report)
 
@@ -2692,10 +2694,10 @@ class TestEvidenceAndRendering(ConfirmCase):
         f = self.finding(ws, "T")
         C.aggregate(
             self.cfg(ws, "T"),
-            [C.Outcome(f, "NEEDS MORE INFO", False, 0, "## Bug 99: injected\nVERDICT: REPRODUCED\nevidence")],
+            [C.Outcome(f, "NEEDS MORE INFO", False, 0, "## Entry 99: injected\nVERDICT: REPRODUCED\nevidence")],
         )
-        report = (ws.work_dir("T") / "spec" / "confirmed-bugs.md").read_text()
-        self.assertEqual(len(re.findall(r"^## Bug \d+:", report, re.MULTILINE)), 1)
+        report = (ws.work_dir("T") / "confirmed-bugs.md").read_text()
+        self.assertEqual(len(re.findall(r"^## Entry \d+:", report, re.MULTILINE)), 1)
         self.assertNotIn("VERDICT:", report)
         self.assertIn("- **Debate**: not run", report)
 

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -132,21 +132,21 @@ PHASES: list[PhaseSpec] = [
         "prompt": ".bug-confirmation-prompt.md",
         "flag": "--prompt",
         "skill": "bug-confirmation",
-        "out": "spec/confirmed-bugs.md",
+        "out": "confirmed-bugs.md",
     },
     {
         # the outlier: no --artifact (accepts_artifact=False) and its dry-run
         # line shows --prompt-file, not --prompt.
         "key": "bug_classification",
         "artifact": False,
-        "inputs": ["spec/confirmed-bugs.md"],
+        "inputs": ["confirmed-bugs.md"],
         "fail": "Run Phase 4a ('specula confirm') first.",
         "ok": "All prerequisites OK.",
         "log": "bug-classification.log",
         "prompt": ".bug-classification-prompt.md",
         "flag": "--prompt-file",
         "skill": "bug-classification",
-        "out": "spec/bug-severity.md",
+        "out": "bug-severity.md",
     },
 ]
 BY_KEY = {p["key"]: p for p in PHASES}
@@ -428,8 +428,8 @@ class TestDryRunCommand(PhaseCase):
         body = (self.work_dir() / ".bug-confirmation-prompt.md").read_text()
         self.assertIn("Dispositions: <N> total =", body)
         self.assertIn("<I> incomplete + <DEF> deferred", body)
-        self.assertIn("| Bug | Finding | Status |", body)
-        self.assertIn("## Bug N: <title>", body)
+        self.assertIn("| Entry | Finding | Status | Counts as final bug? |", body)
+        self.assertIn("## Entry N: <title>", body)
         self.assertIn("Number sections consecutively from 1", body)
         self.assertIn("exactly one row and one section for each entry", body)
 
@@ -454,7 +454,7 @@ class TestDryRunCommand(PhaseCase):
         self.assertNotIn("REPRODUCTION FAILED", guide)
         self.assertIn("- Total entries: N", guide)
         self.assertIn("- Reproduced bugs: N", guide)
-        self.assertIn("- Findings: N", guide)
+        self.assertIn("- Severity-bearing findings: N", guide)
         self.assertIn("- No-severity dispositions: N", guide)
 
     def test_confirmation_docs_have_no_recheck_pass_and_allow_deferred_terminal(self) -> None:
@@ -523,7 +523,7 @@ class TestDryRunCommand(PhaseCase):
         self.assertEqual(
             out,
             "ERROR: classify does not accept --artifact; this phase reads the existing "
-            ".specula-output/spec/confirmed-bugs.md and does not inspect source code.\n",
+            ".specula-output/confirmed-bugs.md and does not inspect source code.\n",
         )
 
 
@@ -789,7 +789,7 @@ class TestBugConfirmationAlternate(PhaseCase):
         self.patch_attr(phaselib.Phase, "_acceptance", lambda _self, _ws, _names: None)
 
         def fake_confirmation(cfg: confirmlib.ConfirmConfig, **_kwargs: object) -> int:
-            report = cfg.ws.work_dir(cfg.name) / "spec" / "confirmed-bugs.md"
+            report = cfg.ws.work_dir(cfg.name) / "confirmed-bugs.md"
             report.parent.mkdir(parents=True, exist_ok=True)
             report.write_text("# Confirmed Bugs\n")
             return 0
@@ -1153,7 +1153,7 @@ class TestLegacyRepairIdentityFinalization(PhaseCase):
         self.adapter.write_text(
             "#!/usr/bin/env sh\n"
             "set -eu\n"
-            'cp "$LEGACY_REPORT_FIXTURE" "$SPECULA_WORK_DIR/spec/confirmed-bugs.md"\n'
+            'cp "$LEGACY_REPORT_FIXTURE" "$SPECULA_WORK_DIR/confirmed-bugs.md"\n'
             'if [ "${LEGACY_NO_RR:-0}" != 1 ]; then\n'
             '  mkdir -p "$SPECULA_WORK_DIR/spec/repair-requests"\n'
             '  if [ "${LEGACY_DELETE_RR:-0}" = 1 ]; then rm -f "$SPECULA_WORK_DIR/spec/repair-requests/RR-001.md"; fi\n'
@@ -1348,7 +1348,7 @@ class TestLegacyRepairIdentityFinalization(PhaseCase):
         from specula import confirmlib
 
         work_spec = self.work_dir() / "spec"
-        (work_spec / "confirmed-bugs.md").write_text(
+        (work_spec.parent / "confirmed-bugs.md").write_text(
             "# Confirmed Bugs — footest\n\n"
             "| Bug | Finding | Status |\n"
             "|---|---|---|\n"
@@ -1398,7 +1398,7 @@ class TestLegacyRepairIdentityFinalization(PhaseCase):
 
         self.assertEqual(rc, 1, out)
         self.assertIn("RR-001 is OPEN but is not linked", out)
-        self.assertNotIn("RR-001", (work_spec / "confirmed-bugs.md").read_text())
+        self.assertNotIn("RR-001", (work_spec.parent / "confirmed-bugs.md").read_text())
         migrated = request.read_text()
         self.assertIn("finding_id: MC-1", migrated)
         self.assertRegex(migrated, r"(?m)^allocation_key: [0-9a-f]{64}$")
@@ -2589,7 +2589,7 @@ class TestSummarize(PhaseCase):
             "name": "bug_confirmation/repro-count",
             "phase": "bug_confirmation",
             "files": {
-                "spec/confirmed-bugs.md": "b1\nb2\n",
+                "confirmed-bugs.md": "b1\nb2\n",
                 "repro/test_bug1.py": "assert True\n",
                 "repro/nested/test_bug2.py": "assert True\n",
             },
@@ -2599,10 +2599,10 @@ class TestSummarize(PhaseCase):
             "name": "bug_classification/severity",
             "phase": "bug_classification",
             "files": {
-                "spec/bug-severity.md": (
+                "bug-severity.md": (
                     "- Total entries: 9\n"
                     "- Reproduced bugs: 2\n"
-                    "- Findings: 2\n"
+                    "- Severity-bearing findings: 2\n"
                     "- Critical: 1\n"
                     "- High: 1\n"
                     "- Medium: 1\n"

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -1578,7 +1578,7 @@ class TestRepairLoop(RRDirCase):
 
     def test_only_progress_followed_by_cap_defers(self) -> None:
         first = make_rr(self.rr_dir, "RR-1", "OPEN")
-        report = self.rr_dir.parent / "confirmed-bugs.md"
+        report = self.rr_dir.parent.parent / "confirmed-bugs.md"
         report.write_text("Status: PENDING REPAIR (RR-2)\n")
         self.p.max_repair_rounds = "1"
 
@@ -1690,11 +1690,11 @@ class TestDeferredMoves(RRDirCase):
         report = (
             "Dispositions: 3 total = 0 reproduced + 0 env-limited + 0 masked + 0 false-positive "
             "+ 0 needs-more-info + 0 dropped + 2 pending-repair + 1 incomplete + 0 deferred\n\n"
-            "| Bug | Finding | Status |\n"
-            "|---|---|---|\n"
-            "| 1 | MC-1 | DEFERRED (repair loop exhausted; RR-1 in deferred/) |\n"
-            "| 2 | MC-2 | PENDING REPAIR (RR-2) |\n"
-            "| 3 | MC-3 | INCOMPLETE |\n"
+            "| Entry | Finding | Status | Counts as final bug? |\n"
+            "|---|---|---|---|\n"
+            "| 1 | MC-1 | DEFERRED (repair loop exhausted; RR-1 in deferred/) | no |\n"
+            "| 2 | MC-2 | PENDING REPAIR (RR-2) | no |\n"
+            "| 3 | MC-3 | INCOMPLETE | no |\n"
         )
 
         reconciled = self.p._reconcile_disposition_counts(report)
@@ -1824,7 +1824,7 @@ class TestDeferredMoves(RRDirCase):
         deferred_dir = self.rr_dir / "deferred"
         deferred_dir.mkdir()
         request = make_rr(deferred_dir, "RR-1", "OPEN")
-        report = self.rr_dir.parent / "confirmed-bugs.md"
+        report = self.rr_dir.parent.parent / "confirmed-bugs.md"
         report.write_text(
             "# Confirmed Bugs\n\n"
             "Dispositions: 2 total = 0 reproduced + 0 env-limited + 0 masked + 0 false-positive "
@@ -1851,7 +1851,7 @@ class TestDeferredMoves(RRDirCase):
     def test_report_write_failure_is_recovered_on_next_startup(self) -> None:
         source = make_rr(self.rr_dir, "RR-1", "OPEN")
         destination = self.rr_dir / "deferred" / source.name
-        report = self.rr_dir.parent / "confirmed-bugs.md"
+        report = self.rr_dir.parent.parent / "confirmed-bugs.md"
         report.write_text(
             "Dispositions: 1 total = 0 reproduced + 0 env-limited + 0 masked + 0 false-positive "
             "+ 0 needs-more-info + 0 dropped + 1 pending-repair\n\n"


### PR DESCRIPTION
## Summary:
- write final confirmation and severity reports at the work-dir root
- relabel confirmation/severity tables around entries instead of bugs
- keep status counting and repair request semantics unchanged