### PR TITLE
Revise 'specula run' command usage examples

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -190,7 +190,7 @@ TLC workers remain unbounded by default: `-w auto` uses every CPU visible to eac
 Use a stable ID when a run may need to be resumed:
 
 ```bash
-specula run \
+specula run <name> \
   --run-id=my-run \
   --artifact=/path/to/source \
   "name|owner/repository|language|reference"
@@ -199,7 +199,7 @@ specula run \
 Attach to the same run and skip completed steps. This resumes at validation:
 
 ```bash
-specula run \
+specula run <name> \
   --run-id=my-run \
   --skip-analysis \
   --skip-specgen \


### PR DESCRIPTION
Updated usage examples for the 'specula run' command to clarify options for resuming runs and skipping completed steps.