### PR TITLE
Fix skip validate flag and repair status validation

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -280,12 +280,12 @@ specula run [options] "name|owner/repository|language|reference"
 | `--enable-reviews` | Enable reviews between steps |
 | `--legacy-confirm` | Use one confirmation agent instead of per-finding agents |
 | `--skip-analysis`, `--skip-specgen`, `--skip-harness` | Reuse earlier outputs |
-| `--skip-validation`, `--skip-confirmation`, `--skip-classification` | Reuse later outputs |
+| `--skip-validate`, `--skip-confirmation`, `--skip-classification` | Reuse later outputs |
 | `--confirm-debate` | Add the adversarial confirmation debate in parallel Phase 4 mode |
 | `--skip-repair-loop` | Disable the confirmation back-edge repair loop |
 | `--max-repair-rounds=N` | Set the global repair-loop round cap (default `10`; `0` means unlimited) |
 | `--skip-analysis`, `--skip-specgen`, `--skip-harness` | Reuse early-phase outputs |
-| `--skip-validation`, `--skip-confirmation`, `--skip-classification` | Reuse later-phase outputs |
+| `--skip-validate`, `--skip-confirmation`, `--skip-classification` | Reuse later-phase outputs |
 | `--run-id=ID` | Create or attach to an isolated run |
 | `--no-isolate` | Use the legacy output layout described above |
 

--- a/skills/workflow-overview.md
+++ b/skills/workflow-overview.md
@@ -166,7 +166,7 @@ After all applicable phases have run, assign a Report Tier (A/B/C) based on the 
 bash scripts/launch/launch_pipeline.sh "system-name|github/repo|Lang|Reference description"
 ```
 
-Options: `--skip-analysis`, `--skip-specgen`, `--skip-harness`, `--skip-validation`, `--max-parallel=N`, `--policy-retries=N`
+Options: `--skip-analysis`, `--skip-specgen`, `--skip-harness`, `--skip-validate`, `--max-parallel=N`, `--policy-retries=N`
 
 ### Scheduler (with quota monitoring)
 

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -1791,6 +1791,16 @@ _REPORT_RR_ROW_RE = re.compile(
     r"(?:\s*[^|]*\s*\|)?\s*$"
 )
 _REPORT_DETAIL_RE = re.compile(r"(?m)^##\s+(?:Bug|Entry)\s+(\d+)\s*:")
+_REPORT_STATUS_FIELD_RE = re.compile(r"^\s*-\s*\*\*Status\*\*:", re.I)
+
+
+def _report_repair_status_key(status: str, rid: str) -> str | None:
+    status = status.strip()
+    if status in {"PENDING REPAIR", f"PENDING REPAIR ({rid})"}:
+        return "PENDING REPAIR"
+    if status in {"DEFERRED", f"DEFERRED (repair loop exhausted; {rid} in deferred/)"}:
+        return "DEFERRED"
+    return None
 
 
 def _legacy_rr_report_identity(
@@ -1986,7 +1996,10 @@ def validate_report_repair_references(cfg: ConfirmConfig) -> None:
                 continue
             end = details[index + 1].start() if index + 1 < len(details) else len(text)
             detail_statuses.extend(re.findall(r"(?m)^- \*\*Status\*\*:\s*(.+?)\s*$", text[detail.end() : end]))
-        if detail_statuses != [rendered_status]:
+        rendered_key = _report_repair_status_key(rendered_status, rid)
+        if not detail_statuses or any(
+            _report_repair_status_key(status, rid) != rendered_key for status in detail_statuses
+        ):
             raise InvalidRepairRequest(f"report Entry {bug_no} table/detail repair status is inconsistent")
 
         matches = list(rr_dir.rglob(f"{rid}.md")) if rr_dir.is_dir() and not rr_dir.is_symlink() else []
@@ -2552,6 +2565,8 @@ def _report_body(body: str) -> str:
     lines: list[str] = []
     for line in body.splitlines():
         if re.match(r"^\s*VERDICT\s*:", line, re.I):
+            continue
+        if _REPORT_STATUS_FIELD_RE.match(line):
             continue
         if re.match(r"^##\s+(?:Bug|Entry)\s+\d+\s*:", line, re.I):
             line = "\\" + line

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -112,7 +112,7 @@ Options:
   --skip-analysis        Skip code analysis (use existing outputs)
   --skip-specgen         Skip spec generation (use existing outputs)
   --skip-harness         Skip harness generation (use existing harness/traces)
-  --skip-validation      Skip validation
+  --skip-validate        Skip validation
   --skip-confirmation    Skip Phase 4a bug confirmation
   --skip-classification  Skip Phase 4b severity classification
   --skip-repair-loop     Skip the confirmation back-edge repair loop (default: enabled)
@@ -352,7 +352,7 @@ class Pipeline:
                 self.skip_specgen = True
             elif arg == "--skip-harness":
                 self.skip_harness = True
-            elif arg == "--skip-validation":
+            elif arg == "--skip-validate":
                 self.skip_validation = True
             elif arg == "--skip-confirmation":
                 self.skip_confirmation = True
@@ -2186,7 +2186,7 @@ class Pipeline:
             source = "resumed repair loop" if resumed_repair else "recovered committed repairs"
             log(f"Ordinary Phase 3 covered for every target by the {source}")
         else:
-            log("Skipping Phase 3 (--skip-validation)")
+            log("Skipping Phase 3 (--skip-validate)")
 
         phase4_covered = resumed_repair and not normal_phase3_ran
         fresh_phase4_ran = False

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -219,7 +219,7 @@ class CliE2E(unittest.TestCase):
             "--skip-analysis",
             "--skip-specgen",
             "--skip-harness",
-            "--skip-validation",
+            "--skip-validate",
             "--skip-confirmation",
             "--skip-classification",
             "--skip-repair-loop",

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -1844,7 +1844,14 @@ class TestCacheContracts(ConfirmCase):
         output.write_text("trace\n")
         f.fdir.mkdir(parents=True, exist_ok=True)
         (f.fdir / "repair-request.body.md").write_text(TestMergeRR.AGENT_BODY)
-        pending = C.Outcome(f, "PENDING REPAIR", True, 0, EVIDENCE, bug_no=1)
+        pending = C.Outcome(
+            f,
+            "PENDING REPAIR",
+            True,
+            0,
+            f"{EVIDENCE}\n- **Status**: PENDING REPAIR",
+            bug_no=1,
+        )
         pending.rr = C.allocate_rr(cfg, pending)
         C._save_verdict(pending, cfg)
         self.assertIsNotNone(C._load_verdict(f, cfg))
@@ -1887,6 +1894,7 @@ class TestCacheContracts(ConfirmCase):
         self.assertEqual(list(rr_dir.rglob("RR-*.md")), [deferred])
         report = (ws.work_dir("T") / "confirmed-bugs.md").read_text()
         self.assertIn("| 1 | MC-1 | DEFERRED (repair loop exhausted; RR-001 in deferred/) |", report)
+        self.assertNotIn("- **Status**: PENDING REPAIR", report)
         self.assertIn("+ 0 pending-repair + 0 incomplete + 1 deferred", report)
 
         terminal_bytes = deferred.read_bytes()
@@ -2002,14 +2010,24 @@ class TestCacheContracts(ConfirmCase):
 
 class TestValidationContracts(ConfirmCase):
     @staticmethod
-    def _write_repair_report(spec: Path, status: str, *, bug_no: int = 1, finding_id: str = "MC-1") -> None:
+    def _write_repair_report(
+        spec: Path,
+        status: str,
+        *,
+        bug_no: int = 1,
+        finding_id: str = "MC-1",
+        extra_detail_statuses: tuple[str, ...] = (),
+    ) -> None:
+        detail_statuses = "\n".join(f"- **Status**: {extra}" for extra in extra_detail_statuses)
+        if detail_statuses:
+            detail_statuses = f"\n{detail_statuses}"
         (spec.parent / "confirmed-bugs.md").write_text(
             "| Entry | Finding | Status | Counts as final bug? |\n"
             "|---|---|---|---|\n"
             f"| {bug_no} | {finding_id} | {status} | no |\n\n"
             f"## Entry {bug_no}: one\n\n"
             f"- **Finding ID**: {finding_id}\n"
-            f"- **Status**: {status}\n"
+            f"- **Status**: {status}{detail_statuses}\n"
         )
 
     def test_structural_hygiene_still_enforced(self) -> None:
@@ -2349,6 +2367,45 @@ class TestValidationContracts(ConfirmCase):
                 )
             )
         with self.assertRaisesRegex(C.InvalidRepairRequest, "RR-001 resolves to 2 files"):
+            C.validate_report_repair_references(self.cfg(ws, "T"))
+
+    def test_report_pending_reference_allows_duplicate_bare_detail_status(self) -> None:
+        ws = self.seed("T", [])
+        spec = ws.work_dir("T") / "spec"
+        self._write_repair_report(spec, "PENDING REPAIR (RR-001)", extra_detail_statuses=("PENDING REPAIR",))
+        rr_dir = spec / "repair-requests"
+        rr_dir.mkdir()
+        (rr_dir / "RR-001.md").write_text(
+            C._merge_rr(
+                "RR-001",
+                "Bug 1",
+                "fallback.out",
+                TestMergeRR.AGENT_BODY,
+                finding_id="MC-1",
+                allocation_key="key",
+            )
+        )
+
+        C.validate_report_repair_references(self.cfg(ws, "T"))
+
+    def test_report_pending_reference_rejects_conflicting_detail_status(self) -> None:
+        ws = self.seed("T", [])
+        spec = ws.work_dir("T") / "spec"
+        self._write_repair_report(spec, "PENDING REPAIR (RR-001)", extra_detail_statuses=("FALSE POSITIVE",))
+        rr_dir = spec / "repair-requests"
+        rr_dir.mkdir()
+        (rr_dir / "RR-001.md").write_text(
+            C._merge_rr(
+                "RR-001",
+                "Bug 1",
+                "fallback.out",
+                TestMergeRR.AGENT_BODY,
+                finding_id="MC-1",
+                allocation_key="key",
+            )
+        )
+
+        with self.assertRaisesRegex(C.InvalidRepairRequest, "table/detail repair status is inconsistent"):
             C.validate_report_repair_references(self.cfg(ws, "T"))
 
     def test_report_deferred_reference_requires_deferred_file_and_status(self) -> None:

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -541,6 +541,7 @@ class TestParsing(TmpCwd):
         rc = p.parse_args(
             [
                 "--skip-analysis",
+                "--skip-validate",
                 "--skip-repair-loop",
                 "--max-repair-rounds=2",
                 "--max-parallel=4",
@@ -553,6 +554,7 @@ class TestParsing(TmpCwd):
         )
         self.assertIsNone(rc)
         self.assertTrue(p.skip_analysis)
+        self.assertTrue(p.skip_validation)
         self.assertTrue(p.skip_repair_loop)
         self.assertEqual(p.max_repair_rounds, "2")
         self.assertEqual(p.max_parallel, "4")
@@ -794,6 +796,12 @@ class TestParsing(TmpCwd):
         self.assertEqual(rc, 1)
         self.assertIn("Unknown option: --bogus", out)
 
+    def test_parse_args_rejects_old_skip_validation_name(self) -> None:
+        p = pl.Pipeline()
+        rc, out = quiet(p.parse_args, ["--skip-validation"])
+        self.assertEqual(rc, 1)
+        self.assertIn("Unknown option: --skip-validation", out)
+
     def test_parse_args_help(self) -> None:
         p = pl.Pipeline()
         rc, out = quiet(p.parse_args, ["--help"])
@@ -803,6 +811,8 @@ class TestParsing(TmpCwd):
         self.assertIn("--effort=LEVEL", out)
         self.assertIn("--policy-retries=N", out)
         self.assertIn("--transient-resumes=N", out)
+        self.assertIn("--skip-validate", out)
+        self.assertNotIn("--skip-validation", out)
         self.assertIn("default: 20", out)
 
     def test_default_target_is_cwd_basename(self) -> None:

--- a/tests/unit/test_workspace_isolation.py
+++ b/tests/unit/test_workspace_isolation.py
@@ -679,7 +679,7 @@ class TestParallelIsolation(EnvIsolatedCase):
         "--skip-analysis",
         "--skip-specgen",
         "--skip-harness",
-        "--skip-validation",
+        "--skip-validate",
         "--skip-confirmation",
         "--skip-classification",
         "--skip-repair-loop",


### PR DESCRIPTION
## Summary
- Rename the run skip flag from `--skip-validation` to `--skip-validate` and update docs/tests.
- Let Phase 4 report validation accept duplicate detail `Status` metadata when it is semantically equivalent to the table repair status.
- Strip agent-authored `- **Status**:` lines from published report bodies so dispatcher-owned `DEFERRED (...)` statuses remain authoritative.
- Keep rejecting the old `--skip-validation` spelling and genuinely conflicting repair-status references.

## Tests
- `uv run python -m unittest tests.unit.test_confirmlib.TestCacheContracts.test_deferred_pending_cache_stays_terminal_without_rerunning_agent tests.unit.test_confirmlib.TestValidationContracts.test_report_pending_reference_allows_duplicate_bare_detail_status tests.unit.test_confirmlib.TestValidationContracts.test_report_pending_reference_rejects_conflicting_detail_status`
- `uv run --extra dev pytest tests/unit/test_confirmlib.py -q`
- `uv run --extra dev mypy`
- `git ls-files -z '*.py' | xargs -0 uv run --with ruff==0.15.18 ruff check`
- `git ls-files -z '*.py' | xargs -0 uv run --with ruff==0.15.18 ruff format --check`

Fixes #92
Fixes #94