### PR TITLE
Retry blocked confirmations with compact fresh sessions

### DIFF
--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -335,6 +335,24 @@ class Outcome:
 # ── prompt builders ──────────────────────────────────────────────────────────
 
 
+def _write_finding_context(cfg: ConfirmConfig, f: Finding) -> Path:
+    """Publish the current finding as the compact retry's canonical input."""
+    path = f.fdir / "finding.json"
+    payload: dict[str, object] = {"finding": f.data}
+    if cfg.prompt_extra.strip():
+        payload["target_specific_instructions"] = cfg.prompt_extra.strip()
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    try:
+        temporary.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+        os.replace(temporary, path)
+    except OSError as exc:
+        raise ConfirmationFailed(f"{f.id}: cannot publish finding context: {exc}") from exc
+    finally:
+        with contextlib.suppress(OSError):
+            temporary.unlink()
+    return path
+
+
 def _context(cfg: ConfirmConfig, f: Finding, repo_for_agent: str) -> str:
     wd = cfg.ws.work_dir(cfg.name).absolute()
     return render(
@@ -410,6 +428,49 @@ def prompt_repair_draft_retry(
     )
 
 
+def _policy_role_task(role: str, turn_no: int) -> str:
+    if role == "A-repair":
+        return (
+            "Keep `PENDING REPAIR`. Inspect the existing repair draft and the prior Agent A log, "
+            "then make one focused correction so the draft follows the skill's semantic format."
+        )
+    if role == "B":
+        return (
+            "Continue as the Challenger. Read `debate.md` and the most recent Agent A log, test the finding's "
+            "reachability and consequence, and return an evidence-based verdict."
+        )
+    if role == "A" and turn_no == 1:
+        return (
+            "Continue as the Reproducer. Investigate the current finding, preserve any useful existing work, "
+            "execute the reproduction, and return the supported verdict."
+        )
+    if role == "A":
+        return (
+            "Continue as the Prover. Read `debate.md` and the Challenger's most recent log, strengthen and rerun "
+            "the reproduction where warranted, or move to the honest verdict."
+        )
+    raise ValueError(f"unsupported confirmation role: {role}")
+
+
+def prompt_policy_recovery(cfg: ConfirmConfig, f: Finding, role: str, turn_no: int, repo: str) -> str:
+    wd = cfg.ws.work_dir(cfg.name).absolute()
+    return render(
+        "confirmation/policy-recovery",
+        finding_id=f.id,
+        turn_no=str(turn_no),
+        role=role,
+        finding_context=str((f.fdir / "finding.json").absolute()),
+        repo=repo,
+        fdir=str(f.fdir.absolute()),
+        repro_dir=str(wd / "repro"),
+        debate=str((f.fdir / "debate.md").absolute()),
+        repair_draft=str((f.fdir / "repair-request.body.md").absolute()),
+        bug_confirmation_skill=prompt_skill_ids("bug-confirmation"),
+        role_task=_policy_role_task(role, turn_no),
+        canon=" / ".join(CANON),
+    )
+
+
 # ── one debate turn (blocking, via the shared phaselib primitive) ────────────
 
 
@@ -446,6 +507,7 @@ def run_turn(
 
     state_key = ("finding", f.id, str(turn_no), role)
     policy_state = cfg.policy_state(state_key, prompt)
+    repo_for_agent = lease.repo_for_agent if lease is not None else (cfg.repo_dir or str(cwd or ""))
     rc, text = run_agent_blocking(
         cfg.adapter,
         prompt,
@@ -462,6 +524,7 @@ def run_turn(
         policy_retries=cfg.policy_retries,
         transient_resumes=cfg.transient_resumes,
         policy_state=policy_state,
+        policy_fresh_prompt=prompt_policy_recovery(cfg, f, role, turn_no, repo_for_agent),
     )
     if rc == 75:
         raise RateLimited(f"{f.id} turn {turn_no} {role}")
@@ -857,6 +920,7 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
     if not f.id or set(f.id) - ID_CHARS or f.id in {".", ".."}:
         raise InvalidAgentOutput(f"unsafe finding id: {f.id!r}")
     f.fdir.mkdir(parents=True, exist_ok=True)
+    _write_finding_context(cfg, f)
     repro_dir = cfg.ws.work_dir(cfg.name).absolute() / "repro"
     repro_dir.mkdir(parents=True, exist_ok=True)
     owned_lease = _lease is None
@@ -1204,7 +1268,14 @@ def _repo_cache_identity(cfg: ConfirmConfig) -> dict[str, str]:
 def _prompt_sources() -> dict[str, str]:
     root = Path(__file__).resolve().parent / "prompts" / "confirmation"
     result: dict[str, str] = {}
-    for name in ("context.md", "reproduce.md", "challenge.md", "defend.md", "repair-draft-retry.md"):
+    for name in (
+        "context.md",
+        "reproduce.md",
+        "challenge.md",
+        "defend.md",
+        "repair-draft-retry.md",
+        "policy-recovery.md",
+    ):
         path = root / name
         result[name] = path.read_text() if path.is_file() else ""
     return result

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -170,9 +170,19 @@ def _transient_resume_delay(attempt: int) -> float:
     return min(TRANSIENT_RESUME_BACKOFF_MAX_SECONDS, float(2 ** min(attempt + 1, 6)))
 
 
-def _retry_prompt(original: str, reason: str, *, resumable: bool) -> str:
+def _retry_prompt(
+    original: str,
+    reason: str,
+    *,
+    resumable: bool,
+    policy_fresh_prompt: str | None = None,
+) -> str:
     if not resumable:
-        return _policy_recovery_prompt(original) if reason == "policy" else original
+        if reason != "policy":
+            return original
+        if policy_fresh_prompt is not None:
+            return policy_fresh_prompt
+        return _policy_recovery_prompt(original)
     if reason == "policy":
         return _POLICY_SESSION_RESUME_PROMPT
     if reason in {"rate_limit", "transient"}:
@@ -1353,6 +1363,7 @@ def run_agent_blocking(
     policy_retries: int = DEFAULT_POLICY_RETRIES,
     transient_resumes: int = DEFAULT_TRANSIENT_RESUMES,
     policy_state: PolicyRetryState | None = None,
+    policy_fresh_prompt: str | None = None,
 ) -> tuple[int, str]:
     """Run an agent turn, blocking, and return (returncode, log text).
 
@@ -1374,9 +1385,10 @@ def run_agent_blocking(
     75) is the caller's concern. A provider policy block (exit 76) advances up
     to ``policy_retries`` continuation levels. A retryable provider/transport
     failure (exit 74) resumes up to ``transient_resumes`` times with bounded
-    backoff. Every retry reuses the exact native session captured in a state
-    file; if the CLI failed before emitting an ID, Specula safely replays the
-    original prompt. Callers that automatically replay exit 75 may pass
+    backoff. When ``policy_fresh_prompt`` is supplied, the first policy retry
+    resumes the exact native session when one was captured; if that session is
+    blocked again, or no session was captured, Specula starts fresh with that
+    compact handoff. Callers that automatically replay exit 75 may pass
     ``policy_state`` so the native session and both budgets survive that wait.
     The caller must discard that state after any non-75 terminal result.
     """
@@ -1396,6 +1408,8 @@ def run_agent_blocking(
         run_cwd = (caller_cwd / run_cwd).resolve()
 
     prompt = materialize_skill_refs(prompt, adapter)
+    if policy_fresh_prompt is not None:
+        policy_fresh_prompt = materialize_skill_refs(policy_fresh_prompt, adapter)
     prompt_file.parent.mkdir(parents=True, exist_ok=True)
     last_message_file = _last_message_path(log_file)
     resume_state = _resume_state_path(log_file)
@@ -1459,6 +1473,7 @@ def run_agent_blocking(
                 prompt,
                 prompt_reason,
                 resumable=resumable,
+                policy_fresh_prompt=policy_fresh_prompt,
             )
             prompt_file.write_text(current_prompt)
             with contextlib.suppress(OSError):
@@ -1490,8 +1505,15 @@ def run_agent_blocking(
             if rc == POLICY_BLOCKED_RC and policy_attempt < policy_retries:
                 state.policy_attempt = policy_attempt + 1
                 state.retry_reason = "policy"
+                if policy_fresh_prompt is None:
+                    mode = "retrying with a revised request"
+                else:
+                    resume_exact_session = policy_attempt == 0 and resume_state.is_file()
+                    if not resume_exact_session:
+                        _clear_resume_state(resume_state)
+                    mode = "resuming the exact session" if resume_exact_session else "starting a fresh compact handoff"
                 print(
-                    f"[{_ts()}] Provider policy interrupted the agent turn; retrying with a revised request "
+                    f"[{_ts()}] Provider policy interrupted the agent turn; {mode} "
                     f"({state.policy_attempt}/{policy_retries})"
                 )
                 continue

--- a/src/specula/prompts/confirmation/policy-recovery.md
+++ b/src/specula/prompts/confirmation/policy-recovery.md
@@ -1,0 +1,28 @@
+# Continue interrupted confirmation turn: {{finding_id}}
+
+This is a fresh session continuing turn {{turn_no}} as Agent {{role}}. The
+previous session was interrupted by the provider. Do not restart useful work
+that is already present.
+
+## Canonical inputs
+- Current finding only: `{{finding_context}}`
+- Source repo and retained finding worktree: `{{repo}}`
+- Finding work dir: `{{fdir}}`
+- Reproduction dir: `{{repro_dir}}`
+- Debate index and prior-turn log links: `{{debate}}`
+- Repair draft, when required: `{{repair_draft}}`
+
+Use the installed Specula skill {{bug_confirmation_skill}}. Read the finding
+capsule first, inspect the retained worktree and relevant files in the finding
+work dir, then complete only the remaining work. Do not inspect other finding
+directories, `bug-report.md`, `confirmed-bugs.md`, or the shared repair queue.
+
+## This turn
+{{role_task}}
+
+End the entire response with one line:
+`VERDICT: <one of: {{canon}}>`
+
+For `PENDING REPAIR`, also write the semantic draft at `{{repair_draft}}` using
+the skill's repair-request format. Do not allocate an RR id or write the shared
+repair queue.

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -187,6 +187,10 @@ class TestConfirmConfigCompatibility(ConfirmCase):
         self.assertEqual(run.call_args.kwargs["policy_retries"], 100)
         self.assertEqual(run.call_args.kwargs["gate_work_dir"], finding.fdir)
         self.assertEqual(run.call_args.kwargs["cwd"], "/repo-worktree")
+        fresh_prompt = run.call_args.kwargs["policy_fresh_prompt"]
+        self.assertIn(str(finding.fdir / "finding.json"), fresh_prompt)
+        self.assertIn("/repo-worktree", fresh_prompt)
+        self.assertIn("Continue as the Reproducer", fresh_prompt)
 
     def test_finding_turn_starts_in_clean_dispatcher_cwd_not_untrusted_repo(self) -> None:
         ws = Workspace(["T"])
@@ -528,7 +532,7 @@ class TestDriver(ConfirmCase):
         self.assertEqual((first_rc, second_rc), (75, 1))
         self.assertEqual(count.read_text(), "xxx")
         prompts = [(root / f"prompt-{attempt}.md").read_text() for attempt in range(1, 4)]
-        marker = "Continue After Provider Policy Interruption"
+        marker = "# Continue interrupted confirmation turn"
         self.assertNotIn(marker, prompts[0])
         self.assertIn(marker, prompts[1])
         self.assertEqual(prompts[2], prompts[1])
@@ -552,7 +556,7 @@ class TestDriver(ConfirmCase):
         self.assertEqual((first_rc, second_rc), (75, 0))
         self.assertEqual(count.read_text(), "xxx")
         prompts = [(root / f"prompt-{attempt}.md").read_text() for attempt in range(1, 4)]
-        marker = "Continue After Provider Policy Interruption"
+        marker = "# Continue interrupted confirmation turn"
         self.assertNotIn(marker, prompts[0])
         self.assertEqual(prompts[1], prompts[0])
         self.assertIn(marker, prompts[2])
@@ -576,7 +580,7 @@ class TestDriver(ConfirmCase):
         # Completed A is cached across the outer replay; only unfinished B is
         # invoked again, with its own rate-limit cursor.
         self.assertEqual(count.read_text(), "xxxx")
-        marker = "Continue After Provider Policy Interruption"
+        marker = "# Continue interrupted confirmation turn"
         self.assertNotIn(marker, (root / "prompt-1.md").read_text())
         self.assertIn(marker, (root / "prompt-2.md").read_text())
         self.assertNotIn(marker, (root / "prompt-3.md").read_text())
@@ -1543,6 +1547,36 @@ class TestPromptExtraAndLog(ConfirmCase):
         cfg = self.cfg(ws, "T", prompt_extra="\n## Target-Specific Instructions\n\nCHECK THE FOO RACE")
         f = C.Finding({"id": "MC-1", "title": "t", "summary": "s"}, ws.work_dir("T") / "confirmation" / "MC-1")
         self.assertIn("CHECK THE FOO RACE", C.prompt_reproduce(cfg, f, "/repo"))
+
+    def test_policy_recovery_prompt_uses_current_finding_capsule(self) -> None:
+        ws = self.seed("T", [])
+        cfg = self.cfg(ws, "T", prompt_extra="\n## Target-Specific Instructions\n\nCHECK THE FOO RACE")
+        data = {
+            "id": "MC-1",
+            "source": "model-checking",
+            "title": "Sensitive finding title",
+            "summary": "Sensitive finding details",
+        }
+        f = C.Finding(data, ws.work_dir("T") / "confirmation" / "MC-1")
+        f.fdir.mkdir(parents=True)
+
+        capsule = C._write_finding_context(cfg, f)
+        prompt = C.prompt_policy_recovery(cfg, f, "B", 2, "/repo-worktree")
+
+        self.assertEqual(
+            json.loads(capsule.read_text()),
+            {
+                "finding": data,
+                "target_specific_instructions": "## Target-Specific Instructions\n\nCHECK THE FOO RACE",
+            },
+        )
+        self.assertIn(str(capsule), prompt)
+        self.assertIn("/repo-worktree", prompt)
+        self.assertIn(str(f.fdir / "debate.md"), prompt)
+        self.assertIn("Continue as the Challenger", prompt)
+        self.assertIn("installed Specula skill **bug-confirmation**", prompt)
+        self.assertNotIn("Sensitive finding title", prompt)
+        self.assertNotIn("Sensitive finding details", prompt)
 
     def test_parallel_prompts_assign_rr_queue_only_to_dispatcher(self) -> None:
         ws = self.seed("T", [])

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -1575,6 +1575,85 @@ class TestRunAgentBlocking(PhaseCase):
         self.assertEqual(third_prompt, second_prompt)
         self.assertEqual(second_prompt.count("Continue After Provider Policy Interruption"), 1)
 
+    def test_policy_block_without_session_uses_fresh_compact_prompt(self) -> None:
+        adapter = self.tmp() / "adapter.sh"
+        count = self.tmp() / "count"
+        captures = self.tmp()
+        adapter.write_text(
+            "#!/bin/sh\n"
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            'for arg do case "$arg" in --prompt-file=*) prompt=${arg#*=} ;; --log=*) log=${arg#*=} ;; esac; done\n'
+            'cp "$prompt" "$CAPTURE_DIR/prompt-$attempt.md"\n'
+            '[ "$attempt" -gt 2 ] || exit 76\n'
+            'printf "continued\\n" > "$log"\n'
+        )
+        adapter.chmod(0o755)
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("CAPTURE_DIR", str(captures))
+
+        rc, text = phaselib.run_agent_blocking(
+            adapter,
+            "original detailed prompt",
+            captures / "prompt.md",
+            captures / "turn.log",
+            phase_key="bug_confirmation",
+            work_dir=self.work_dir(),
+            claude_alias="profile",
+            policy_retries=2,
+            policy_fresh_prompt="compact handoff",
+        )
+
+        self.assertEqual((rc, text), (0, "continued\n"))
+        self.assertEqual((captures / "prompt-1.md").read_text(), "original detailed prompt")
+        self.assertEqual((captures / "prompt-2.md").read_text(), "compact handoff")
+        self.assertEqual((captures / "prompt-3.md").read_text(), "compact handoff")
+
+    def test_repeated_policy_block_switches_from_exact_resume_to_fresh_compact_prompt(self) -> None:
+        adapter = self.tmp() / "adapter.sh"
+        count = self.tmp() / "count"
+        captures = self.tmp()
+        adapter.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            'for arg do case "$arg" in '
+            "--prompt-file=*) prompt=${arg#*=} ;; "
+            "--log=*) log=${arg#*=} ;; "
+            "--resume-state=*) resume=${arg#*=} ;; "
+            "esac; done\n"
+            'cp "$prompt" "$CAPTURE_DIR/prompt-$attempt.md"\n'
+            'case "$attempt" in\n'
+            '  1) printf "blocked-session\\n" > "$resume"; exit 76 ;;\n'
+            '  2) test "$(cat "$resume")" = "blocked-session"; exit 76 ;;\n'
+            '  3) test ! -e "$resume"; printf "continued\\n" > "$log" ;;\n'
+            "  *) exit 99 ;;\n"
+            "esac\n"
+        )
+        adapter.chmod(0o755)
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("CAPTURE_DIR", str(captures))
+        log_file = captures / "turn.log"
+
+        rc, text = phaselib.run_agent_blocking(
+            adapter,
+            "original detailed prompt",
+            captures / "prompt.md",
+            log_file,
+            phase_key="bug_confirmation",
+            work_dir=self.work_dir(),
+            claude_alias="profile",
+            policy_retries=2,
+            policy_fresh_prompt="compact handoff",
+        )
+
+        self.assertEqual((rc, text), (0, "continued\n"))
+        self.assertEqual((captures / "prompt-1.md").read_text(), "original detailed prompt")
+        self.assertEqual((captures / "prompt-2.md").read_text(), phaselib._POLICY_SESSION_RESUME_PROMPT)
+        self.assertEqual((captures / "prompt-3.md").read_text(), "compact handoff")
+        self.assertFalse(log_file.with_suffix(".resume.json").exists())
+
     def test_default_policy_retry_budget_bounds_blocking_turn(self) -> None:
         adapter = self.tmp() / "adapter.sh"
         count = self.tmp() / "count"


### PR DESCRIPTION
## Summary

- publish the current finding as a small canonical `finding.json` capsule for Phase 4 recovery
- resume the exact provider session once after a policy block, then clear its cursor and start a fresh compact handoff if it blocks again or no session was captured
- retain the finding worktree and existing artifacts while keeping the existing `--policy-retries` budget and output validation unchanged

Addresses #93