### PR TITLE
Document Phase 4 model access caveat

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -30,6 +30,8 @@ The first setup needs network access to GitHub, PyPI, and Maven Central. Agent r
 
 Specula relies on the selected agent to analyze code and reason about counterexamples, so use a strong reasoning model at high effort. Harness generation builds and instruments the target project; verify that the target builds normally before starting a full pipeline.
 
+Some frontier models apply stricter cyber-safety access checks during the `confirm` step, because Phase 4 asks the agent to validate and reproduce real bugs in source code. If those checks block your run, use a model/provider with the required cyber access, or a model that does not block this defensive reproduction workflow, for Phase 4; earlier phases can still use frontier reasoning models.
+
 Model checking can be long-running and memory-intensive. On machines with limited memory, you can run more TLC simulations or configure TLC to offload state data to disk. Limited memory may constrain model checking, but it does not prevent you from using Specula, and we plan to improve resource handling and provide more support for resource-constrained machines in future releases.
 
 ### Optional sandbox dependencies


### PR DESCRIPTION
## Summary
- Document that Phase 4 bug confirmation can trigger stricter cyber-safety access checks on some frontier models.
- Recommend using a model/provider with the required cyber access for Phase 4 while keeping frontier reasoning models usable for earlier phases.

Supersedes #99.