### PR TITLE
Add per-phase agent configuration

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -134,7 +134,7 @@ specula run \
 
 Supported adapters are `claude-code` (default), `codex`, `copilot-cli`, `opencode`, and `pi`. Model names and effort values are interpreted by the selected agent. OpenCode and Pi model names use `provider/model` syntax.
 
-### Hybrid Agent Configuration
+### Hybrid agent configuration
 
 Use an agent configuration file to select different agents or models for different pipeline phases:
 
@@ -164,13 +164,11 @@ specula run --agent-config=/abs/path/hybrid-agents.json ...
 }
 ```
 
-Each profile requires `agent`; `model` and `effort` are optional. Unmapped phases use `default_profile`. `repair` inherits the `validate` profile unless it is mapped explicitly. Reviews inherit the profile of the phase they review; map `review` explicitly to use one profile for every review.
+Unmapped phases use `default_profile`. `repair` inherits `validate`, and reviews inherit the phase they review unless either is mapped explicitly.
 
 Valid phase keys are `analyze`, `specgen`, `harness`, `validate`, `confirm`, `repair`, `classify`, and `review`.
 
-`--agent-config` cannot be combined with `--agent`, `--model`, or `--effort`. Specula does not discover configuration files automatically or switch agents after a failure. The file should not contain credentials; each configured agent uses its existing CLI authentication.
-
-GitHub Copilot CLI can be selected with `"agent": "copilot-cli"`. Copilot CLI has a per-prompt size limit, so large confirmation or debate prompts may require another agent.
+`--agent-config` cannot be combined with `--agent`, `--model`, or `--effort`; configured agents use their existing CLI authentication.
 
 ### Models tested by the Specula team
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -134,6 +134,44 @@ specula run \
 
 Supported adapters are `claude-code` (default), `codex`, `copilot-cli`, `opencode`, and `pi`. Model names and effort values are interpreted by the selected agent. OpenCode and Pi model names use `provider/model` syntax.
 
+### Hybrid Agent Configuration
+
+Use an agent configuration file to select different agents or models for different pipeline phases:
+
+```bash
+specula run --agent-config=/abs/path/hybrid-agents.json ...
+```
+
+```json
+{
+  "version": 1,
+  "default_profile": "reasoning",
+  "profiles": {
+    "reasoning": {
+      "agent": "claude-code",
+      "model": "fable",
+      "effort": "max"
+    },
+    "reproduction": {
+      "agent": "codex",
+      "model": "gpt-5.6-sol",
+      "effort": "ultra"
+    }
+  },
+  "phases": {
+    "confirm": "reproduction"
+  }
+}
+```
+
+Each profile requires `agent`; `model` and `effort` are optional. Unmapped phases use `default_profile`. `repair` inherits the `validate` profile unless it is mapped explicitly. Reviews inherit the profile of the phase they review; map `review` explicitly to use one profile for every review.
+
+Valid phase keys are `analyze`, `specgen`, `harness`, `validate`, `confirm`, `repair`, `classify`, and `review`.
+
+`--agent-config` cannot be combined with `--agent`, `--model`, or `--effort`. Specula does not discover configuration files automatically or switch agents after a failure. The file should not contain credentials; each configured agent uses its existing CLI authentication.
+
+GitHub Copilot CLI can be selected with `"agent": "copilot-cli"`. Copilot CLI has a per-prompt size limit, so large confirmation or debate prompts may require another agent.
+
 ### Models tested by the Specula team
 
 We have tested the following agent and model combinations. These observations summarize our own runs and are not guarantees for every target or configuration.
@@ -225,7 +263,7 @@ specula run <name> \
   "name|owner/repository|language|reference"
 ```
 
-Specula reuses `runs/<run-id>/<name>/.specula-output/`. Pass the target, artifact, agent, model, and effort again when resuming. A `--keep-original` run automatically resumes against its existing private source even when that flag and the original artifact are omitted. The run's TLC memory and worker limits are restored from `tlc-resources.json`; `run.json` remains an audit record, not arguments for the new invocation.
+Specula reuses `runs/<run-id>/<name>/.specula-output/`. Pass the target and artifact again when resuming, together with either `--agent-config` or the original agent, model, and effort options. A `--keep-original` run automatically resumes against its existing private source even when that flag and the original artifact are omitted. The run's TLC memory and worker limits are restored from `tlc-resources.json`; `run.json` remains an audit record, not arguments for the new invocation.
 
 ## Individual Steps
 
@@ -277,6 +315,7 @@ specula run [options] "name|owner/repository|language|reference"
 |---|---|
 | `--dry-run` | Print the step commands without starting agents |
 | `--agent=NAME` | Select `claude-code`, `codex`, `copilot-cli`, `opencode`, or `pi` |
+| `--agent-config=PATH` | Select agent/model profiles by pipeline phase from a JSON file |
 | `--model=NAME` | Override the configured model |
 | `--effort=LEVEL` | Override reasoning effort |
 | `--artifact=PATH` | Set the target source checkout |

--- a/src/specula/agent_config.py
+++ b/src/specula/agent_config.py
@@ -1,0 +1,137 @@
+"""Strict loading and phase routing for agent configuration files."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import cast
+
+PHASES = frozenset(
+    {
+        "analyze",
+        "specgen",
+        "harness",
+        "validate",
+        "confirm",
+        "repair",
+        "classify",
+        "review",
+    }
+)
+_TOP_LEVEL_FIELDS = frozenset({"version", "default_profile", "profiles", "phases"})
+_PROFILE_FIELDS = frozenset({"agent", "model", "effort"})
+
+
+class AgentConfigError(Exception):
+    """An agent configuration file is unreadable or invalid."""
+
+
+@dataclass(frozen=True)
+class AgentSelection:
+    agent: str
+    model: str | None = None
+    effort: str | None = None
+
+
+@dataclass(frozen=True)
+class AgentRouting:
+    default: AgentSelection
+    profiles: Mapping[str, AgentSelection]
+    phases: Mapping[str, str]
+
+    def resolve(self, phase: str, fallback: str | None = None) -> AgentSelection:
+        """Resolve an explicit phase, then a fallback phase, then the default."""
+        profile = self.phases.get(phase)
+        if profile is None and fallback is not None:
+            profile = self.phases.get(fallback)
+        if profile is None:
+            return self.default
+        return self.profiles[profile]
+
+
+def _as_object(value: object, location: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise AgentConfigError(f"{location} must be a JSON object")
+    return cast(dict[str, object], value)
+
+
+def _reject_unknown_fields(
+    value: Mapping[str, object],
+    allowed: frozenset[str],
+    location: str,
+) -> None:
+    unknown = sorted(value.keys() - allowed)
+    if unknown:
+        raise AgentConfigError(f"{location} contains unknown field '{unknown[0]}'")
+
+
+def _optional_string(profile: Mapping[str, object], field: str, profile_name: str) -> str | None:
+    if field not in profile:
+        return None
+    value = profile[field]
+    if not isinstance(value, str):
+        raise AgentConfigError(f"profile '{profile_name}' field '{field}' must be a string")
+    return value
+
+
+def load_agent_routing(path: Path) -> AgentRouting:
+    """Read and strictly validate an agent routing JSON file."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise AgentConfigError(f"cannot read agent config {path}: {exc}") from exc
+    try:
+        loaded: object = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise AgentConfigError(
+            f"invalid JSON in agent config {path} at line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        ) from exc
+
+    document = _as_object(loaded, "agent config")
+    _reject_unknown_fields(document, _TOP_LEVEL_FIELDS, "agent config")
+
+    version = document.get("version")
+    if not isinstance(version, int) or isinstance(version, bool) or version != 1:
+        raise AgentConfigError("agent config field 'version' must be the integer 1")
+
+    default_profile = document.get("default_profile")
+    if not isinstance(default_profile, str):
+        raise AgentConfigError("agent config field 'default_profile' must be a string")
+
+    raw_profiles = _as_object(document.get("profiles"), "agent config field 'profiles'")
+    profiles: dict[str, AgentSelection] = {}
+    for name, raw_profile in raw_profiles.items():
+        profile = _as_object(raw_profile, f"profile '{name}'")
+        _reject_unknown_fields(profile, _PROFILE_FIELDS, f"profile '{name}'")
+        agent = profile.get("agent")
+        if not isinstance(agent, str) or not agent:
+            raise AgentConfigError(f"profile '{name}' field 'agent' must be a non-empty string")
+        profiles[name] = AgentSelection(
+            agent=agent,
+            model=_optional_string(profile, "model", name),
+            effort=_optional_string(profile, "effort", name),
+        )
+
+    if default_profile not in profiles:
+        raise AgentConfigError(f"default profile '{default_profile}' does not exist")
+
+    raw_phases_value = document.get("phases", {})
+    raw_phases = _as_object(raw_phases_value, "agent config field 'phases'")
+    phases: dict[str, str] = {}
+    for phase, raw_profile_name in raw_phases.items():
+        if phase not in PHASES:
+            raise AgentConfigError(f"agent config contains unknown phase '{phase}'")
+        if not isinstance(raw_profile_name, str):
+            raise AgentConfigError(f"phase '{phase}' must reference a profile by name")
+        if raw_profile_name not in profiles:
+            raise AgentConfigError(f"phase '{phase}' references unknown profile '{raw_profile_name}'")
+        phases[phase] = raw_profile_name
+
+    return AgentRouting(
+        default=profiles[default_profile],
+        profiles=MappingProxyType(profiles),
+        phases=MappingProxyType(phases),
+    )

--- a/src/specula/agent_config.py
+++ b/src/specula/agent_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -41,6 +42,7 @@ class AgentRouting:
     default: AgentSelection
     profiles: Mapping[str, AgentSelection]
     phases: Mapping[str, str]
+    source_sha256: str
 
     def resolve(self, phase: str, fallback: str | None = None) -> AgentSelection:
         """Resolve an explicit phase, then a fallback phase, then the default."""
@@ -80,8 +82,12 @@ def _optional_string(profile: Mapping[str, object], field: str, profile_name: st
 def load_agent_routing(path: Path) -> AgentRouting:
     """Read and strictly validate an agent routing JSON file."""
     try:
-        text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeError) as exc:
+        source = path.read_bytes()
+    except OSError as exc:
+        raise AgentConfigError(f"cannot read agent config {path}: {exc}") from exc
+    try:
+        text = source.decode("utf-8")
+    except UnicodeDecodeError as exc:
         raise AgentConfigError(f"cannot read agent config {path}: {exc}") from exc
     try:
         loaded: object = json.loads(text)
@@ -134,4 +140,5 @@ def load_agent_routing(path: Path) -> AgentRouting:
         default=profiles[default_profile],
         profiles=MappingProxyType(profiles),
         phases=MappingProxyType(phases),
+        source_sha256=hashlib.sha256(source).hexdigest(),
     )

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -460,6 +460,7 @@ class Phase:
     _effort: str | None = None
     _policy_retries = DEFAULT_POLICY_RETRIES
     _transient_resumes = DEFAULT_TRANSIENT_RESUMES
+    _rate_limit_agent = "claude-code"
 
     # ── per-phase hooks ──
     def parse_flag(self, arg: str, extra: dict[str, str | bool]) -> bool:
@@ -597,6 +598,14 @@ class Phase:
         return os.environ.get("SPECULA_RATE_LIMIT_REACTIVE", "").lower() in {"1", "true", "yes", "on"}
 
     def _wait_for_rate_limit(self) -> None:
+        if self._rate_limit_agent != "claude-code":
+            seconds = quota.RATE_LIMIT_FALLBACK_SECONDS
+            print(
+                f"[{_ts()}] No quota reset endpoint for {self._rate_limit_agent}; "
+                f"sleeping {seconds:g}s after rate limit"
+            )
+            time.sleep(seconds)
+            return
         quota.wait_for_quota(
             usage_script=SPECULA_ROOT / "scripts" / "exp" / "usage.sh",
             q5=os.environ.get("SPECULA_QUOTA_5H") or "85",
@@ -775,6 +784,7 @@ class Phase:
         if not adapter.is_file():
             print(f"ERROR: Unknown agent '{agent}' — adapter not found at {adapter}")
             return 1
+        self._rate_limit_agent = agent
 
         ws = Workspace(targets, artifact=artifact, opts=extra)
         names = [self.target_name(t) for t in targets]
@@ -2609,6 +2619,7 @@ Output:
         if not adapter.is_file():
             print(f"ERROR: Unknown agent '{agent}' — adapter not found at {adapter}")
             return 1
+        self._rate_limit_agent = agent
 
         ws = Workspace(targets)
         names = [_trim(t) for t in targets]

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -14,7 +14,6 @@ Usage:  python3 pipelinelib.py [options] "name|github|lang|reference" [...]
 from __future__ import annotations
 
 import contextlib
-import hashlib
 import json
 import locale
 import math
@@ -314,7 +313,6 @@ class Pipeline:
         self.agent = "claude-code"
         self._agent_given = False
         self.agent_config_path: Path | None = None
-        self.agent_config_sha256: str | None = None
         self.agent_routing: AgentRouting | None = None
         self.claude_alias = os.environ.get("CLAUDE_ALIAS") or "claude"
         # None means no pipeline CLI override: phase launchers may consult
@@ -465,7 +463,6 @@ class Pipeline:
         if self.agent_config_path is not None:
             try:
                 self.agent_routing = load_agent_routing(self.agent_config_path)
-                self.agent_config_sha256 = hashlib.sha256(self.agent_config_path.read_bytes()).hexdigest()
             except (AgentConfigError, OSError) as exc:
                 print(f"ERROR: {exc}", file=sys.stderr)
                 return 1
@@ -824,7 +821,7 @@ class Pipeline:
                     "effort": route_effort,
                 }
             meta["agent_config"] = str(self.agent_config_path)
-            meta["agent_config_sha256"] = self.agent_config_sha256
+            meta["agent_config_sha256"] = self.agent_routing.source_sha256
             meta["agent_routes"] = routes
         if self.keep_original:
             meta["source_mode"] = "snapshot"

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -14,6 +14,7 @@ Usage:  python3 pipelinelib.py [options] "name|github|lang|reference" [...]
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import locale
 import math
@@ -39,6 +40,7 @@ from typing import Any
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from specula import quota as _quota
+from specula.agent_config import AgentConfigError, AgentRouting, AgentSelection, load_agent_routing
 from specula.phaselib import (
     DEFAULT_POLICY_RETRIES,
     DEFAULT_TRANSIENT_RESUMES,
@@ -126,6 +128,7 @@ Options:
   --policy-retries=N     Policy-block continuation retries after the initial attempt (default: 20; 0 disables)
   --transient-resumes=N  Transient provider/transport session resumes after the initial attempt (default: 20; 0 disables)
   --agent=NAME           Agent adapter to use (default: claude-code; e.g., claude-code, codex, copilot-cli, opencode, pi)
+  --agent-config=PATH    JSON file selecting an agent/model profile per phase
   --claude-alias=NAME    Claude CLI profile (default: claude)
   --model=NAME           Model forwarded to every agent adapter
   --effort=LEVEL         Reasoning effort forwarded to every agent adapter
@@ -309,6 +312,10 @@ class Pipeline:
         self.max_repair_rounds = os.environ.get("MAX_REPAIR_ROUNDS") or "10"
         self.skip_reviews = True
         self.agent = "claude-code"
+        self._agent_given = False
+        self.agent_config_path: Path | None = None
+        self.agent_config_sha256: str | None = None
+        self.agent_routing: AgentRouting | None = None
         self.claude_alias = os.environ.get("CLAUDE_ALIAS") or "claude"
         # None means no pipeline CLI override: phase launchers may consult
         # SPECULA_MODEL / SPECULA_EFFORT.  "" is an explicit empty flag and
@@ -406,6 +413,20 @@ class Pipeline:
                     return 1
             elif arg.startswith("--agent="):
                 self.agent = arg.split("=", 1)[1]
+                self._agent_given = True
+            elif arg.startswith("--agent-config="):
+                raw_path = arg.split("=", 1)[1]
+                if not raw_path:
+                    print("ERROR: --agent-config requires a path", file=sys.stderr)
+                    return 1
+                try:
+                    config_path = Path(raw_path).expanduser()
+                    if not config_path.is_absolute():
+                        config_path = _logical_cwd() / config_path
+                    self.agent_config_path = config_path.resolve()
+                except (OSError, RuntimeError) as exc:
+                    print(f"ERROR: invalid --agent-config path '{raw_path}': {exc}", file=sys.stderr)
+                    return 1
             elif arg.startswith("--claude-alias="):
                 self.claude_alias = arg.split("=", 1)[1]
             elif arg.startswith("--model="):
@@ -433,6 +454,21 @@ class Pipeline:
         if self.confirm_legacy and self.confirm_debate:
             print("ERROR: --legacy-confirm conflicts with --confirm-debate", file=sys.stderr)
             return 1
+        if self.agent_config_path is not None and (
+            self._agent_given or self.model is not None or self.effort is not None
+        ):
+            print(
+                "ERROR: --agent-config cannot be combined with --agent, --model, or --effort",
+                file=sys.stderr,
+            )
+            return 1
+        if self.agent_config_path is not None:
+            try:
+                self.agent_routing = load_agent_routing(self.agent_config_path)
+                self.agent_config_sha256 = hashlib.sha256(self.agent_config_path.read_bytes()).hexdigest()
+            except (AgentConfigError, OSError) as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return 1
         if not self.targets:
             self.targets.append(_logical_cwd().name)  # bash `basename "$PWD"` (logical)
         # order-independent: the two are contradictory however they arrive
@@ -746,13 +782,14 @@ class Pipeline:
                 lines = r.stdout.decode(errors="replace").splitlines()
                 if r.returncode == 0 and len(lines) == 2 and Path(lines[0]).resolve() == artifact:
                     artifact_sha = lines[1]
-        model, effort = self._resolved_run_tuning()
-        meta = {
+        default_selection = self._agent_selection()
+        model, effort = self._resolved_run_tuning(default_selection)
+        meta: dict[str, object] = {
             "run_id": self.run_id,
             "created": _date_iseconds(),
             "argv": self.argv,
             "targets": self.targets,
-            "agent": self.agent,
+            "agent": default_selection.agent,
             "model": model,
             "effort": effort,
             "policy_retries": self.policy_retries,
@@ -763,12 +800,45 @@ class Pipeline:
             "tlc_memory_limit": self.tlc_memory_limit or os.environ.get(MEMORY_LIMIT_ENV) or "auto",
             "tlc_worker_limit": self.tlc_worker_limit or os.environ.get(WORKER_LIMIT_ENV) or None,
         }
+        if self.agent_routing is not None:
+            assert self.agent_config_path is not None
+            route_specs: dict[str, tuple[str, str | None]] = {
+                "analyze": ("analyze", None),
+                "specgen": ("specgen", None),
+                "harness": ("harness", None),
+                "validate": ("validate", None),
+                "confirm": ("confirm", None),
+                "repair": ("repair", "validate"),
+                "classify": ("classify", None),
+                "review:analysis": ("review", "analyze"),
+                "review:specgen": ("review", "specgen"),
+                "review:validation": ("review", "validate"),
+            }
+            routes: dict[str, dict[str, str | None]] = {}
+            for route_name, (phase, fallback) in route_specs.items():
+                selection = self._agent_selection(phase, fallback=fallback)
+                route_model, route_effort = self._resolved_run_tuning(selection)
+                routes[route_name] = {
+                    "agent": selection.agent,
+                    "model": route_model,
+                    "effort": route_effort,
+                }
+            meta["agent_config"] = str(self.agent_config_path)
+            meta["agent_config_sha256"] = self.agent_config_sha256
+            meta["agent_routes"] = routes
         if self.keep_original:
             meta["source_mode"] = "snapshot"
         with contextlib.suppress(OSError):
             meta_file.write_text(json.dumps(meta, indent=2) + "\n")
 
-    def _resolved_run_tuning(self) -> tuple[str | None, str | None]:
+    def _agent_selection(self, phase: str | None = None, *, fallback: str | None = None) -> AgentSelection:
+        if self.agent_routing is None:
+            return AgentSelection(agent=self.agent, model=self.model, effort=self.effort)
+        if phase is None:
+            return self.agent_routing.default
+        return self.agent_routing.resolve(phase, fallback=fallback)
+
+    def _resolved_run_tuning(self, selection: AgentSelection | None = None) -> tuple[str | None, str | None]:
         """Return model/effort values that are knowable at run creation.
 
         Pipeline flags win even when explicitly empty. An empty flag resets the
@@ -776,8 +846,9 @@ class Pipeline:
         and therefore recorded as null. Otherwise mirror the phase and adapter
         environment fallbacks; never guess values selected by CLI config files.
         """
-        if self.model is not None:
-            model = self.model or None
+        selected = selection or self._agent_selection()
+        if selected.model is not None:
+            model = selected.model or None
         else:
             model = os.environ.get("SPECULA_MODEL") or None
             if model is None:
@@ -787,16 +858,16 @@ class Pipeline:
                     "copilot-cli": "COPILOT_MODEL",
                     "opencode": "OPENCODE_MODEL",
                     "pi": "PI_MODEL",
-                }.get(self.agent)
+                }.get(selected.agent)
                 if adapter_model_env is not None:
                     model = os.environ.get(adapter_model_env) or None
 
-        if self.effort is not None:
-            effort = self.effort or None
+        if selected.effort is not None:
+            effort = selected.effort or None
         else:
             effort = os.environ.get("SPECULA_EFFORT") or None
             if effort is None:
-                if self.agent == "claude-code":
+                if selected.agent == "claude-code":
                     # Phase launchers explicitly pass max, overriding any
                     # ambient CLAUDE_EFFORT value.
                     effort = "max"
@@ -805,12 +876,12 @@ class Pipeline:
                         "codex": "CODEX_EFFORT",
                         "opencode": "OPENCODE_EFFORT",
                         "pi": "PI_EFFORT",
-                    }.get(self.agent)
+                    }.get(selected.agent)
                     if effort_env is not None:
                         effort = os.environ.get(effort_env) or None
 
         # The Claude adapter omits --effort for this explicit reset sentinel.
-        if self.agent == "claude-code" and effort == "default":
+        if selected.agent == "claude-code" and effort == "default":
             effort = None
         return model, effort
 
@@ -832,13 +903,17 @@ class Pipeline:
         return names
 
     def validate_agent_adapter(self) -> None:
-        adapter = LAUNCH_DIR / "adapters" / f"{self.agent}.sh"
-        if not adapter.is_file():
-            print(
-                f"ERROR: Unknown agent '{self.agent}' — adapter not found at {adapter}",
-                file=sys.stderr,
-            )
-            raise SystemExit(1)
+        agents = {self.agent}
+        if self.agent_routing is not None:
+            agents = {selection.agent for selection in self.agent_routing.profiles.values()}
+        for agent in sorted(agents):
+            adapter = LAUNCH_DIR / "adapters" / f"{agent}.sh"
+            if not adapter.is_file():
+                print(
+                    f"ERROR: Unknown agent '{agent}' — adapter not found at {adapter}",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
 
     def get_work_dir(self, name: str) -> str:
         """Legacy: $PWD is evaluated at call time — after the single-target cd.
@@ -888,6 +963,11 @@ class Pipeline:
             claude_alias=self.claude_alias,
             reactive=reactive,
         )
+
+    def wait_for_phase_quota(self, phase: str, *, fallback: str | None = None) -> None:
+        """The proactive usage endpoint is Claude-specific."""
+        if self._agent_selection(phase, fallback=fallback).agent == "claude-code":
+            self.wait_for_quota()
 
     # ── repair-loop helpers ──
     def repair_dir(self, name: str) -> str:
@@ -1516,7 +1596,8 @@ class Pipeline:
             self._atomic_replace_text(marker, json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
     # ── phase runners ──
-    def _model_effort_args(self) -> list[str]:
+    @staticmethod
+    def _model_effort_args(selection: AgentSelection) -> list[str]:
         """Explicit pipeline tuning flags, preserving an explicit empty value.
 
         An absent flag stays absent so phase launchers can apply their run-wide
@@ -1524,10 +1605,10 @@ class Pipeline:
         flag must be forwarded to override (and clear) those fallbacks.
         """
         args: list[str] = []
-        if self.model is not None:
-            args.append(f"--model={self.model}")
-        if self.effort is not None:
-            args.append(f"--effort={self.effort}")
+        if selection.model is not None:
+            args.append(f"--model={selection.model}")
+        if selection.effort is not None:
+            args.append(f"--effort={selection.effort}")
         return args
 
     def _max_parallel_summary(self) -> str:
@@ -1538,7 +1619,16 @@ class Pipeline:
         )
         return f"phase defaults (ordinary phases 1 at a time; {confirmation_default})"
 
-    def _phase_args(self, positional: list[str], pre: list[str] | None = None, with_artifact: bool = True) -> list[str]:
+    def _phase_args(
+        self,
+        positional: list[str],
+        pre: list[str] | None = None,
+        with_artifact: bool = True,
+        *,
+        phase: str | None = None,
+        fallback: str | None = None,
+    ) -> list[str]:
+        selection = self._agent_selection(phase, fallback=fallback)
         args = list(pre or [])
         if self.max_parallel is not None:
             args.append(f"--max-parallel={self.max_parallel}")
@@ -1546,9 +1636,9 @@ class Pipeline:
             f"--max-turns={self.max_turns}",
             f"--policy-retries={self.policy_retries}",
             f"--transient-resumes={self.transient_resumes}",
-            f"--agent={self.agent}",
+            f"--agent={selection.agent}",
             f"--claude-alias={self.claude_alias}",
-            *self._model_effort_args(),
+            *self._model_effort_args(selection),
         ]
         if with_artifact and self._artifact_given and not self.keep_original:
             args.append(f"--artifact={self.artifact}")
@@ -1652,7 +1742,11 @@ class Pipeline:
         self._run_launcher(script, args)
 
     def run_phase1_analysis(self) -> None:
-        self._phase("PHASE 1: CODE ANALYSIS", "launch_code_analysis.sh", self._phase_args(self.targets))
+        self._phase(
+            "PHASE 1: CODE ANALYSIS",
+            "launch_code_analysis.sh",
+            self._phase_args(self.targets, phase="analyze"),
+        )
 
     def run_review(self, phase: str, names: list[str]) -> None:
         if self.skip_reviews:
@@ -1665,32 +1759,44 @@ class Pipeline:
         # died with "Unknown phase" — invisible under --dry-run, which only logs
         # the command without executing it. Phase goes first: a deliberate
         # divergence from the buggy bash order (git history has the original).
+        fallback = {
+            "analysis": "analyze",
+            "specgen": "specgen",
+            "validation": "validate",
+        }[phase]
+        selection = self._agent_selection("review", fallback=fallback)
+        if self.agent_routing is not None:
+            self.wait_for_phase_quota("review", fallback=fallback)
         args = [
             phase,
-            f"--agent={self.agent}",
+            f"--agent={selection.agent}",
             f"--claude-alias={self.claude_alias}",
             f"--policy-retries={self.policy_retries}",
             f"--transient-resumes={self.transient_resumes}",
-            *self._model_effort_args(),
+            *self._model_effort_args(selection),
             *names,
         ]
         self._phase(f"REVIEW: {phase}", "launch_review.sh", args)
 
     def run_phase2_specgen(self) -> None:
-        self._phase("PHASE 2: SPEC GENERATION", "launch_spec_generation.sh", self._phase_args(self.extract_names()))
+        self._phase(
+            "PHASE 2: SPEC GENERATION",
+            "launch_spec_generation.sh",
+            self._phase_args(self.extract_names(), phase="specgen"),
+        )
 
     def run_phase2_5_harness(self) -> None:
         self._phase(
             "PHASE 2.5: HARNESS GENERATION (instrumentation + trace collection)",
             "launch_harness_generation.sh",
-            self._phase_args(self.extract_names()),
+            self._phase_args(self.extract_names(), phase="harness"),
         )
 
     def run_phase3_validation(self) -> None:
         self._phase(
             "PHASE 3: SPEC VALIDATION (trace validation + invariant checking + bug hunting)",
             "launch_spec_validation.sh",
-            self._phase_args(self.extract_names()),
+            self._phase_args(self.extract_names(), phase="validate"),
         )
         self.advance_confirmation_generation(0)
 
@@ -1709,7 +1815,7 @@ class Pipeline:
             # explicit --max-parallel=1: omitted fans findings out to four,
             # while explicit 1 deliberately runs them serially. Other phases
             # still receive Pipeline's implicit default of one.
-            self._phase_args(self.extract_names(), pre=pre or None),
+            self._phase_args(self.extract_names(), pre=pre or None, phase="confirm"),
         )
 
     def run_phase3_repair(self, round_: int, names: list[str] | None = None) -> None:
@@ -1722,7 +1828,7 @@ class Pipeline:
         self._phase(
             f"REPAIR ROUND {round_}: PHASE 3 (scoped spec/fault/invariant repair)",
             "launch_spec_validation.sh",
-            self._phase_args(selected, pre=["--repair"]),
+            self._phase_args(selected, pre=["--repair"], phase="repair", fallback="validate"),
         )
         self.advance_confirmation_generation(round_, selected)
 
@@ -1730,7 +1836,7 @@ class Pipeline:
         self._phase(
             "PHASE 4b: BUG CLASSIFICATION (severity tier assignment)",
             "launch_bug_classification.sh",
-            self._phase_args(self.extract_names(), with_artifact=False),
+            self._phase_args(self.extract_names(), with_artifact=False, phase="classify"),
         )
 
     def run_repair_loop(self, prepared_commits: set[str] | None = None) -> set[str]:
@@ -1765,7 +1871,7 @@ class Pipeline:
         phase3_targets = set(recovered_commits)
         if not self.has_open_repair_requests():
             if recovered_commits:
-                self.wait_for_quota()
+                self.wait_for_phase_quota("confirm")
                 self.run_phase4_confirmation()
                 self.regenerate_ledger()
                 names = ", ".join(sorted(recovered_commits))
@@ -1791,7 +1897,9 @@ class Pipeline:
             repaired_names: list[str] = []
             for name in self.names_with_open_repair_requests():
                 try:
-                    self.wait_for_quota()  # budget pressure -> WAIT, never auto-defer
+                    self.wait_for_phase_quota(
+                        "repair", fallback="validate"
+                    )  # budget pressure -> WAIT, never auto-defer
                 except BaseException as exc:
                     detail = f"exit {exc.code}" if isinstance(exc, SystemExit) else f"{type(exc).__name__}: {exc}"
                     log(
@@ -1843,7 +1951,7 @@ class Pipeline:
                 phase3_targets.add(name)
 
             try:
-                self.wait_for_quota()
+                self.wait_for_phase_quota("confirm")
                 self.run_phase4_confirmation()  # normal Phase 4 on the fresh bug-report
             except BaseException as exc:
                 self.regenerate_ledger()
@@ -2088,7 +2196,13 @@ class Pipeline:
         print(f"Max turns:    {self.max_turns}")
         print(f"Policy retries: {self.policy_retries}")
         print(f"Transient resumes: {self.transient_resumes}")
-        print(f"Agent:        {self.agent}  (claude-alias={self.claude_alias})")
+        if self.agent_routing is None:
+            print(f"Agent:        {self.agent}  (claude-alias={self.claude_alias})")
+        else:
+            print(
+                f"Agent config: {self.agent_config_path}"
+                f"  (default={self._agent_selection().agent}, claude-alias={self.claude_alias})"
+            )
         memory_limit = self.tlc_memory_limit or os.environ.get(MEMORY_LIMIT_ENV) or "auto (80% available)"
         worker_limit = self.tlc_worker_limit or os.environ.get(WORKER_LIMIT_ENV) or "unbounded (report only)"
         print(f"TLC memory:   {memory_limit}")
@@ -2140,21 +2254,21 @@ class Pipeline:
         upstream_all_skipped = self.skip_analysis and self.skip_specgen and self.skip_harness
 
         if not self.skip_analysis:
-            self.wait_for_quota()
+            self.wait_for_phase_quota("analyze")
             self.run_phase1_analysis()
             self.run_review("analysis", names)
         else:
             log("Skipping Phase 1 (--skip-analysis)")
 
         if not self.skip_specgen:
-            self.wait_for_quota()
+            self.wait_for_phase_quota("specgen")
             self.run_phase2_specgen()
             self.run_review("specgen", names)
         else:
             log("Skipping Phase 2 (--skip-specgen)")
 
         if not self.skip_harness:
-            self.wait_for_quota()
+            self.wait_for_phase_quota("harness")
             self.run_phase2_5_harness()
         else:
             log("Skipping Phase 2.5 (--skip-harness)")
@@ -2178,7 +2292,7 @@ class Pipeline:
         )
         normal_phase3_ran = False
         if not self.skip_validation and not phase3_covered:
-            self.wait_for_quota()
+            self.wait_for_phase_quota("validate")
             self.run_phase3_validation()
             self.run_review("validation", names)
             normal_phase3_ran = True
@@ -2191,7 +2305,7 @@ class Pipeline:
         phase4_covered = resumed_repair and not normal_phase3_ran
         fresh_phase4_ran = False
         if not self.skip_confirmation and not phase4_covered:
-            self.wait_for_quota()
+            self.wait_for_phase_quota("confirm")
             self.run_phase4_confirmation()
             fresh_phase4_ran = True
         elif self.skip_confirmation:
@@ -2205,7 +2319,7 @@ class Pipeline:
             log("Skipping repair loop (--skip-repair-loop)")
 
         if not self.skip_classification:
-            self.wait_for_quota()
+            self.wait_for_phase_quota("classify")
             self.run_phase4b_classification()
         else:
             log("Skipping Phase 4b (--skip-classification)")

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -180,6 +180,62 @@ class CliE2E(unittest.TestCase):
                 self.assertEqual(meta["policy_retries"], 100)
                 self.assertEqual(meta["transient_resumes"], 80)
 
+    def test_agent_config_routes_phase_and_review_commands(self) -> None:
+        root = self.specroot()
+        work = self.workdir()
+        config = work / "agents.json"
+        config.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "default_profile": "reasoning",
+                    "profiles": {
+                        "reasoning": {
+                            "agent": "codex",
+                            "model": "gpt-5.6-sol",
+                            "effort": "ultra",
+                        },
+                        "confirmation": {
+                            "agent": "copilot-cli",
+                            "model": "claude-sonnet-4.5",
+                        },
+                        "reviewer": {
+                            "agent": "opencode",
+                            "model": "openai/gpt-5.4",
+                        },
+                    },
+                    "phases": {
+                        "confirm": "confirmation",
+                        "review": "reviewer",
+                    },
+                }
+            )
+        )
+
+        proc = self.run_cli(
+            root,
+            ["run", "--dry-run", "--enable-reviews", f"--agent-config={config.name}", "footest"],
+            cwd=work,
+        )
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        lines = proc.stdout.splitlines()
+        analysis = next(line for line in lines if "launch_code_analysis.sh" in line)
+        confirmation = next(line for line in lines if "launch_bug_confirmation.sh" in line)
+        review = next(line for line in lines if "launch_review.sh analysis" in line)
+        self.assertIn("--agent=codex", analysis)
+        self.assertIn("--model=gpt-5.6-sol", analysis)
+        self.assertIn("--effort=ultra", analysis)
+        self.assertIn("--agent=copilot-cli", confirmation)
+        self.assertIn("--model=claude-sonnet-4.5", confirmation)
+        self.assertIn("--agent=opencode", review)
+        self.assertIn("--model=openai/gpt-5.4", review)
+
+        meta = json.loads((self.sole_run_dir(root) / "run.json").read_text())
+        self.assertEqual(meta["agent_config"], str(config))
+        self.assertEqual(meta["agent_routes"]["confirm"]["agent"], "copilot-cli")
+        self.assertEqual(meta["agent_routes"]["review:analysis"]["agent"], "opencode")
+
     def test_run_json_records_argv(self) -> None:
         root = self.specroot()
         work = self.workdir()
@@ -188,6 +244,7 @@ class CliE2E(unittest.TestCase):
         meta = json.loads((run / "run.json").read_text())
         self.assertEqual(meta["targets"], ["footest"])
         self.assertEqual(meta["run_id"], run.name)
+        self.assertNotIn("agent_config", meta)
 
     def test_keep_original_dry_run_records_mode_without_copying(self) -> None:
         root = self.specroot()

--- a/tests/unit/test_agent_config.py
+++ b/tests/unit/test_agent_config.py
@@ -1,0 +1,135 @@
+"""Unit tests for strict agent configuration loading and routing."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from specula.agent_config import AgentConfigError, AgentSelection, load_agent_routing
+
+
+def _valid_config() -> dict[str, object]:
+    return {
+        "version": 1,
+        "default_profile": "claude",
+        "profiles": {
+            "claude": {"agent": "claude-code"},
+            "codex": {"agent": "codex", "model": "", "effort": ""},
+            "copilot": {"agent": "copilot-cli", "model": "gpt-5-mini", "effort": "low"},
+        },
+        "phases": {
+            "analyze": "codex",
+            "validate": "copilot",
+        },
+    }
+
+
+class AgentConfigTest(unittest.TestCase):
+    def load(self, payload: object) -> object:
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "agents.json"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            return load_agent_routing(path)
+
+    def assert_invalid(self, payload: object, message: str) -> None:
+        with self.assertRaisesRegex(AgentConfigError, message):
+            self.load(payload)
+
+    def test_resolves_explicit_fallback_and_default_profiles(self) -> None:
+        routing = load_agent_routing(self._write(_valid_config()))
+
+        self.assertEqual(routing.default, AgentSelection("claude-code"))
+        self.assertEqual(routing.resolve("analyze"), AgentSelection("codex", "", ""))
+        self.assertEqual(
+            routing.resolve("repair", fallback="validate"), AgentSelection("copilot-cli", "gpt-5-mini", "low")
+        )
+        self.assertEqual(routing.resolve("confirm"), routing.default)
+
+    def test_phases_are_optional(self) -> None:
+        payload = _valid_config()
+        del payload["phases"]
+
+        routing = load_agent_routing(self._write(payload))
+
+        self.assertEqual(routing.resolve("analyze"), routing.default)
+
+    def test_reports_read_and_json_errors_with_the_path(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            missing = Path(raw) / "missing.json"
+            with self.assertRaisesRegex(AgentConfigError, rf"cannot read agent config {missing}"):
+                load_agent_routing(missing)
+
+            invalid = Path(raw) / "invalid.json"
+            invalid.write_text("{", encoding="utf-8")
+            with self.assertRaisesRegex(AgentConfigError, rf"invalid JSON in agent config {invalid} at line 1"):
+                load_agent_routing(invalid)
+
+            invalid_utf8 = Path(raw) / "invalid-utf8.json"
+            invalid_utf8.write_bytes(b"\xff")
+            with self.assertRaisesRegex(AgentConfigError, rf"cannot read agent config {invalid_utf8}"):
+                load_agent_routing(invalid_utf8)
+
+    def test_rejects_invalid_top_level_fields(self) -> None:
+        cases: tuple[tuple[object, str], ...] = (
+            ([], "agent config must be a JSON object"),
+            ({"version": 1}, "default_profile"),
+            ({**_valid_config(), "extra": True}, "unknown field 'extra'"),
+            ({**_valid_config(), "version": True}, "version"),
+            ({**_valid_config(), "version": 2}, "version"),
+            ({**_valid_config(), "default_profile": 1}, "default_profile"),
+            ({**_valid_config(), "profiles": []}, "profiles.*JSON object"),
+        )
+        for payload, message in cases:
+            with self.subTest(message=message):
+                self.assert_invalid(payload, message)
+
+    def test_rejects_invalid_profiles(self) -> None:
+        cases: tuple[tuple[object, str], ...] = (
+            (
+                {
+                    **_valid_config(),
+                    "profiles": {"claude": {"agent": "claude-code", "extra": True}},
+                },
+                "profile 'claude'.*unknown field 'extra'",
+            ),
+            ({**_valid_config(), "profiles": {"claude": []}}, "profile 'claude'.*JSON object"),
+            ({**_valid_config(), "profiles": {"claude": {}}}, "agent.*non-empty string"),
+            ({**_valid_config(), "profiles": {"claude": {"agent": ""}}}, "agent.*non-empty string"),
+            ({**_valid_config(), "profiles": {"claude": {"agent": 1}}}, "agent.*non-empty string"),
+            (
+                {**_valid_config(), "profiles": {"claude": {"agent": "claude-code", "model": None}}},
+                "model.*string",
+            ),
+            (
+                {**_valid_config(), "profiles": {"claude": {"agent": "claude-code", "effort": 1}}},
+                "effort.*string",
+            ),
+            ({**_valid_config(), "default_profile": "missing"}, "default profile 'missing' does not exist"),
+        )
+        for payload, message in cases:
+            with self.subTest(message=message):
+                self.assert_invalid(payload, message)
+
+    def test_rejects_invalid_phase_routes(self) -> None:
+        cases: tuple[tuple[object, str], ...] = (
+            ({**_valid_config(), "phases": []}, "phases.*JSON object"),
+            ({**_valid_config(), "phases": {"analysis": "codex"}}, "unknown phase 'analysis'"),
+            ({**_valid_config(), "phases": {"analyze": 1}}, "phase 'analyze'.*profile by name"),
+            ({**_valid_config(), "phases": {"analyze": "missing"}}, "unknown profile 'missing'"),
+        )
+        for payload, message in cases:
+            with self.subTest(message=message):
+                self.assert_invalid(payload, message)
+
+    def _write(self, payload: object) -> Path:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        path = Path(directory.name) / "agents.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_agent_config.py
+++ b/tests/unit/test_agent_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import tempfile
 import unittest
@@ -38,7 +39,8 @@ class AgentConfigTest(unittest.TestCase):
             self.load(payload)
 
     def test_resolves_explicit_fallback_and_default_profiles(self) -> None:
-        routing = load_agent_routing(self._write(_valid_config()))
+        path = self._write(_valid_config())
+        routing = load_agent_routing(path)
 
         self.assertEqual(routing.default, AgentSelection("claude-code"))
         self.assertEqual(routing.resolve("analyze"), AgentSelection("codex", "", ""))
@@ -46,6 +48,7 @@ class AgentConfigTest(unittest.TestCase):
             routing.resolve("repair", fallback="validate"), AgentSelection("copilot-cli", "gpt-5-mini", "low")
         )
         self.assertEqual(routing.resolve("confirm"), routing.default)
+        self.assertEqual(routing.source_sha256, hashlib.sha256(path.read_bytes()).hexdigest())
 
     def test_phases_are_optional(self) -> None:
         payload = _valid_config()

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -642,6 +642,38 @@ class TestArgErrors(PhaseCase):
                 self.assertIn("default: 20", out)
 
 
+class TestReactiveRateLimitWait(unittest.TestCase):
+    def test_non_claude_agent_uses_fixed_fallback_sleep(self) -> None:
+        phase = phaselib.Phase()
+        phase._rate_limit_agent = "codex"
+        out = io.StringIO()
+
+        with (
+            contextlib.redirect_stdout(out),
+            mock.patch.object(quota, "wait_for_quota") as wait_for_quota,
+            mock.patch("specula.phaselib.time.sleep") as sleep,
+        ):
+            phase._wait_for_rate_limit()
+
+        wait_for_quota.assert_not_called()
+        sleep.assert_called_once_with(quota.RATE_LIMIT_FALLBACK_SECONDS)
+        self.assertIn("No quota reset endpoint for codex", out.getvalue())
+
+    def test_claude_agent_uses_quota_wait(self) -> None:
+        phase = phaselib.Phase()
+        phase._rate_limit_agent = "claude-code"
+
+        with (
+            mock.patch.object(quota, "wait_for_quota") as wait_for_quota,
+            mock.patch("specula.phaselib.time.sleep") as sleep,
+        ):
+            phase._wait_for_rate_limit()
+
+        wait_for_quota.assert_called_once()
+        self.assertTrue(wait_for_quota.call_args.kwargs["reactive"])
+        sleep.assert_not_called()
+
+
 class TestBugConfirmationAlternate(PhaseCase):
     def _patch_confirmation(self, codes: list[int]) -> list[tuple[int, str]]:
         from specula import confirmlib

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -13,6 +13,7 @@ stdlib unittest, collected natively by pytest; imports the installed package:
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import io
 import json
 import os
@@ -467,6 +468,36 @@ def make_pipeline(targets: list[str], **attrs: Any) -> pl.Pipeline:
     return p
 
 
+def write_agent_config(path: Path, phases: dict[str, str] | None = None) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "default_profile": "claude",
+                "profiles": {
+                    "claude": {
+                        "agent": "claude-code",
+                        "model": "claude-sonnet",
+                        "effort": "max",
+                    },
+                    "codex": {
+                        "agent": "codex",
+                        "model": "gpt-5.5",
+                        "effort": "high",
+                    },
+                    "copilot": {
+                        "agent": "copilot-cli",
+                        "model": "gpt-5-mini",
+                        "effort": "low",
+                    },
+                },
+                "phases": phases or {},
+            }
+        )
+    )
+    return path.resolve()
+
+
 class TestParsing(TmpCwd):
     def test_keep_original_is_opt_in_and_requires_isolation(self) -> None:
         default = pl.Pipeline()
@@ -766,6 +797,20 @@ class TestParsing(TmpCwd):
         self.assertIn("--model=", empty_args)
         self.assertIn("--effort=", empty_args)
 
+    def test_agent_config_conflicts_are_order_independent_and_include_empty_tuning(self) -> None:
+        config = write_agent_config(self.tmp / "agents.json")
+        for flag in ("--agent=codex", "--model=", "--effort="):
+            for argv in (
+                [f"--agent-config={config}", flag, "t"],
+                [flag, f"--agent-config={config}", "t"],
+            ):
+                with self.subTest(argv=argv):
+                    err = io.StringIO()
+                    with contextlib.redirect_stderr(err):
+                        rc = pl.Pipeline().parse_args(argv)
+                    self.assertEqual(rc, 1)
+                    self.assertIn("--agent-config cannot be combined", err.getvalue())
+
     def test_invalid_repair_round_cap_rejected_at_parse(self) -> None:
         for value in ("", "bad", "1.5", "-1", "+1"):
             with self.subTest(value=value):
@@ -807,6 +852,7 @@ class TestParsing(TmpCwd):
         rc, out = quiet(p.parse_args, ["--help"])
         self.assertEqual(rc, 0)
         self.assertIn("Full Specula pipeline", out)
+        self.assertIn("--agent-config=PATH", out)
         self.assertIn("--model=NAME", out)
         self.assertIn("--effort=LEVEL", out)
         self.assertIn("--policy-retries=N", out)
@@ -830,6 +876,140 @@ class TestParsing(TmpCwd):
         self.assertEqual(single.get_work_dir("a"), f"{self.tmp}/.specula-output")
         batch = make_pipeline(["a|x|y|z", "b|x|y|z"])
         self.assertEqual(batch.get_work_dir("a"), f"{self.tmp}/a/.specula-output")
+
+
+class TestAgentRouting(TmpCwd):
+    @staticmethod
+    def _agent_arg(args: list[str]) -> str:
+        return next(arg for arg in args if arg.startswith("--agent="))
+
+    def test_relative_config_routes_default_explicit_and_repair_fallback(self) -> None:
+        config = write_agent_config(
+            self.tmp / "agents.json",
+            {
+                "analyze": "codex",
+                "validate": "copilot",
+            },
+        )
+        p = pl.Pipeline()
+        self.assertIsNone(p.parse_args(["--agent-config=agents.json", "t"]))
+
+        later_cwd = self.tmp / "case-studies" / "t"
+        later_cwd.mkdir(parents=True)
+        os.chdir(later_cwd)
+
+        self.assertEqual(p.agent_config_path, config)
+        default_args = p._phase_args(["t"], phase="specgen")
+        self.assertIn("--agent=claude-code", default_args)
+        self.assertIn("--model=claude-sonnet", default_args)
+        explicit_args = p._phase_args(["t"], phase="analyze")
+        self.assertIn("--agent=codex", explicit_args)
+        self.assertIn("--model=gpt-5.5", explicit_args)
+        repair_args = p._phase_args(["t"], phase="repair", fallback="validate")
+        self.assertIn("--agent=copilot-cli", repair_args)
+        self.assertIn("--model=gpt-5-mini", repair_args)
+
+    def test_review_uses_reviewed_phase_fallback_or_explicit_review_route(self) -> None:
+        fallback_config = write_agent_config(
+            self.tmp / "fallback.json",
+            {
+                "analyze": "codex",
+                "validate": "copilot",
+            },
+        )
+        fallback = pl.Pipeline()
+        self.assertIsNone(fallback.parse_args([f"--agent-config={fallback_config}", "--enable-reviews", "t"]))
+        fallback_calls: list[list[str]] = []
+        fallback.wait_for_quota = mock.Mock()  # type: ignore[method-assign]
+        fallback._phase = lambda banner, script, args: fallback_calls.append(args)  # type: ignore[method-assign]
+
+        for phase in ("analysis", "specgen", "validation"):
+            fallback.run_review(phase, ["t"])
+
+        self.assertEqual([args[0] for args in fallback_calls], ["analysis", "specgen", "validation"])
+        self.assertEqual(
+            [self._agent_arg(args) for args in fallback_calls],
+            ["--agent=codex", "--agent=claude-code", "--agent=copilot-cli"],
+        )
+
+        explicit_config = write_agent_config(
+            self.tmp / "explicit.json",
+            {
+                "analyze": "codex",
+                "review": "copilot",
+            },
+        )
+        explicit = pl.Pipeline()
+        self.assertIsNone(explicit.parse_args([f"--agent-config={explicit_config}", "--enable-reviews", "t"]))
+        explicit_calls: list[list[str]] = []
+        explicit.wait_for_quota = mock.Mock()  # type: ignore[method-assign]
+        explicit._phase = lambda banner, script, args: explicit_calls.append(args)  # type: ignore[method-assign]
+
+        explicit.run_review("analysis", ["t"])
+
+        self.assertEqual(explicit_calls[0][0], "analysis")
+        self.assertEqual(self._agent_arg(explicit_calls[0]), "--agent=copilot-cli")
+
+    def test_proactive_quota_waits_only_for_claude_routes(self) -> None:
+        config = write_agent_config(
+            self.tmp / "agents.json",
+            {
+                "analyze": "codex",
+                "validate": "copilot",
+            },
+        )
+        p = pl.Pipeline()
+        self.assertIsNone(p.parse_args([f"--agent-config={config}", "t"]))
+        wait = mock.Mock()
+        p.wait_for_quota = wait  # type: ignore[method-assign]
+
+        p.wait_for_phase_quota("analyze")
+        p.wait_for_phase_quota("repair", fallback="validate")
+        p.wait_for_phase_quota("specgen")
+
+        wait.assert_called_once_with()
+
+    def test_run_metadata_records_config_hash_and_resolved_review_routes(self) -> None:
+        config = write_agent_config(
+            self.tmp / "agents.json",
+            {
+                "analyze": "codex",
+                "validate": "copilot",
+            },
+        )
+        p = pl.Pipeline()
+        self.assertIsNone(p.parse_args([f"--agent-config={config}", "t"]))
+        p.run_id = "run"
+        p.run_dir = self.tmp / "run"
+        p.run_dir.mkdir()
+
+        p._write_run_meta()
+
+        meta = json.loads((p.run_dir / "run.json").read_text())
+        self.assertEqual(meta["agent_config"], str(config))
+        self.assertEqual(meta["agent_config_sha256"], hashlib.sha256(config.read_bytes()).hexdigest())
+        routes = meta["agent_routes"]
+        expected_agents = {
+            "analyze": "codex",
+            "specgen": "claude-code",
+            "harness": "claude-code",
+            "validate": "copilot-cli",
+            "confirm": "claude-code",
+            "repair": "copilot-cli",
+            "classify": "claude-code",
+            "review:analysis": "codex",
+            "review:specgen": "claude-code",
+            "review:validation": "copilot-cli",
+        }
+        self.assertEqual({name: route["agent"] for name, route in routes.items()}, expected_agents)
+        self.assertEqual(
+            routes["review:analysis"],
+            {
+                "agent": "codex",
+                "model": "gpt-5.5",
+                "effort": "high",
+            },
+        )
 
 
 class TestPhaseParallelArgs(TmpCwd):
@@ -1030,6 +1210,7 @@ class TestRunReview(TmpCwd):
             transient_resumes=transient_resumes,
         )
         seen: list[list[str]] = []
+        p.wait_for_quota = lambda **kwargs: None  # type: ignore[method-assign]
         p._phase = lambda banner, script, args: seen.append(args)  # type: ignore[method-assign]
         p.run_review(phase, ["footest"])
         self.assertEqual(len(seen), 1)

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -909,6 +909,49 @@ class TestAgentRouting(TmpCwd):
         self.assertIn("--agent=copilot-cli", repair_args)
         self.assertIn("--model=gpt-5-mini", repair_args)
 
+    def test_config_routing_and_sha_use_the_same_file_read(self) -> None:
+        config = write_agent_config(self.tmp / "agents.json", {"analyze": "codex"})
+        source = config.read_bytes()
+        replacement = json.dumps(
+            {
+                "version": 1,
+                "default_profile": "replacement",
+                "profiles": {
+                    "replacement": {
+                        "agent": "copilot-cli",
+                    }
+                },
+            }
+        ).encode()
+        read_bytes = Path.read_bytes
+        reads = 0
+
+        def replace_after_read(path: Path) -> bytes:
+            nonlocal reads
+            data = read_bytes(path)
+            if path == config:
+                reads += 1
+                if reads == 1:
+                    config.write_bytes(replacement)
+            return data
+
+        p = pl.Pipeline()
+        with mock.patch.object(Path, "read_bytes", replace_after_read):
+            self.assertIsNone(p.parse_args([f"--agent-config={config}", "t"]))
+
+        self.assertEqual(reads, 1)
+        self.assertEqual(p._agent_selection("analyze").agent, "codex")
+        assert p.agent_routing is not None
+        self.assertEqual(p.agent_routing.source_sha256, hashlib.sha256(source).hexdigest())
+        self.assertEqual(config.read_bytes(), replacement)
+        p.run_id = "run"
+        p.run_dir = self.tmp / "run"
+        p.run_dir.mkdir()
+        p._write_run_meta()
+        meta = json.loads((p.run_dir / "run.json").read_text())
+        self.assertEqual(meta["agent_config_sha256"], hashlib.sha256(source).hexdigest())
+        self.assertEqual(meta["agent_routes"]["analyze"]["agent"], "codex")
+
     def test_review_uses_reviewed_phase_fallback_or_explicit_review_route(self) -> None:
         fallback_config = write_agent_config(
             self.tmp / "fallback.json",


### PR DESCRIPTION
## Summary

- add an explicit JSON `--agent-config` for per-phase agent, model, and effort profiles
- route analysis, generation, validation, confirmation, repair, classification, and reviews with documented fallback rules
- preserve the existing global agent flags when no config is provided
- record the config hash and resolved routes in `run.json`, with provider-aware quota handling

This implements the hybrid configuration referenced in #107.