### PR TITLE
Add human-readable output indexes

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -206,23 +206,26 @@ Runs are isolated by default under:
 
 ```text
 runs/<run-id>/
+├── index.md
 ├── run.json
 ├── tlc-resources.json
 ├── pipeline.log
 ├── pipeline-summary.md
 └── <name>/
     ├── .specula-output/
+    │   ├── index.md
+    │   └── ...             # Existing phase outputs stay in place
     ├── source/          # --keep-original only
     └── changes.patch   # --keep-original only
 ```
 
-The `.specula-output/` directory contains the modeling brief, specifications, harness, traces, reproduction tests, reports, and per-step logs. `runs/latest` points to the newest run.
+The run-level `index.md` is a compact target chooser. Each target link opens its `.specula-output/index.md`, which presents human-readable results as Recommended Reading, Confirmation Details, Technical Details, and Troubleshooting. It intentionally omits review artifacts, machine-readable records, state sidecars, caches, and detailed phase logs; those files remain in their existing locations. No existing phase output is moved. `pipeline-summary.md` remains the final run status, and `runs/latest` points to the newest run.
 
 By default, Specula works directly in the source passed through `--artifact`, so harness or reproduction work may modify it. Use `--keep-original` to run every phase on a private copy instead. The original checkout stays unchanged, and the final filesystem changes are written to `changes.patch`.
 
 The patch includes every non-`.git` change, including ignored, untracked, and generated files and executable-bit changes. Expect roughly one extra copy of the checkout and Git history. Unsafe layouts such as external symlinks, linked worktrees, submodules, nested repositories, or externally shared Git objects are rejected. Without the optional sandbox, this does not prevent a command from deliberately writing to the original absolute path.
 
-`--keep-original` requires the isolated layout and conflicts with `--no-isolate`. Without it, `--no-isolate` selects the legacy layout: a single target writes step outputs under `$PWD/.specula-output/`, or under `case-studies/<name>/.specula-output/` when that canonical case study exists; multiple targets use `$PWD/<name>/.specula-output/`. For a canonical single target, `pipeline.log` remains under the launch directory's `.specula-output/` while the step outputs and summary use the case-study directory.
+`--keep-original` requires the isolated layout and conflicts with `--no-isolate`. Without it, `--no-isolate` selects the legacy layout: a single target writes step outputs under `$PWD/.specula-output/`, or under `case-studies/<name>/.specula-output/` when that canonical case study exists; multiple targets use `$PWD/<name>/.specula-output/`. A legacy single-target run has only the target-level `.specula-output/index.md`, without a separate run-level target chooser. For a canonical single target, `pipeline.log` remains under the launch directory's `.specula-output/` while the step outputs and summary use the case-study directory.
 
 TLC can use substantial memory and temporary disk space during model checking. The bundled `scripts/tlc/run_model_check.sh` stores states under `TMPDIR` (or `/tmp`) by default; set `TLC_STATE_DIR` to a larger or faster filesystem when necessary.
 
@@ -367,4 +370,4 @@ The scheduler owns `--run-id`, `--isolate`, and `--no-isolate` so that each task
 
 ## Progress and Logs
 
-Agent activity is printed during each step and written to its log. Set `SPECULA_PROGRESS=off` to disable live reporting. After a run, start with `pipeline-summary.md` for deliverable status and log locations.
+Agent activity is printed during each step and written to its log. Set `SPECULA_PROGRESS=off` to disable live reporting. During or after a default isolated run, start with the run-level `index.md` to choose a target and browse its results; for a legacy single-target run, start with `.specula-output/index.md`. Use `pipeline-summary.md` for final deliverable status and `pipeline.log` for troubleshooting.

--- a/scripts/tlc/run_model_check.sh
+++ b/scripts/tlc/run_model_check.sh
@@ -383,6 +383,12 @@ for _ in {1..600}; do
         break
     fi
     if ! process_running "$TLC_PID"; then
+        # The owner may publish its status and exit between the status probe
+        # above and this liveness check. Prefer the published handshake so its
+        # report follows the normal stdout path.
+        if [ -s "$OWNER_STATUS" ]; then
+            break
+        fi
         wait "$TLC_PID" 2>/dev/null
         ADMISSION_RC=$?
         TLC_PID=""

--- a/src/specula/output_index.py
+++ b/src/specula/output_index.py
@@ -1,0 +1,366 @@
+"""Deterministic, human-readable navigation for Specula run outputs.
+
+The indexes are derived views only: pipeline, repair, resume, and confirmation
+never consume them. The renderer is limited to fixed files and shallow
+directory scans; it never walks runtime trees recursively.
+"""
+
+from __future__ import annotations
+
+import html
+import os
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import quote_from_bytes
+
+INDEX_FILENAME = "index.md"
+PIPELINE_LOG_ENV = "SPECULA_PIPELINE_LOG"
+_NOT_AVAILABLE = "Not available"
+
+
+@dataclass(frozen=True)
+class TargetOutput:
+    """One target row in a run index."""
+
+    name: str
+    work_dir: Path
+    output_root: Path
+
+
+def is_safe_target_name(name: str) -> bool:
+    """Whether name can be used as one output-layout path component."""
+    try:
+        os.fsencode(name)
+    except UnicodeError:
+        return False
+    candidate = Path(name)
+    return (
+        bool(name.strip())
+        and name not in (".", "..")
+        and not candidate.is_absolute()
+        and candidate.parts == (name,)
+        and not any(ord(character) < 32 for character in name)
+    )
+
+
+def _is_file(path: Path) -> bool:
+    try:
+        return not path.is_symlink() and path.is_file()
+    except (OSError, UnicodeError):
+        return False
+
+
+def _is_file_under(root: Path, path: Path) -> bool:
+    """Accept a file only when every component below root is non-symlink."""
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return False
+    current = root
+    try:
+        if current.is_symlink():
+            return False
+        for part in relative.parts:
+            current /= part
+            if current.is_symlink():
+                return False
+        return current.is_file()
+    except (OSError, UnicodeError):
+        return False
+
+
+def _is_dir_under(root: Path, path: Path) -> bool:
+    """Accept a directory only when every component below root is non-symlink."""
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return False
+    current = root
+    try:
+        if current.is_symlink():
+            return False
+        for part in relative.parts:
+            current /= part
+            if current.is_symlink():
+                return False
+        return current.is_dir()
+    except (OSError, UnicodeError):
+        return False
+
+
+def _path_below_root_is_symlink_free(root: Path, path: Path) -> bool:
+    """Lexically confine path to root and reject symlinks below that root."""
+    normalized_root = Path(os.path.abspath(root))
+    normalized_path = Path(os.path.abspath(path))
+    try:
+        relative = normalized_path.relative_to(normalized_root)
+    except ValueError:
+        return False
+    current = normalized_root
+    try:
+        for part in relative.parts:
+            current /= part
+            if current.is_symlink():
+                return False
+    except (OSError, UnicodeError):
+        return False
+    return True
+
+
+def _markdown_text(value: str) -> str:
+    """One safe Markdown table/heading fragment."""
+    one_line = " ".join(value.splitlines()).strip()
+    one_line = one_line.encode("utf-8", errors="replace").decode("utf-8")
+    escaped = html.escape(one_line, quote=False)
+    return escaped.replace("\\", "\\\\").replace("|", "\\|").replace("[", "\\[").replace("]", "\\]")
+
+
+def _relative_url(base: Path, target: Path) -> str:
+    relative = os.path.relpath(target, start=base).replace(os.sep, "/")
+    return quote_from_bytes(os.fsencode(relative), safe="/._~-")
+
+
+def _link(label: str, target: Path, base: Path) -> str:
+    return f"[{_markdown_text(label)}]({_relative_url(base, target)})"
+
+
+def _document(label: str, target: Path, base: Path) -> str:
+    if _is_file_under(base, target):
+        return _link(label, target, base)
+    return f"{_markdown_text(label)}: {_NOT_AVAILABLE}"
+
+
+def _reproduction_files(work_dir: Path, finding_id: str) -> list[Path]:
+    repro_dir = work_dir / "repro"
+    if not _is_dir_under(work_dir, repro_dir):
+        return []
+    prefix = f"test_bug{finding_id}_"
+    try:
+        entries = sorted(repro_dir.iterdir(), key=lambda path: path.name)
+    except OSError:
+        return []
+    return [path for path in entries if path.name.startswith(prefix) and _is_file_under(work_dir, path)]
+
+
+def _confirmation_rows(work_dir: Path) -> list[str]:
+    confirmation_dir = work_dir / "confirmation"
+    if not _is_dir_under(work_dir, confirmation_dir):
+        return []
+    try:
+        finding_dirs = sorted(confirmation_dir.iterdir(), key=lambda path: path.name)
+    except OSError:
+        return []
+
+    rows: list[str] = []
+    for finding_dir in finding_dirs:
+        if finding_dir.name.startswith(".") or not _is_dir_under(work_dir, finding_dir):
+            continue
+        investigation = finding_dir / "investigation.md"
+        debate = finding_dir / "debate.md"
+        reproductions = _reproduction_files(work_dir, finding_dir.name)
+        if not _is_file_under(work_dir, investigation) and not _is_file_under(work_dir, debate) and not reproductions:
+            continue
+
+        investigation_cell = (
+            _link("Read", investigation, work_dir) if _is_file_under(work_dir, investigation) else _NOT_AVAILABLE
+        )
+        debate_cell = _link("Read", debate, work_dir) if _is_file_under(work_dir, debate) else _NOT_AVAILABLE
+        reproduction_cell = (
+            " · ".join(_link(path.name, path, work_dir) for path in reproductions) if reproductions else _NOT_AVAILABLE
+        )
+        rows.append(
+            f"| {_markdown_text(finding_dir.name)} | {investigation_cell} | {debate_cell} | {reproduction_cell} |"
+        )
+    return rows
+
+
+def render_target_index(name: str, work_dir: Path, *, pipeline_log: Path | None = None) -> str:
+    """Render the approved human-facing target navigation."""
+    spec_dir = work_dir / "spec"
+    lines = [
+        f"# {_markdown_text(name)} Results",
+        "",
+        "Read the documents below from top to bottom.",
+        "",
+        "> Availability means that a document exists. It does not imply review approval",
+        "> or confirmation of every finding.",
+        "",
+        "## Recommended Reading",
+        "",
+        "| Step | Document | What it contains |",
+        "|---:|---|---|",
+        (
+            f"| 1 | {_document('Modeling brief', work_dir / 'modeling-brief.md', work_dir)} "
+            "| System model, bug families, and proposed invariants |"
+        ),
+        (
+            f"| 2 | {_document('Analysis report', work_dir / 'analysis-report.md', work_dir)} "
+            "| Detailed source-code investigation |"
+        ),
+        (
+            f"| 3 | {_document('Spec coverage', spec_dir / 'brief-coverage.md', work_dir)} · "
+            f"{_document('Instrumentation map', spec_dir / 'instrumentation-spec.md', work_dir)} "
+            "| How the analysis was translated into the model |"
+        ),
+        (
+            f"| 4 | {_document('Validation changelog', spec_dir / 'changelog.md', work_dir)} "
+            "| Model corrections and validation history |"
+        ),
+        (
+            f"| 5 | {_document('Model-checking report', spec_dir / 'bug-report.md', work_dir)} "
+            "| Candidate findings from model checking |"
+        ),
+        (
+            f"| 6 | {_document('Confirmation report', work_dir / 'confirmed-bugs.md', work_dir)} "
+            "| Findings checked against the real system |"
+        ),
+        (
+            f"| 7 | {_document('Severity report', work_dir / 'bug-severity.md', work_dir)} "
+            "| Severity view of confirmed findings |"
+        ),
+    ]
+
+    confirmation_rows = _confirmation_rows(work_dir)
+    if confirmation_rows:
+        lines += [
+            "",
+            "## Confirmation Details",
+            "",
+            "| Finding | Investigation | Discussion | Reproduction |",
+            "|---|---|---|---|",
+            *confirmation_rows,
+        ]
+
+    technical: list[str] = []
+    models = [
+        _link(path.name, path, work_dir)
+        for path in (spec_dir / "base.tla", spec_dir / "MC.tla", spec_dir / "Trace.tla")
+        if _is_file_under(work_dir, path)
+    ]
+    if models:
+        technical.append(f"- TLA+ models: {' · '.join(models)}")
+    harness_guide = work_dir / "harness" / "INSTRUMENTATION.md"
+    if _is_file_under(work_dir, harness_guide):
+        technical.append(f"- Harness guide: {_link('INSTRUMENTATION.md', harness_guide, work_dir)}")
+    repair_ledger = spec_dir / "repair-ledger.md"
+    if _is_file_under(work_dir, repair_ledger):
+        technical.append(f"- Repair history: {_link('repair-ledger.md', repair_ledger, work_dir)}")
+    if technical:
+        lines += ["", "## Technical Details", "", *technical]
+
+    if pipeline_log is not None and _is_file(pipeline_log):
+        lines += [
+            "",
+            "## Troubleshooting",
+            "",
+            f"- Full pipeline log: {_link('pipeline.log', pipeline_log, work_dir)}",
+        ]
+
+    return "\n".join(lines) + "\n"
+
+
+def render_run_index(
+    run_root: Path,
+    targets: list[TargetOutput],
+    *,
+    summary: Path,
+    pipeline_log: Path,
+) -> str:
+    """Render the intentionally minimal run-level target chooser."""
+    lines = [
+        "# Specula Run",
+        "",
+        "Select a target to browse its results.",
+        "",
+        "## Targets",
+        "",
+        "| Target | Results |",
+        "|---|---|",
+    ]
+    for target in targets:
+        target_index = target.work_dir / INDEX_FILENAME
+        result = (
+            _link("Open results", target_index, run_root)
+            if _path_below_root_is_symlink_free(target.output_root, target_index) and _is_file(target_index)
+            else _NOT_AVAILABLE
+        )
+        lines.append(f"| {_markdown_text(target.name)} | {result} |")
+
+    summary_cell = (
+        _link("pipeline-summary.md", summary, run_root) if _is_file_under(run_root, summary) else _NOT_AVAILABLE
+    )
+    log_cell = (
+        _link("pipeline.log", pipeline_log, run_root) if _is_file_under(run_root, pipeline_log) else _NOT_AVAILABLE
+    )
+    lines += [
+        "",
+        "## Run Status",
+        "",
+        f"- Final summary: {summary_cell}",
+        f"- Full pipeline log: {log_cell}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _atomic_write_if_changed(path: Path, content: str) -> bool:
+    """Publish a complete index, preserving the previous file on failure."""
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    if parent.is_symlink() or not parent.is_dir():
+        raise OSError(f"index parent is not a safe directory: {parent}")
+
+    if _is_file(path):
+        try:
+            if path.read_text(encoding="utf-8") == content:
+                return False
+        except (OSError, UnicodeError):
+            pass
+
+    temporary = parent / f".{path.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp"
+    fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
+    try:
+        handle = os.fdopen(fd, "w", encoding="utf-8")
+    except BaseException:
+        os.close(fd)
+        temporary.unlink(missing_ok=True)
+        raise
+    try:
+        with handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return True
+
+
+def write_target_index(
+    name: str,
+    work_dir: Path,
+    *,
+    output_root: Path,
+    pipeline_log: Path | None = None,
+) -> bool:
+    """Create or refresh one target index. Returns whether bytes changed."""
+    if not _path_below_root_is_symlink_free(output_root, work_dir):
+        raise OSError(f"target output escapes its layout root or crosses a symlink: {work_dir}")
+    if work_dir.exists() and (work_dir.is_symlink() or not work_dir.is_dir()):
+        raise OSError(f"target output is not a safe directory: {work_dir}")
+    content = render_target_index(name, work_dir, pipeline_log=pipeline_log)
+    return _atomic_write_if_changed(work_dir / INDEX_FILENAME, content)
+
+
+def write_run_index(
+    run_root: Path,
+    targets: list[TargetOutput],
+    *,
+    summary: Path,
+    pipeline_log: Path,
+) -> bool:
+    """Create or refresh the run-level target chooser."""
+    if run_root.exists() and (run_root.is_symlink() or not run_root.is_dir()):
+        raise OSError(f"run output is not a safe directory: {run_root}")
+    content = render_run_index(run_root, targets, summary=summary, pipeline_log=pipeline_log)
+    return _atomic_write_if_changed(run_root / INDEX_FILENAME, content)

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -37,6 +37,7 @@ import specula.progress as progress
 from specula import quota
 from specula.adapters.utils.policy import POLICY_BLOCKED_RC
 from specula.adapters.utils.transient import TRANSIENT_FAILURE_RC
+from specula.output_index import PIPELINE_LOG_ENV, is_safe_target_name, write_target_index
 from specula.prompts import render
 from specula.skill_refs import materialize_skill_refs, prompt_skill_ids
 from specula.snapshotlib import (
@@ -403,6 +404,30 @@ class Workspace:
         if any(os.pathsep in root for root in roots):
             raise RuntimeError("private source path cannot be represented in GIT_CEILING_DIRECTORIES")
         return os.pathsep.join(dict.fromkeys(roots)) or None
+
+
+def _refresh_target_indexes(ws: Workspace, names: list[str]) -> None:
+    """Best-effort navigation refresh; indexes never affect phase results."""
+    configured_log = os.environ.get(PIPELINE_LOG_ENV)
+    pipeline_log = Path(configured_log) if configured_log else None
+    if pipeline_log is None:
+        pipeline_log = (
+            ws.run_dir / "pipeline.log" if ws.run_dir is not None else ws.cwd / ".specula-output/pipeline.log"
+        )
+    output_root = ws.run_dir if ws.run_dir is not None else ws.cwd
+    for name in dict.fromkeys(names):
+        if not is_safe_target_name(name):
+            print(f"WARNING: cannot update output index for unsafe target name {name!r}", file=sys.stderr)
+            continue
+        try:
+            write_target_index(
+                name,
+                ws.work_dir(name),
+                output_root=output_root,
+                pipeline_log=pipeline_log,
+            )
+        except Exception as exc:
+            print(f"WARNING: cannot update output index for {name}: {exc}", file=sys.stderr)
 
 
 def _pin_sandbox_config(env: MutableMapping[str, str], launch_cwd: Path) -> None:
@@ -804,6 +829,9 @@ class Phase:
         print(f"Transient resumes: {transient_resumes}")
         print()
 
+        if not dry_run and not check_only:
+            _refresh_target_indexes(ws, names)
+
         print(self.check_header)
         if not self.check(ws, names):
             print()
@@ -828,6 +856,8 @@ class Phase:
             dry_run=dry_run,
         )
         if alt is not None:
+            if not dry_run:
+                _refresh_target_indexes(ws, names)
             return alt
 
         integrity_snapshot = self.capture_output_integrity(
@@ -895,6 +925,7 @@ class Phase:
                     running, completed = self._reap_agents(running, show_progress)
                     for completed_agent, rc in completed:
                         completed_names.add(completed_agent.name)
+                        _refresh_target_indexes(ws, [completed_agent.name])
                         if rc == 0:
                             successful_names.add(completed_agent.name)
                             continue
@@ -1010,6 +1041,8 @@ class Phase:
                     print(f"[{_ts()}] All agents completed.")
             except BaseException:
                 self._terminate_agents(running)
+                if not dry_run:
+                    _refresh_target_indexes(ws, names)
                 raise
 
         integrity_failures = self.audit_output_integrity(
@@ -1036,6 +1069,7 @@ class Phase:
 
         self.summarize(ws, names)
         if not dry_run:
+            _refresh_target_indexes(ws, names)
             self._acceptance(ws, names)
         if failures:
             print()
@@ -2322,11 +2356,15 @@ Prerequisites:
                         continue
                     break
             finally:
-                # A quota wait can abort (or the process can be interrupted)
-                # after the confirmation driver deliberately retained its exact
-                # session/worktree. Never leak that runtime lease when no next
-                # replay will execute in this process.
-                cfg.clear_retry_runtime()
+                try:
+                    # A quota wait can abort (or the process can be interrupted)
+                    # after the confirmation driver deliberately retained its exact
+                    # session/worktree. Never leak that runtime lease when no next
+                    # replay will execute in this process.
+                    cfg.clear_retry_runtime()
+                finally:
+                    if not dry_run:
+                        _refresh_target_indexes(ws, [name])
             if code != 0:
                 failures.append((name, code))
                 if code == quota.RATE_LIMIT_RC:
@@ -2629,6 +2667,8 @@ Output:
             print(f"ERROR: cannot restore private source: {exc}")
             return 1
 
+        _refresh_target_indexes(ws, names)
+
         print("========================================")
         print(f" Specula — Review Agent ({phase})")
         print("========================================")
@@ -2640,17 +2680,20 @@ Output:
             for name in names:
                 request = _LaunchRequest(name)
                 while True:
-                    rc = self._launch_review(
-                        ws,
-                        name,
-                        phase,
-                        adapter,
-                        claude_alias,
-                        policy_attempt=request.policy_attempt,
-                        transient_attempt=request.transient_attempt,
-                        invocation_attempt=request.invocation_attempt,
-                        retry_reason=request.retry_reason,
-                    )
+                    try:
+                        rc = self._launch_review(
+                            ws,
+                            name,
+                            phase,
+                            adapter,
+                            claude_alias,
+                            policy_attempt=request.policy_attempt,
+                            transient_attempt=request.transient_attempt,
+                            invocation_attempt=request.invocation_attempt,
+                            retry_reason=request.retry_reason,
+                        )
+                    finally:
+                        _refresh_target_indexes(ws, [name])
                     if (
                         rc == quota.RATE_LIMIT_RC
                         and self._reactive_rate_limit_enabled()

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -40,6 +40,13 @@ if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from specula import quota as _quota
 from specula.agent_config import AgentConfigError, AgentRouting, AgentSelection, load_agent_routing
+from specula.output_index import (
+    PIPELINE_LOG_ENV,
+    TargetOutput,
+    is_safe_target_name,
+    write_run_index,
+    write_target_index,
+)
 from specula.phaselib import (
     DEFAULT_POLICY_RETRIES,
     DEFAULT_TRANSIENT_RESUMES,
@@ -147,31 +154,15 @@ Options:
   --run-id=ID            Attach to runs/ID — reuse an existing run's workspace,
                          e.g. to resume with --skip-* flags (implies --isolate)
 
-Output structure (per system):
-  .specula-output/
-    ├── analysis-report.md          # Phase 1 output
-    ├── modeling-brief.md           # Phase 1 output
-    ├── agent.log                   # Phase 1 agent log
-    ├── review-analysis.md          # Phase 1 review
-    ├── review-analysis.log         # Phase 1 review agent log
-    ├── spec/
-    │   ├── base.tla                # Phase 2 output
-    │   ├── MC.tla                  # Phase 2 output
-    │   ├── Trace.tla               # Phase 2 output
-    │   ├── instrumentation-spec.md # Phase 2 output
-    │   ├── MC_hunt_*.cfg          # Phase 2 output (bug hunting configs)
-    │   ├── changelog.md           # Phase 3 output
-    │   ├── output/                # Phase 3 output (TLC results)
-    │   └── bug-report.md          # Phase 3 output (bug hunting results)
-    ├── harness/                     # Phase 2.5 output
-    │   ├── src/                   # Trace module + test scenarios
-    │   ├── apply.sh               # Apply instrumentation
-    │   ├── run.sh                 # Build + run + collect traces
-    │   └── INSTRUMENTATION.md     # Guide for adjusting instrumentation
-    ├── traces/                      # Phase 2.5 output (NDJSON traces)
-    ├── spec-gen.log                # Phase 2 agent log
-    ├── harness-gen.log             # Phase 2.5 agent log
-    └── pipeline.log                # This script's log
+Output navigation (default isolated layout):
+  runs/<run-id>/
+    ├── index.md                    # Choose a target
+    ├── pipeline-summary.md         # Final run summary, when available
+    ├── pipeline.log                # Full pipeline log
+    └── <name>/
+        └── .specula-output/
+            ├── index.md            # Human-readable results guide
+            └── ...                 # Existing phase artifacts
 
 """
 
@@ -340,6 +331,7 @@ class Pipeline:
         self.run_id = ""
         self._run_id_given = False  # `--run-id=` (empty) must error, not mint a fresh id
         self.run_dir: Path | None = None
+        self.pipeline_log_path: Path | None = None
         self.tlc_scope = ""
         self.argv: list[str] = []
 
@@ -921,6 +913,80 @@ class Pipeline:
         if len(self.targets) == 1:
             return f"{_logical_cwd()}/.specula-output"
         return f"{_logical_cwd()}/{name}/.specula-output"
+
+    @staticmethod
+    def _descriptor_name(target: str) -> str:
+        first_line = target.split("\n", 1)[0]
+        return first_line.split("|", 1)[0].strip()
+
+    def _index_names(self) -> list[str]:
+        """Original run targets first, so a partial resume cannot erase rows."""
+        descriptors: list[str] = []
+        if self.run_dir is not None:
+            metadata = self.run_dir / "run.json"
+            with contextlib.suppress(OSError, UnicodeError, json.JSONDecodeError):
+                document = json.loads(metadata.read_text())
+                stored = document.get("targets") if isinstance(document, dict) else None
+                if isinstance(stored, list):
+                    descriptors.extend(target for target in stored if isinstance(target, str))
+        descriptors.extend(self.targets)
+        names = [self._descriptor_name(target) for target in descriptors]
+        return list(dict.fromkeys(name for name in names if name))
+
+    def _index_targets(self) -> list[TargetOutput]:
+        targets: list[TargetOutput] = []
+        output_root = self.run_dir if self.run_dir is not None else _logical_cwd()
+        for name in self._index_names():
+            if not is_safe_target_name(name):
+                log(f"WARNING: cannot update output index for unsafe target name {name!r}")
+                continue
+            targets.append(TargetOutput(name, Path(self.get_work_dir(name)), output_root))
+        return targets
+
+    def refresh_target_indexes(self) -> list[TargetOutput]:
+        """Best-effort target navigation refresh; never changes pipeline status."""
+        if self.dry_run:
+            return []
+        try:
+            targets = self._index_targets()
+        except Exception as exc:
+            log(f"WARNING: cannot resolve output indexes: {exc}")
+            return []
+        for target in targets:
+            try:
+                write_target_index(
+                    target.name,
+                    target.work_dir,
+                    output_root=target.output_root,
+                    pipeline_log=self.pipeline_log_path,
+                )
+            except Exception as exc:
+                log(f"WARNING: cannot update output index for {target.name}: {exc}")
+        return targets
+
+    def refresh_output_indexes(self) -> None:
+        """Refresh target indexes, then the run-level target chooser when distinct."""
+        targets = self.refresh_target_indexes()
+        if not targets or self.pipeline_log_path is None:
+            return
+        if self.run_dir is not None:
+            run_root = self.run_dir
+        elif len(targets) > 1:
+            # Legacy multi-target has a distinct launch-level output directory.
+            # Legacy single-target collapses run and target index to one path, so
+            # only the detailed target index is generated.
+            run_root = self.pipeline_log_path.parent
+        else:
+            return
+        try:
+            write_run_index(
+                run_root,
+                targets,
+                summary=run_root / "pipeline-summary.md",
+                pipeline_log=self.pipeline_log_path,
+            )
+        except Exception as exc:
+            log(f"WARNING: cannot update run index: {exc}")
 
     def prepare_source_snapshots(self, names: list[str]) -> None:
         if not self.keep_original:
@@ -1665,6 +1731,8 @@ class Pipeline:
             env[WORKER_LIMIT_ENV] = self.tlc_worker_limit
         if self.tlc_scope:
             env[SCOPE_ENV] = self.tlc_scope
+        if self.pipeline_log_path is not None:
+            env[PIPELINE_LOG_ENV] = str(self.pipeline_log_path)
 
         proc: subprocess.Popen[bytes] | None = None
         received: list[tuple[int, float]] = []
@@ -1736,7 +1804,10 @@ class Pipeline:
         if self.dry_run:
             log(f"[DRY RUN] bash scripts/launch/{script} {' '.join(args)}")
             return
-        self._run_launcher(script, args)
+        try:
+            self._run_launcher(script, args)
+        finally:
+            self.refresh_target_indexes()
 
     def run_phase1_analysis(self) -> None:
         self._phase(
@@ -1865,6 +1936,7 @@ class Pipeline:
         divider()
 
         recovered_commits = self.prepare_repair_state() if prepared_commits is None else set(prepared_commits)
+        self.refresh_target_indexes()
         phase3_targets = set(recovered_commits)
         if not self.has_open_repair_requests():
             if recovered_commits:
@@ -2248,6 +2320,7 @@ class Pipeline:
         # snapshot token commits. Skip flags control later work, never whether
         # durable crash state is reconciled.
         recovered_phase3_commits = self.prepare_repair_state()
+        self.refresh_output_indexes()
         upstream_all_skipped = self.skip_analysis and self.skip_specgen and self.skip_harness
 
         if not self.skip_analysis:
@@ -2322,6 +2395,7 @@ class Pipeline:
             log("Skipping Phase 4b (--skip-classification)")
 
         self.generate_summary()
+        self.refresh_output_indexes()
 
         elapsed = int(time.time()) - start_time
         print()
@@ -2356,6 +2430,7 @@ def main(argv: list[str]) -> int:
         out_dir = _logical_cwd() / ".specula-output"
         out_dir.mkdir(parents=True, exist_ok=True)
         log_path = out_dir / "pipeline.log"
+    p.pipeline_log_path = log_path
     tee = subprocess.Popen(["tee", str(log_path)], stdin=subprocess.PIPE)
     assert tee.stdin is not None  # stdin=PIPE
     tee_in = tee.stdin
@@ -2380,6 +2455,12 @@ def main(argv: list[str]) -> int:
             traceback.print_exc()
             if code == 0:
                 code = 130 if isinstance(e, KeyboardInterrupt) else 1
+        try:
+            p.refresh_output_indexes()
+        except BaseException:
+            # Navigation is a disposable view and must never mask the pipeline's
+            # original exit status, including on an interrupted cleanup path.
+            traceback.print_exc()
         sys.stdout.flush()
         sys.stderr.flush()
         # release every write end of the pipe before waiting, or tee never EOFs
@@ -2392,6 +2473,10 @@ def main(argv: list[str]) -> int:
         # non-zero, so a failing tee (unwritable/full log) wins even when main
         # also failed — verified: `set -o pipefail; (exit 2)|(exit 1)` exits 1.
         tee_rc = tee.wait()
+        with contextlib.suppress(BaseException):
+            # tee creates the log asynchronously. Refresh once more after EOF so
+            # even an immediate pipeline failure gets a Troubleshooting link.
+            p.refresh_output_indexes()
         if tee_rc != 0:
             code = tee_rc
     return code

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -43,6 +43,7 @@ _VOLATILE = (
     "SPECULA_RUN_DIR",
     "SPECULA_PHASE",
     "SPECULA_WORK_DIR",
+    "SPECULA_PIPELINE_LOG",
     "SPECULA_SOURCE_SNAPSHOT",
     "SPECULA_SANDBOX_EXTRA_WRITE",
     "SPECULA_STOP_GATE",
@@ -55,6 +56,16 @@ _VOLATILE = (
     "CODEX_MODEL",
     "CODEX_EFFORT",
     "COPILOT_MODEL",
+)
+
+ALL_PHASE_SKIPS = (
+    "--skip-analysis",
+    "--skip-specgen",
+    "--skip-harness",
+    "--skip-validate",
+    "--skip-confirmation",
+    "--skip-classification",
+    "--skip-repair-loop",
 )
 
 
@@ -144,6 +155,52 @@ class CliE2E(unittest.TestCase):
         self.assertIn("Specula", out)
         self.assertIn("[DRY RUN] bash scripts/launch/launch_code_analysis.sh", out)
         self.assertIn("Pipeline completed", out)
+
+    def test_noop_run_writes_two_level_human_indexes(self) -> None:
+        root = self.specroot()
+        work = self.workdir()
+        proc = self.run_cli(root, ["run", *ALL_PHASE_SKIPS, "footest"], cwd=work)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        run = self.sole_run_dir(root)
+        run_index = (run / "index.md").read_text()
+        target_dir = run / "footest" / ".specula-output"
+        target_index = (target_dir / "index.md").read_text()
+
+        self.assertIn("| footest | [Open results](footest/.specula-output/index.md) |", run_index)
+        self.assertIn("- Final summary: [pipeline-summary.md](pipeline-summary.md)", run_index)
+        self.assertNotIn("run.json", run_index)
+        self.assertNotIn("tlc-resources.json", run_index)
+
+        self.assertIn("# footest Results", target_index)
+        self.assertIn("## Recommended Reading", target_index)
+        self.assertIn("Modeling brief: Not available", target_index)
+        self.assertIn("[pipeline.log](../../pipeline.log)", target_index)
+        self.assertNotIn("## Reviews", target_index)
+        self.assertNotIn("findings.json", target_index)
+        self.assertFalse((run / "reports").exists())
+        self.assertFalse((target_dir / "classification").exists())
+
+    def test_noop_multi_target_run_keeps_target_indexes_separate(self) -> None:
+        root = self.specroot(case_dirs=("alpha", "beta"))
+        work = self.workdir()
+        proc = self.run_cli(
+            root,
+            ["run", *ALL_PHASE_SKIPS, "alpha|o/a|Go|ref", "beta|o/b|Rust|ref"],
+            cwd=work,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        run = self.sole_run_dir(root)
+        run_index = (run / "index.md").read_text()
+        self.assertIn("| alpha | [Open results](alpha/.specula-output/index.md) |", run_index)
+        self.assertIn("| beta | [Open results](beta/.specula-output/index.md) |", run_index)
+        alpha = (run / "alpha" / ".specula-output" / "index.md").read_text()
+        beta = (run / "beta" / ".specula-output" / "index.md").read_text()
+        self.assertIn("# alpha Results", alpha)
+        self.assertNotIn("beta", alpha)
+        self.assertIn("# beta Results", beta)
+        self.assertNotIn("alpha", beta)
 
     def test_run_tuning_and_retry_budgets_reach_phase_and_review_commands(self) -> None:
         for model, effort in (("gpt-5.5", "high"), ("", "")):
@@ -302,6 +359,57 @@ class CliE2E(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertTrue((work / ".specula-output" / "pipeline.log").is_file(), "legacy layout not written")
         self.assertFalse((root / "runs").exists(), "--no-isolate must not mint a run dir")
+
+    def test_no_isolate_single_target_uses_one_detailed_index(self) -> None:
+        root = self.specroot(case_dirs=())
+        work = self.workdir()
+        proc = self.run_cli(root, ["run", "--no-isolate", *ALL_PHASE_SKIPS, "nocase"], cwd=work)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        index = (work / ".specula-output" / "index.md").read_text()
+        self.assertIn("# nocase Results", index)
+        self.assertIn("## Recommended Reading", index)
+        self.assertNotIn("# Specula Run", index)
+        self.assertIn("[pipeline.log](pipeline.log)", index)
+        self.assertFalse((root / "runs").exists())
+
+    def test_no_isolate_canonical_single_target_links_launch_log(self) -> None:
+        root = self.specroot()
+        work = self.workdir()
+        proc = self.run_cli(root, ["run", "--no-isolate", *ALL_PHASE_SKIPS, "footest"], cwd=work)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        target_dir = root / "case-studies" / "footest" / ".specula-output"
+        target_index = (target_dir / "index.md").read_text()
+        pipeline_log = work / ".specula-output" / "pipeline.log"
+        relative_log = os.path.relpath(pipeline_log, start=target_dir).replace(os.sep, "/")
+        self.assertIn("# footest Results", target_index)
+        self.assertIn(f"[pipeline.log]({relative_log})", target_index)
+        self.assertTrue((target_dir / "pipeline-summary.md").is_file())
+        self.assertFalse((work / ".specula-output" / "index.md").exists())
+
+    def test_no_isolate_multi_target_keeps_a_distinct_run_chooser(self) -> None:
+        root = self.specroot(case_dirs=())
+        work = self.workdir()
+        proc = self.run_cli(
+            root,
+            [
+                "run",
+                "--no-isolate",
+                *ALL_PHASE_SKIPS,
+                "alpha|o/a|Go|ref",
+                "beta|o/b|Rust|ref",
+            ],
+            cwd=work,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        run_index = (work / ".specula-output" / "index.md").read_text()
+        self.assertIn("# Specula Run", run_index)
+        self.assertIn("[Open results](../alpha/.specula-output/index.md)", run_index)
+        self.assertIn("[Open results](../beta/.specula-output/index.md)", run_index)
+        self.assertIn("# alpha Results", (work / "alpha" / ".specula-output" / "index.md").read_text())
+        self.assertIn("# beta Results", (work / "beta" / ".specula-output" / "index.md").read_text())
 
     # ── batch (scheduler) dry-run ────────────────────────────────────────────
     def test_batch_dry_run_over_queue(self) -> None:

--- a/tests/unit/test_output_index.py
+++ b/tests/unit/test_output_index.py
@@ -1,0 +1,388 @@
+"""Unit tests for the deterministic, human-facing output indexes."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from specula import output_index as oi
+
+
+class OutputIndexCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self._temporary.cleanup)
+        self.root = Path(self._temporary.name).resolve()
+
+    @staticmethod
+    def write(base: Path, relative: str, content: str = "content\n") -> Path:
+        path = base / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+
+class TestRunIndex(OutputIndexCase):
+    def test_minimal_deterministic_status_and_noop_refresh(self) -> None:
+        run_root = self.root / "run"
+        beta = run_root / "beta" / ".specula-output"
+        alpha = run_root / "alpha" / ".specula-output"
+        self.assertTrue(oi.write_target_index("beta", beta, output_root=run_root))
+        self.assertTrue(oi.write_target_index("alpha", alpha, output_root=run_root))
+        pipeline_log = self.write(run_root, "pipeline.log")
+        self.write(run_root, "run.json")
+        self.write(run_root, "tlc-resources.json")
+        summary = run_root / "pipeline-summary.md"
+        targets = [
+            oi.TargetOutput("beta", beta, run_root),
+            oi.TargetOutput("alpha", alpha, run_root),
+        ]
+
+        expected_pending = textwrap.dedent(
+            """\
+            # Specula Run
+
+            Select a target to browse its results.
+
+            ## Targets
+
+            | Target | Results |
+            |---|---|
+            | beta | [Open results](beta/.specula-output/index.md) |
+            | alpha | [Open results](alpha/.specula-output/index.md) |
+
+            ## Run Status
+
+            - Final summary: Not available
+            - Full pipeline log: [pipeline.log](pipeline.log)
+            """
+        )
+        self.assertEqual(
+            oi.render_run_index(run_root, targets, summary=summary, pipeline_log=pipeline_log),
+            expected_pending,
+        )
+
+        self.assertTrue(oi.write_run_index(run_root, targets, summary=summary, pipeline_log=pipeline_log))
+        index = run_root / "index.md"
+        self.assertEqual(index.read_text(), expected_pending)
+        self.assertFalse(oi.write_run_index(run_root, targets, summary=summary, pipeline_log=pipeline_log))
+        self.assertEqual(index.read_text(), expected_pending)
+
+        summary.write_text("# Complete\n")
+        self.assertTrue(oi.write_run_index(run_root, targets, summary=summary, pipeline_log=pipeline_log))
+        completed = index.read_text()
+        self.assertIn("- Final summary: [pipeline-summary.md](pipeline-summary.md)", completed)
+        self.assertLess(completed.index("| beta |"), completed.index("| alpha |"))
+        for machine_detail in ("run.json", "tlc-resources.json", "model", "SHA", "## Reviews"):
+            self.assertNotIn(machine_detail, completed)
+        self.assertFalse(oi.write_run_index(run_root, targets, summary=summary, pipeline_log=pipeline_log))
+
+
+class TestTargetIndex(OutputIndexCase):
+    def test_approved_seven_step_reading_order_has_no_reviews_or_machine_files(self) -> None:
+        work_dir = self.root / ".specula-output"
+        for relative in (
+            "modeling-brief.md",
+            "analysis-report.md",
+            "spec/brief-coverage.md",
+            "spec/instrumentation-spec.md",
+            "spec/changelog.md",
+            "spec/bug-report.md",
+            "confirmed-bugs.md",
+            "bug-severity.md",
+        ):
+            self.write(work_dir, relative)
+        for hidden_from_humans in (
+            "review-analysis.md",
+            "spec/review-specgen.md",
+            "spec/review-validation.md",
+            "spec/findings.json",
+            "spec/candidates.json",
+            "agent.pid",
+            "agent.usage.json",
+            "agent.resume.json",
+        ):
+            self.write(work_dir, hidden_from_humans)
+
+        expected = textwrap.dedent(
+            """\
+            # demo Results
+
+            Read the documents below from top to bottom.
+
+            > Availability means that a document exists. It does not imply review approval
+            > or confirmation of every finding.
+
+            ## Recommended Reading
+
+            | Step | Document | What it contains |
+            |---:|---|---|
+            | 1 | [Modeling brief](modeling-brief.md) | System model, bug families, and proposed invariants |
+            | 2 | [Analysis report](analysis-report.md) | Detailed source-code investigation |
+            | 3 | [Spec coverage](spec/brief-coverage.md) · [Instrumentation map](spec/instrumentation-spec.md) | How the analysis was translated into the model |
+            | 4 | [Validation changelog](spec/changelog.md) | Model corrections and validation history |
+            | 5 | [Model-checking report](spec/bug-report.md) | Candidate findings from model checking |
+            | 6 | [Confirmation report](confirmed-bugs.md) | Findings checked against the real system |
+            | 7 | [Severity report](bug-severity.md) | Severity view of confirmed findings |
+            """
+        )
+        rendered = oi.render_target_index("demo", work_dir)
+        self.assertEqual(rendered, expected)
+        for hidden_from_humans in (
+            "review-analysis.md",
+            "review-specgen.md",
+            "review-validation.md",
+            "findings.json",
+            "candidates.json",
+            "agent.pid",
+            "agent.usage.json",
+            "agent.resume.json",
+            "## Reviews",
+            "Machine-Readable",
+        ):
+            self.assertNotIn(hidden_from_humans, rendered)
+
+    def test_optional_sections_only_show_available_human_documents(self) -> None:
+        work_dir = self.root / "run" / "demo" / ".specula-output"
+        self.write(work_dir, "spec/findings.json")
+        self.write(work_dir, "spec/candidates.json")
+        self.write(work_dir, "confirmation/MC-1/verdict.json")
+        pipeline_log = work_dir.parents[1] / "pipeline.log"
+
+        minimal = oi.render_target_index("demo", work_dir, pipeline_log=pipeline_log)
+        for section in ("## Confirmation Details", "## Technical Details", "## Troubleshooting"):
+            self.assertNotIn(section, minimal)
+
+        self.write(work_dir, "spec/base.tla")
+        self.write(work_dir, "spec/MC.tla")
+        self.write(work_dir, "harness/INSTRUMENTATION.md")
+        self.write(work_dir, "spec/repair-ledger.md")
+        pipeline_log.write_text("pipeline\n")
+        rendered = oi.render_target_index("demo", work_dir, pipeline_log=pipeline_log)
+
+        self.assertIn("## Technical Details", rendered)
+        self.assertIn("- TLA+ models: [base.tla](spec/base.tla) · [MC.tla](spec/MC.tla)", rendered)
+        self.assertNotIn("Trace.tla", rendered)
+        self.assertIn("- Harness guide: [INSTRUMENTATION.md](harness/INSTRUMENTATION.md)", rendered)
+        self.assertIn("- Repair history: [repair-ledger.md](spec/repair-ledger.md)", rendered)
+        self.assertIn("## Troubleshooting", rendered)
+        self.assertIn("- Full pipeline log: [pipeline.log](../../pipeline.log)", rendered)
+        self.assertNotIn("## Confirmation Details", rendered)
+        for machine_file in ("findings.json", "candidates.json", "verdict.json"):
+            self.assertNotIn(machine_file, rendered)
+
+    def test_confirmation_rows_are_sorted_partial_and_match_reproductions_by_finding(self) -> None:
+        work_dir = self.root / ".specula-output"
+        self.write(work_dir, "confirmation/MC-2/investigation.md")
+        self.write(work_dir, "confirmation/MC-1/debate.md")
+        self.write(work_dir, "confirmation/MC-3/verdict.json")
+        self.write(work_dir, "repro/test_bugMC-1_z.py")
+        self.write(work_dir, "repro/test_bugMC-1_a.py")
+        self.write(work_dir, "repro/test_bugMC-2_case.py")
+        self.write(work_dir, "repro/test_bugMC-10_other.py")
+        self.write(work_dir, "repro/unrelated.py")
+
+        rendered = oi.render_target_index("demo", work_dir)
+        self.assertIn("## Confirmation Details", rendered)
+        mc1 = (
+            "| MC-1 | Not available | [Read](confirmation/MC-1/debate.md) | "
+            "[test_bugMC-1_a.py](repro/test_bugMC-1_a.py) · "
+            "[test_bugMC-1_z.py](repro/test_bugMC-1_z.py) |"
+        )
+        mc2 = (
+            "| MC-2 | [Read](confirmation/MC-2/investigation.md) | Not available | "
+            "[test_bugMC-2_case.py](repro/test_bugMC-2_case.py) |"
+        )
+        self.assertIn(mc1, rendered)
+        self.assertIn(mc2, rendered)
+        self.assertLess(rendered.index(mc1), rendered.index(mc2))
+        for excluded in ("MC-3 |", "test_bugMC-10_other.py", "unrelated.py", "verdict.json"):
+            self.assertNotIn(excluded, rendered)
+
+
+class TestIndexSafety(OutputIndexCase):
+    def test_symlinked_inputs_and_unlisted_trees_are_never_followed(self) -> None:
+        work_dir = self.root / ".specula-output"
+        work_dir.mkdir()
+        outside = self.root / "outside"
+        self.write(outside, "document.md")
+        self.write(outside, "confirmation/MC-9/investigation.md")
+        (work_dir / "modeling-brief.md").symlink_to(outside / "document.md")
+        (work_dir / "spec").mkdir()
+        (work_dir / "spec" / "base.tla").symlink_to(outside / "document.md")
+        (work_dir / "confirmation").symlink_to(outside / "confirmation", target_is_directory=True)
+        self.write(work_dir, "spec/output/deep/unlisted.md")
+
+        with mock.patch.object(Path, "rglob", side_effect=AssertionError("recursive scan attempted")):
+            rendered = oi.render_target_index("demo", work_dir)
+
+        self.assertIn("| 1 | Modeling brief: Not available |", rendered)
+        self.assertNotIn("## Confirmation Details", rendered)
+        self.assertNotIn("## Technical Details", rendered)
+        self.assertNotIn("unlisted.md", rendered)
+
+        parent_symlink = self.root / "parent-symlink" / ".specula-output"
+        parent_symlink.mkdir(parents=True)
+        self.write(outside, "base.tla")
+        (parent_symlink / "spec").symlink_to(outside, target_is_directory=True)
+        parent_rendered = oi.render_target_index("parent-symlink", parent_symlink)
+        self.assertNotIn("[base.tla]", parent_rendered)
+        self.assertNotIn("## Technical Details", parent_rendered)
+
+        safe_confirmation = self.root / "safe" / ".specula-output"
+        self.write(safe_confirmation, "confirmation/MC-1/debate.md")
+        repro_dir = safe_confirmation / "repro"
+        repro_dir.mkdir()
+        (repro_dir / "test_bugMC-1_escape.py").symlink_to(outside / "document.md")
+        safe_rendered = oi.render_target_index("safe", safe_confirmation)
+        self.assertIn(
+            "| MC-1 | Not available | [Read](confirmation/MC-1/debate.md) | Not available |",
+            safe_rendered,
+        )
+        self.assertNotIn("test_bugMC-1_escape.py", safe_rendered)
+
+    def test_markdown_text_and_relative_urls_are_safe(self) -> None:
+        run_root = self.root / "run"
+        work_dir = run_root / "two words [x] #1 (v1)" / ".specula-output"
+        oi.write_target_index("target", work_dir, output_root=run_root)
+        target_name = "bad|<script>[x]\nnext"
+
+        rendered = oi.render_run_index(
+            run_root,
+            [oi.TargetOutput(target_name, work_dir, run_root)],
+            summary=run_root / "pipeline-summary.md",
+            pipeline_log=run_root / "pipeline.log",
+        )
+
+        self.assertIn("| bad\\|&lt;script&gt;\\[x\\] next |", rendered)
+        self.assertIn(
+            "[Open results](two%20words%20%5Bx%5D%20%231%20%28v1%29/.specula-output/index.md)",
+            rendered,
+        )
+        self.assertNotIn("<script>", rendered)
+        target_rendered = oi.render_target_index(target_name, work_dir)
+        self.assertTrue(target_rendered.startswith("# bad\\|&lt;script&gt;\\[x\\] next Results\n"))
+
+    def test_writing_replaces_an_index_symlink_without_touching_its_target(self) -> None:
+        work_dir = self.root / ".specula-output"
+        work_dir.mkdir()
+        outside = self.root / "outside-index.md"
+        outside.write_text("outside stays unchanged\n")
+        index = work_dir / "index.md"
+        index.symlink_to(outside)
+
+        self.assertTrue(oi.write_target_index("demo", work_dir, output_root=self.root))
+
+        self.assertFalse(index.is_symlink())
+        self.assertTrue(index.is_file())
+        self.assertEqual(outside.read_text(), "outside stays unchanged\n")
+        self.assertTrue(index.read_text().startswith("# demo Results\n"))
+
+    def test_writing_rejects_symlinked_target_ancestor(self) -> None:
+        run_root = self.root / "run"
+        outside = self.root / "outside-target"
+        run_root.mkdir()
+        outside.mkdir()
+        (run_root / "target").symlink_to(outside, target_is_directory=True)
+        work_dir = run_root / "target" / ".specula-output"
+
+        with self.assertRaisesRegex(OSError, "crosses a symlink"):
+            oi.write_target_index("target", work_dir, output_root=run_root)
+
+        self.assertFalse((outside / ".specula-output").exists())
+
+        self.write(outside, ".specula-output/index.md")
+        rendered = oi.render_run_index(
+            run_root,
+            [oi.TargetOutput("target", work_dir, run_root)],
+            summary=run_root / "pipeline-summary.md",
+            pipeline_log=run_root / "pipeline.log",
+        )
+        self.assertIn("| target | Not available |", rendered)
+        self.assertNotIn("[Open results]", rendered)
+
+    def test_target_name_must_be_one_safe_path_component(self) -> None:
+        for valid in ("alpha", "two words", ".hidden", "name[1]"):
+            with self.subTest(valid=valid):
+                self.assertTrue(oi.is_safe_target_name(valid))
+        for invalid in (
+            "",
+            "   ",
+            ".",
+            "..",
+            "../escape",
+            "a/b",
+            "/absolute",
+            "line\nbreak",
+            "tab\tname",
+            "\ud800",
+        ):
+            with self.subTest(invalid=invalid):
+                self.assertFalse(oi.is_safe_target_name(invalid))
+
+    @unittest.skipUnless(os.name == "posix", "invalid-byte filenames are a POSIX behavior")
+    def test_invalid_utf8_filename_does_not_block_index(self) -> None:
+        work_dir = self.root / ".specula-output"
+        self.write(work_dir, "confirmation/MC-1/investigation.md")
+        repro = work_dir / "repro"
+        repro.mkdir()
+        raw_path = os.fsencode(repro) + b"/test_bugMC-1_" + bytes([0xFF]) + b".py"
+        descriptor = os.open(raw_path, os.O_WRONLY | os.O_CREAT, 0o600)
+        os.close(descriptor)
+
+        rendered = oi.render_target_index("demo", work_dir)
+
+        self.assertIn("test_bugMC-1_?.py", rendered)
+        self.assertIn("repro/test_bugMC-1_%FF.py", rendered)
+
+
+class TestAtomicIndexWrite(OutputIndexCase):
+    def test_publish_is_atomic_and_failure_preserves_the_previous_index(self) -> None:
+        index = self.root / "index.md"
+        index.write_text("old complete index\n")
+        real_replace = os.replace
+        observed: list[tuple[Path, Path]] = []
+
+        def observe_replace(source: Path, destination: Path) -> None:
+            self.assertEqual(index.read_text(), "old complete index\n")
+            self.assertEqual(source.read_text(), "new complete index\n")
+            observed.append((source, destination))
+            real_replace(source, destination)
+
+        with mock.patch("specula.output_index.os.replace", side_effect=observe_replace):
+            self.assertTrue(oi._atomic_write_if_changed(index, "new complete index\n"))
+
+        self.assertEqual(len(observed), 1)
+        self.assertEqual(observed[0][1], index)
+        self.assertEqual(index.read_text(), "new complete index\n")
+        self.assertEqual(list(self.root.glob(".index.md.*.tmp")), [])
+
+        with (
+            mock.patch("specula.output_index.os.replace", side_effect=OSError("injected replace failure")),
+            self.assertRaisesRegex(OSError, "injected replace failure"),
+        ):
+            oi._atomic_write_if_changed(index, "unpublished index\n")
+
+        self.assertEqual(index.read_text(), "new complete index\n")
+        self.assertEqual(list(self.root.glob(".index.md.*.tmp")), [])
+
+    def test_identical_content_is_a_true_noop(self) -> None:
+        index = self.root / "index.md"
+        index.write_text("same bytes\n")
+        modified_before = index.stat().st_mtime_ns
+
+        with mock.patch("specula.output_index.os.replace") as replace:
+            self.assertFalse(oi._atomic_write_if_changed(index, "same bytes\n"))
+
+        replace.assert_not_called()
+        self.assertEqual(index.stat().st_mtime_ns, modified_before)
+        self.assertEqual(index.read_text(), "same bytes\n")
+        self.assertEqual(list(self.root.glob(".index.md.*.tmp")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -180,6 +180,7 @@ class PhaseCase(unittest.TestCase):
             "SPECULA_SANDBOX_EXTRA_WRITE",
             "SPECULA_PROGRESS",
             "SPECULA_ACTIVITY_LOG",
+            "SPECULA_PIPELINE_LOG",
             "SPECULA_RATE_LIMIT_REACTIVE",
             "SPECULA_RATE_LIMIT_RETRIES",
             "SPECULA_TLC_SCOPE",
@@ -285,6 +286,18 @@ class TestPreconditionGate(PhaseCase):
                 self.assertIn(spec["fail"], out)  # the phase's own, distinct fail message
                 self.assertNotIn("[DRY RUN]", out)  # gate stops before the launch loop
 
+    def test_index_write_error_does_not_change_phase_result(self) -> None:
+        err = io.StringIO()
+        with (
+            mock.patch.object(phaselib, "write_target_index", side_effect=OSError("disk full")),
+            contextlib.redirect_stderr(err),
+        ):
+            rc, out = self.run_phase("code_analysis", [NAME])
+
+        self.assertEqual(rc, 1, out)
+        self.assertIn(BY_KEY["code_analysis"]["fail"], out)
+        self.assertIn("cannot update output index", err.getvalue())
+
 
 class TestCheckOnly(PhaseCase):
     """--check with prerequisites satisfied -> the ok message + exit 0, no launch."""
@@ -301,6 +314,7 @@ class TestCheckOnly(PhaseCase):
                 self.assertEqual(rc, 0, out)
                 self.assertIn(spec["ok"], out)
                 self.assertNotIn("[DRY RUN]", out)
+                self.assertFalse((self.work_dir() / "index.md").exists())
 
     def test_each_artifact_phase_expands_home_directory(self) -> None:
         home = self.tmp()
@@ -834,6 +848,8 @@ class TestBugConfirmationAlternate(PhaseCase):
 
         self.assertEqual(rc, 0, out)
         self.assertIn("confirmed-bugs OK", out)
+        index = (self.work_dir() / "index.md").read_text()
+        self.assertIn("[Confirmation report](confirmed-bugs.md)", index)
 
 
 class TestHandoffGate(PhaseCase):
@@ -870,6 +886,31 @@ class TestHandoffGate(PhaseCase):
         self.assertIn("Checking handoff to spec_generation...", out)
         self.assertIn("MISSING modeling-brief.md", out)
         self.assertIn("Handoff validation failures:", out)
+
+    def test_live_analysis_refreshes_human_index_after_success(self) -> None:
+        (self.run_dir / "pipeline.log").write_text("pipeline\n")
+        self.write_adapter(
+            'printf "brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
+            'printf "analysis\\n" > "$SPECULA_WORK_DIR/analysis-report.md"\n'
+        )
+
+        rc, out = self.run_analysis()
+
+        self.assertEqual(rc, 0, out)
+        index = (self.work_dir() / "index.md").read_text()
+        self.assertIn("[Modeling brief](modeling-brief.md)", index)
+        self.assertIn("[Analysis report](analysis-report.md)", index)
+        self.assertIn("[pipeline.log](../../pipeline.log)", index)
+
+    def test_live_analysis_failure_keeps_partial_results_browsable(self) -> None:
+        self.write_adapter('printf "analysis\\n" > "$SPECULA_WORK_DIR/analysis-report.md"\nexit 9\n')
+
+        rc, out = self.run_analysis()
+
+        self.assertEqual(rc, 9, out)
+        index = (self.work_dir() / "index.md").read_text()
+        self.assertIn("Modeling brief: Not available", index)
+        self.assertIn("[Analysis report](analysis-report.md)", index)
 
     def test_analysis_handoff_reuses_spec_generation_check(self) -> None:
         calls: list[list[str]] = []
@@ -3034,6 +3075,21 @@ class TestReviewPhase(PhaseCase):
         self.assertEqual(rc, 0, out)
         self.assertEqual(seen.read_text().strip(), "<unset>")
         self.assertFalse((self.work_dir() / "review-analysis.activity.jsonl").exists())
+
+    def test_standalone_review_refreshes_index_but_does_not_list_review_files(self) -> None:
+        modeling_brief = self.work_dir() / "modeling-brief.md"
+        modeling_brief.parent.mkdir(parents=True)
+        modeling_brief.write_text("brief\n")
+        self.install_adapter("fake", "exit 9\n")
+        self.set_env("SPECULA_PROGRESS", "off")
+
+        rc, out = self.run_phase("review", ["analysis", "--agent=fake", NAME])
+
+        self.assertEqual(rc, 9, out)
+        index = (self.work_dir() / "index.md").read_text()
+        self.assertIn("[Modeling brief](modeling-brief.md)", index)
+        self.assertNotIn("review-analysis", index)
+        self.assertNotIn("## Reviews", index)
 
     def test_review_exports_external_workspace_to_adapter(self) -> None:
         seen = self.tmp() / "work-dir"

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -860,6 +860,8 @@ class TestParsing(TmpCwd):
         self.assertIn("--skip-validate", out)
         self.assertNotIn("--skip-validation", out)
         self.assertIn("default: 20", out)
+        self.assertIn("Output navigation", out)
+        self.assertIn("index.md", out)
 
     def test_default_target_is_cwd_basename(self) -> None:
         p = pl.Pipeline()
@@ -876,6 +878,85 @@ class TestParsing(TmpCwd):
         self.assertEqual(single.get_work_dir("a"), f"{self.tmp}/.specula-output")
         batch = make_pipeline(["a|x|y|z", "b|x|y|z"])
         self.assertEqual(batch.get_work_dir("a"), f"{self.tmp}/a/.specula-output")
+
+
+class TestOutputIndexNavigation(TmpCwd):
+    def test_partial_resume_keeps_original_run_targets(self) -> None:
+        run = self.tmp / "run"
+        run.mkdir()
+        (run / "run.json").write_text(
+            json.dumps(
+                {
+                    "targets": [
+                        "alpha|o/a|Go|ref",
+                        "beta|o/b|Rust|ref",
+                    ]
+                }
+            )
+        )
+        pipeline_log = run / "pipeline.log"
+        pipeline_log.write_text("pipeline\n")
+        p = make_pipeline(
+            ["beta|o/b|Rust|ref"],
+            run_dir=run,
+            pipeline_log_path=pipeline_log,
+        )
+
+        p.refresh_output_indexes()
+
+        index = (run / "index.md").read_text()
+        self.assertLess(index.index("| alpha |"), index.index("| beta |"))
+        self.assertTrue((run / "alpha" / ".specula-output" / "index.md").is_file())
+        self.assertTrue((run / "beta" / ".specula-output" / "index.md").is_file())
+
+    def test_unsafe_stored_target_cannot_escape_run_root(self) -> None:
+        run = self.tmp / "run"
+        run.mkdir()
+        (run / "run.json").write_text(
+            json.dumps(
+                {
+                    "targets": [
+                        "../escaped|o/e|Go|ref",
+                        "safe|o/s|Go|ref",
+                    ]
+                }
+            )
+        )
+        pipeline_log = run / "pipeline.log"
+        pipeline_log.write_text("pipeline\n")
+        p = make_pipeline(
+            ["safe|o/s|Go|ref"],
+            run_dir=run,
+            pipeline_log_path=pipeline_log,
+        )
+
+        _, out = quiet(p.refresh_output_indexes)
+
+        self.assertIn("unsafe target name", out)
+        self.assertFalse((self.tmp / "escaped").exists())
+        index = (run / "index.md").read_text()
+        self.assertNotIn("escaped", index)
+        self.assertIn("| safe |", index)
+
+    def test_index_write_errors_are_fail_soft(self) -> None:
+        run = self.tmp / "run"
+        run.mkdir()
+        pipeline_log = run / "pipeline.log"
+        pipeline_log.write_text("pipeline\n")
+        p = make_pipeline(
+            ["alpha|o/a|Go|ref"],
+            run_dir=run,
+            pipeline_log_path=pipeline_log,
+        )
+
+        with (
+            mock.patch.object(pl, "write_target_index", side_effect=OSError("target failure")),
+            mock.patch.object(pl, "write_run_index", side_effect=OSError("run failure")),
+        ):
+            _, out = quiet(p.refresh_output_indexes)
+
+        self.assertIn("cannot update output index for alpha", out)
+        self.assertIn("cannot update run index", out)
 
 
 class TestAgentRouting(TmpCwd):
@@ -2475,14 +2556,19 @@ class TestMainTeeTeardown(TmpCwd):
     """End-to-end pins for the `main 2>&1 | tee` teardown, driven as a
     subprocess because the entry dup2s the real fds 1/2."""
 
-    def _run_entry(self, patch: str) -> subprocess.CompletedProcess[str]:
+    def _run_entry(
+        self,
+        patch: str,
+        argv: list[str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        args = argv or ["--no-isolate", "t|g|l|r"]
         d = self.tmp / "driver.py"
         d.write_text(
             "import sys\n"
             f"sys.path.insert(0, {str(SRC)!r})\n"
             "from specula import pipelinelib as pl\n"
             f"{patch}\n"
-            "sys.exit(pl.main(['--no-isolate', 't|g|l|r']))\n"  # legacy: keep runs/ out of the real repo
+            f"sys.exit(pl.main({args!r}))\n"
         )
         return subprocess.run([sys.executable, str(d)], cwd=self.tmp, capture_output=True, text=True)
 
@@ -2507,6 +2593,42 @@ class TestMainTeeTeardown(TmpCwd):
         )
         self.assertEqual(r.returncode, 7)
         self.assertEqual(marker.read_text(), "done")
+
+    def test_failure_publishes_partial_index_without_completion_summary(self) -> None:
+        r = self._run_entry(
+            "def boom(self):\n"
+            "    open('.specula-output/modeling-brief.md', 'w').write('# Brief\\n')\n"
+            "    raise SystemExit(7)\n"
+            "pl.Pipeline.main = boom"
+        )
+
+        self.assertEqual(r.returncode, 7)
+        out = self.tmp / ".specula-output"
+        index = (out / "index.md").read_text()
+        self.assertIn("[Modeling brief](modeling-brief.md)", index)
+        self.assertIn("[pipeline.log](pipeline.log)", index)
+        self.assertFalse((out / "pipeline-summary.md").exists())
+
+    def test_isolated_failure_publishes_two_level_indexes_without_summary(self) -> None:
+        r = self._run_entry(
+            f"pl.SPECULA_ROOT = pl.Path({str(self.tmp)!r})\n"
+            "def boom(self):\n"
+            "    work = pl.Path(self.get_work_dir('t'))\n"
+            "    work.mkdir(parents=True, exist_ok=True)\n"
+            "    (work / 'modeling-brief.md').write_text('# Brief\\n')\n"
+            "    raise SystemExit(7)\n"
+            "pl.Pipeline.main = boom",
+            ["--run-id=failed-run", "t|g|l|r"],
+        )
+
+        self.assertEqual(r.returncode, 7)
+        run = self.tmp / "runs" / "failed-run"
+        run_index = (run / "index.md").read_text()
+        target_index = (run / "t" / ".specula-output" / "index.md").read_text()
+        self.assertIn("| t | [Open results](t/.specula-output/index.md) |", run_index)
+        self.assertIn("- Final summary: Not available", run_index)
+        self.assertIn("[Modeling brief](modeling-brief.md)", target_index)
+        self.assertFalse((run / "pipeline-summary.md").exists())
 
     def test_failing_tee_fails_the_pipeline(self) -> None:
         # bash pipefail: `main 2>&1 | tee log` exited non-zero when tee could


### PR DESCRIPTION
## Summary

- add a minimal run-level `index.md` for choosing targets and checking final run status
- add a human-facing target `index.md` with recommended reading, confirmation details, technical details, and troubleshooting links
- refresh indexes across pipeline and standalone phase lifecycles without moving existing outputs or changing completion semantics
- stabilize TLC admission diagnostics when the resource owner publishes status immediately before exiting

Address part of #100