### PR TITLE
Surface final reports in output navigation

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -219,7 +219,7 @@ runs/<run-id>/
     └── changes.patch   # --keep-original only
 ```
 
-The run-level `index.md` is a compact target chooser. Each target link opens its `.specula-output/index.md`, which presents human-readable results as Recommended Reading, Confirmation Details, Technical Details, and Troubleshooting. It intentionally omits review artifacts, machine-readable records, state sidecars, caches, and detailed phase logs; those files remain in their existing locations. No existing phase output is moved. `pipeline-summary.md` remains the final run status, and `runs/latest` points to the newest run.
+The run-level `index.md` is a compact target chooser with direct links to each target's confirmation and severity reports. Each target link opens its `.specula-output/index.md`, which presents human-readable results as Final Reports, Supporting Analysis, Confirmation Details, Technical Details, and Troubleshooting. It intentionally omits review artifacts, machine-readable records, state sidecars, caches, and detailed phase logs; those files remain in their existing locations. No existing phase output is moved. `pipeline-summary.md` remains the final run status, and `runs/latest` points to the newest run.
 
 By default, Specula works directly in the source passed through `--artifact`, so harness or reproduction work may modify it. Use `--keep-original` to run every phase on a private copy instead. The original checkout stays unchanged, and the final filesystem changes are written to `changes.patch`.
 

--- a/src/specula/output_index.py
+++ b/src/specula/output_index.py
@@ -108,11 +108,6 @@ def _path_below_root_is_symlink_free(root: Path, path: Path) -> bool:
     return True
 
 
-def is_safe_output_file(output_root: Path, path: Path) -> bool:
-    """Whether path is a regular file below output_root without crossing symlinks."""
-    return _path_below_root_is_symlink_free(output_root, path) and _is_file(path)
-
-
 def _markdown_text(value: str) -> str:
     """One safe Markdown table/heading fragment."""
     one_line = " ".join(value.splitlines()).strip()
@@ -285,19 +280,20 @@ def render_run_index(
         target_index = target.work_dir / INDEX_FILENAME
         result = (
             _link("Open results", target_index, run_root)
-            if is_safe_output_file(target.output_root, target_index)
+            if _path_below_root_is_symlink_free(target.output_root, target_index) and _is_file(target_index)
             else _NOT_AVAILABLE
         )
         confirmation_report = target.work_dir / "confirmed-bugs.md"
         confirmation = (
             _link("Open report", confirmation_report, run_root)
-            if is_safe_output_file(target.output_root, confirmation_report)
+            if _path_below_root_is_symlink_free(target.output_root, confirmation_report)
+            and _is_file(confirmation_report)
             else _NOT_AVAILABLE
         )
         severity_report = target.work_dir / "bug-severity.md"
         severity = (
             _link("Open report", severity_report, run_root)
-            if is_safe_output_file(target.output_root, severity_report)
+            if _path_below_root_is_symlink_free(target.output_root, severity_report) and _is_file(severity_report)
             else _NOT_AVAILABLE
         )
         lines.append(f"| {_markdown_text(target.name)} | {result} | {confirmation} | {severity} |")

--- a/src/specula/output_index.py
+++ b/src/specula/output_index.py
@@ -108,6 +108,11 @@ def _path_below_root_is_symlink_free(root: Path, path: Path) -> bool:
     return True
 
 
+def is_safe_output_file(output_root: Path, path: Path) -> bool:
+    """Whether path is a regular file below output_root without crossing symlinks."""
+    return _path_below_root_is_symlink_free(output_root, path) and _is_file(path)
+
+
 def _markdown_text(value: str) -> str:
     """One safe Markdown table/heading fragment."""
     one_line = " ".join(value.splitlines()).strip()
@@ -280,20 +285,19 @@ def render_run_index(
         target_index = target.work_dir / INDEX_FILENAME
         result = (
             _link("Open results", target_index, run_root)
-            if _path_below_root_is_symlink_free(target.output_root, target_index) and _is_file(target_index)
+            if is_safe_output_file(target.output_root, target_index)
             else _NOT_AVAILABLE
         )
         confirmation_report = target.work_dir / "confirmed-bugs.md"
         confirmation = (
             _link("Open report", confirmation_report, run_root)
-            if _path_below_root_is_symlink_free(target.output_root, confirmation_report)
-            and _is_file(confirmation_report)
+            if is_safe_output_file(target.output_root, confirmation_report)
             else _NOT_AVAILABLE
         )
         severity_report = target.work_dir / "bug-severity.md"
         severity = (
             _link("Open report", severity_report, run_root)
-            if _path_below_root_is_symlink_free(target.output_root, severity_report) and _is_file(severity_report)
+            if is_safe_output_file(target.output_root, severity_report)
             else _NOT_AVAILABLE
         )
         lines.append(f"| {_markdown_text(target.name)} | {result} | {confirmation} | {severity} |")

--- a/src/specula/output_index.py
+++ b/src/specula/output_index.py
@@ -181,12 +181,18 @@ def render_target_index(name: str, work_dir: Path, *, pipeline_log: Path | None 
     lines = [
         f"# {_markdown_text(name)} Results",
         "",
-        "Read the documents below from top to bottom.",
+        "## Final Reports",
+        "",
+        (
+            f"- {_document('Confirmation report', work_dir / 'confirmed-bugs.md', work_dir)} "
+            "— Confirmation results and supporting evidence"
+        ),
+        (f"- {_document('Severity report', work_dir / 'bug-severity.md', work_dir)} — Impact assessment"),
         "",
         "> Availability means that a document exists. It does not imply review approval",
         "> or confirmation of every finding.",
         "",
-        "## Recommended Reading",
+        "## Supporting Analysis",
         "",
         "| Step | Document | What it contains |",
         "|---:|---|---|",
@@ -210,14 +216,6 @@ def render_target_index(name: str, work_dir: Path, *, pipeline_log: Path | None 
         (
             f"| 5 | {_document('Model-checking report', spec_dir / 'bug-report.md', work_dir)} "
             "| Candidate findings from model checking |"
-        ),
-        (
-            f"| 6 | {_document('Confirmation report', work_dir / 'confirmed-bugs.md', work_dir)} "
-            "| Findings checked against the real system |"
-        ),
-        (
-            f"| 7 | {_document('Severity report', work_dir / 'bug-severity.md', work_dir)} "
-            "| Severity view of confirmed findings |"
         ),
     ]
 
@@ -271,12 +269,12 @@ def render_run_index(
     lines = [
         "# Specula Run",
         "",
-        "Select a target to browse its results.",
+        "Select a target to browse its results or open its final reports directly.",
         "",
         "## Targets",
         "",
-        "| Target | Results |",
-        "|---|---|",
+        "| Target | Results | Confirmation | Severity |",
+        "|---|---|---|---|",
     ]
     for target in targets:
         target_index = target.work_dir / INDEX_FILENAME
@@ -285,7 +283,20 @@ def render_run_index(
             if _path_below_root_is_symlink_free(target.output_root, target_index) and _is_file(target_index)
             else _NOT_AVAILABLE
         )
-        lines.append(f"| {_markdown_text(target.name)} | {result} |")
+        confirmation_report = target.work_dir / "confirmed-bugs.md"
+        confirmation = (
+            _link("Open report", confirmation_report, run_root)
+            if _path_below_root_is_symlink_free(target.output_root, confirmation_report)
+            and _is_file(confirmation_report)
+            else _NOT_AVAILABLE
+        )
+        severity_report = target.work_dir / "bug-severity.md"
+        severity = (
+            _link("Open report", severity_report, run_root)
+            if _path_below_root_is_symlink_free(target.output_root, severity_report) and _is_file(severity_report)
+            else _NOT_AVAILABLE
+        )
+        lines.append(f"| {_markdown_text(target.name)} | {result} | {confirmation} | {severity} |")
 
     summary_cell = (
         _link("pipeline-summary.md", summary, run_root) if _is_file_under(run_root, summary) else _NOT_AVAILABLE

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -2484,7 +2484,26 @@ def main(argv: list[str]) -> int:
         out_dir.mkdir(parents=True, exist_ok=True)
         log_path = out_dir / "pipeline.log"
     p.pipeline_log_path = log_path
-    tee = subprocess.Popen(["tee", str(log_path)], stdin=subprocess.PIPE)
+    log_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_APPEND
+    if hasattr(os, "O_NOFOLLOW"):
+        log_flags |= os.O_NOFOLLOW
+    log_fd = os.open(log_path, log_flags, 0o666)
+    try:
+        pipeline_log = os.fdopen(log_fd, "a", encoding="utf-8")
+    except BaseException:
+        os.close(log_fd)
+        raise
+    try:
+        # Both tee and the success footer use this original fd, so replacing
+        # pipeline.log during a run cannot redirect either write.
+        tee = subprocess.Popen(
+            ["tee", "-a", f"/dev/fd/{log_fd}"],
+            stdin=subprocess.PIPE,
+            pass_fds=(log_fd,),
+        )
+    except BaseException:
+        pipeline_log.close()
+        raise
     assert tee.stdin is not None  # stdin=PIPE
     tee_in = tee.stdin
     terminal_stdout = os.dup(1)
@@ -2536,16 +2555,21 @@ def main(argv: list[str]) -> int:
         os.dup2(terminal_stderr, 2)
         os.close(terminal_stdout)
         os.close(terminal_stderr)
-        if code == 0 and p.elapsed_seconds is not None:
-            elapsed = p.elapsed_seconds
-            footer_buffer = io.StringIO()
-            with contextlib.redirect_stdout(footer_buffer):
-                print()
-                log(f"Pipeline completed in {elapsed // 60}m {elapsed % 60}s")
-                p.print_output_guide()
-            footer = footer_buffer.getvalue()
-            with log_path.open("a", encoding="utf-8") as pipeline_log:
+        footer: str | None = None
+        try:
+            if code == 0 and p.elapsed_seconds is not None:
+                elapsed = p.elapsed_seconds
+                footer_buffer = io.StringIO()
+                with contextlib.redirect_stdout(footer_buffer):
+                    print()
+                    log(f"Pipeline completed in {elapsed // 60}m {elapsed % 60}s")
+                    p.print_output_guide()
+                footer = footer_buffer.getvalue()
                 pipeline_log.write(footer)
+                pipeline_log.flush()
+        finally:
+            pipeline_log.close()
+        if footer is not None:
             sys.stdout.write(footer)
             sys.stdout.flush()
     return code

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -14,7 +14,6 @@ Usage:  python3 pipelinelib.py [options] "name|github|lang|reference" [...]
 from __future__ import annotations
 
 import contextlib
-import io
 import json
 import locale
 import math
@@ -42,10 +41,8 @@ if __package__ in (None, ""):
 from specula import quota as _quota
 from specula.agent_config import AgentConfigError, AgentRouting, AgentSelection, load_agent_routing
 from specula.output_index import (
-    INDEX_FILENAME,
     PIPELINE_LOG_ENV,
     TargetOutput,
-    is_safe_output_file,
     is_safe_target_name,
     write_run_index,
     write_target_index,
@@ -335,7 +332,6 @@ class Pipeline:
         self._run_id_given = False  # `--run-id=` (empty) must error, not mint a fresh id
         self.run_dir: Path | None = None
         self.pipeline_log_path: Path | None = None
-        self.elapsed_seconds: int | None = None
         self.tlc_scope = ""
         self.argv: list[str] = []
 
@@ -991,57 +987,6 @@ class Pipeline:
             )
         except Exception as exc:
             log(f"WARNING: cannot update run index: {exc}")
-
-    def print_output_guide(self) -> None:
-        """Point a successful run at its human-facing result documents."""
-        if self.dry_run:
-            return
-        try:
-            targets = self._index_targets()
-        except Exception:
-            return
-        if not targets:
-            return
-
-        if self.run_dir is not None:
-            index = self.run_dir / INDEX_FILENAME
-        elif len(targets) > 1 and self.pipeline_log_path is not None:
-            index = self.pipeline_log_path.parent / INDEX_FILENAME
-        else:
-            index = targets[0].work_dir / INDEX_FILENAME
-
-        index_available = is_safe_output_file(targets[0].output_root, index)
-        reports: list[tuple[TargetOutput, Path | None, Path | None]] = []
-        for target in targets:
-            confirmation_path = target.work_dir / "confirmed-bugs.md"
-            severity_path = target.work_dir / "bug-severity.md"
-            reports.append(
-                (
-                    target,
-                    confirmation_path if is_safe_output_file(target.output_root, confirmation_path) else None,
-                    severity_path if is_safe_output_file(target.output_root, severity_path) else None,
-                )
-            )
-        if not index_available and not any(confirmation or severity for _, confirmation, severity in reports):
-            return
-
-        print()
-        print("View results:")
-        if index_available:
-            print(f"  All results: {index}")
-        multiple_targets = len(targets) > 1
-        for target, confirmation, severity in reports:
-            if confirmation is None and severity is None:
-                continue
-            if multiple_targets:
-                print(f"  {target.name}:")
-                indent = "    "
-            else:
-                indent = "  "
-            if confirmation is not None:
-                print(f"{indent}Confirmation results and evidence: {confirmation}")
-            if severity is not None:
-                print(f"{indent}Impact assessment: {severity}")
 
     def prepare_source_snapshots(self, names: list[str]) -> None:
         if not self.keep_original:
@@ -2452,7 +2397,9 @@ class Pipeline:
         self.generate_summary()
         self.refresh_output_indexes()
 
-        self.elapsed_seconds = int(time.time()) - start_time
+        elapsed = int(time.time()) - start_time
+        print()
+        log(f"Pipeline completed in {elapsed // 60}m {elapsed % 60}s")
         return 0
 
 
@@ -2484,30 +2431,9 @@ def main(argv: list[str]) -> int:
         out_dir.mkdir(parents=True, exist_ok=True)
         log_path = out_dir / "pipeline.log"
     p.pipeline_log_path = log_path
-    log_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_APPEND
-    if hasattr(os, "O_NOFOLLOW"):
-        log_flags |= os.O_NOFOLLOW
-    log_fd = os.open(log_path, log_flags, 0o666)
-    try:
-        pipeline_log = os.fdopen(log_fd, "a", encoding="utf-8")
-    except BaseException:
-        os.close(log_fd)
-        raise
-    try:
-        # Both tee and the success footer use this original fd, so replacing
-        # pipeline.log during a run cannot redirect either write.
-        tee = subprocess.Popen(
-            ["tee", "-a", f"/dev/fd/{log_fd}"],
-            stdin=subprocess.PIPE,
-            pass_fds=(log_fd,),
-        )
-    except BaseException:
-        pipeline_log.close()
-        raise
+    tee = subprocess.Popen(["tee", str(log_path)], stdin=subprocess.PIPE)
     assert tee.stdin is not None  # stdin=PIPE
     tee_in = tee.stdin
-    terminal_stdout = os.dup(1)
-    terminal_stderr = os.dup(2)
     sys.stdout.flush()
     sys.stderr.flush()
     os.dup2(tee_in.fileno(), 1)  # fd-level: phase subprocesses inherit the tee
@@ -2517,7 +2443,9 @@ def main(argv: list[str]) -> int:
     except SystemExit as e:
         code = e.code if isinstance(e.code, int) else 1
     except BaseException as e:
-        # Print while fd 2 still feeds the tee so the failure reaches pipeline.log.
+        # Print while fd 2 still feeds the tee: after the finally below it is
+        # /dev/null, and an escaping exception would die with no diagnostics
+        # anywhere. bash `set -e` left the failing command's stderr in the log.
         traceback.print_exc()
         code = 130 if isinstance(e, KeyboardInterrupt) else 1  # 128+SIGINT, like bash
     finally:
@@ -2551,27 +2479,6 @@ def main(argv: list[str]) -> int:
             p.refresh_output_indexes()
         if tee_rc != 0:
             code = tee_rc
-        os.dup2(terminal_stdout, 1)
-        os.dup2(terminal_stderr, 2)
-        os.close(terminal_stdout)
-        os.close(terminal_stderr)
-        footer: str | None = None
-        try:
-            if code == 0 and p.elapsed_seconds is not None:
-                elapsed = p.elapsed_seconds
-                footer_buffer = io.StringIO()
-                with contextlib.redirect_stdout(footer_buffer):
-                    print()
-                    log(f"Pipeline completed in {elapsed // 60}m {elapsed % 60}s")
-                    p.print_output_guide()
-                footer = footer_buffer.getvalue()
-                pipeline_log.write(footer)
-                pipeline_log.flush()
-        finally:
-            pipeline_log.close()
-        if footer is not None:
-            sys.stdout.write(footer)
-            sys.stdout.flush()
     return code
 
 

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -41,6 +41,7 @@ if __package__ in (None, ""):
 from specula import quota as _quota
 from specula.agent_config import AgentConfigError, AgentRouting, AgentSelection, load_agent_routing
 from specula.output_index import (
+    INDEX_FILENAME,
     PIPELINE_LOG_ENV,
     TargetOutput,
     is_safe_target_name,
@@ -2403,6 +2404,28 @@ class Pipeline:
         return 0
 
 
+def _result_index_path(pipeline: Pipeline) -> Path | None:
+    """Return the generated human-facing index for one successful run."""
+    if pipeline.dry_run:
+        return None
+    try:
+        targets = pipeline._index_targets()
+    except Exception:
+        return None
+    if not targets:
+        return None
+    if pipeline.run_dir is not None:
+        index = pipeline.run_dir / INDEX_FILENAME
+    elif len(targets) > 1 and pipeline.pipeline_log_path is not None:
+        index = pipeline.pipeline_log_path.parent / INDEX_FILENAME
+    else:
+        index = targets[0].work_dir / INDEX_FILENAME
+    try:
+        return None if index.is_symlink() or not index.is_file() else index
+    except (OSError, UnicodeError):
+        return None
+
+
 def main(argv: list[str]) -> int:
     # bash echo flushed per line; python block-buffers when stdout is a pipe
     # (everything below runs through the tee), which would hold progress lines
@@ -2434,6 +2457,7 @@ def main(argv: list[str]) -> int:
     tee = subprocess.Popen(["tee", str(log_path)], stdin=subprocess.PIPE)
     assert tee.stdin is not None  # stdin=PIPE
     tee_in = tee.stdin
+    terminal_stdout = os.fdopen(os.dup(1), "w", encoding="utf-8")
     sys.stdout.flush()
     sys.stderr.flush()
     os.dup2(tee_in.fileno(), 1)  # fd-level: phase subprocesses inherit the tee
@@ -2479,6 +2503,19 @@ def main(argv: list[str]) -> int:
             p.refresh_output_indexes()
         if tee_rc != 0:
             code = tee_rc
+        try:
+            if code == 0:
+                index = _result_index_path(p)
+                if index is not None:
+                    with contextlib.suppress(OSError, UnicodeError):
+                        print(
+                            f"\nView all results: {index} (final reports are listed at the top).",
+                            file=terminal_stdout,
+                            flush=True,
+                        )
+        finally:
+            with contextlib.suppress(OSError, UnicodeError):
+                terminal_stdout.close()
     return code
 
 

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -944,15 +944,16 @@ class Pipeline:
             targets.append(TargetOutput(name, Path(self.get_work_dir(name)), output_root))
         return targets
 
-    def refresh_target_indexes(self) -> list[TargetOutput]:
-        """Best-effort target navigation refresh; never changes pipeline status."""
+    def _refresh_target_indexes(self) -> tuple[list[TargetOutput], set[Path]]:
+        """Refresh target navigation and report indexes published by this call."""
         if self.dry_run:
-            return []
+            return [], set()
         try:
             targets = self._index_targets()
         except Exception as exc:
             log(f"WARNING: cannot resolve output indexes: {exc}")
-            return []
+            return [], set()
+        published: set[Path] = set()
         for target in targets:
             try:
                 write_target_index(
@@ -961,15 +962,21 @@ class Pipeline:
                     output_root=target.output_root,
                     pipeline_log=self.pipeline_log_path,
                 )
+                published.add(target.work_dir / INDEX_FILENAME)
             except Exception as exc:
                 log(f"WARNING: cannot update output index for {target.name}: {exc}")
+        return targets, published
+
+    def refresh_target_indexes(self) -> list[TargetOutput]:
+        """Best-effort target navigation refresh; never changes pipeline status."""
+        targets, _ = self._refresh_target_indexes()
         return targets
 
-    def refresh_output_indexes(self) -> None:
-        """Refresh target indexes, then the run-level target chooser when distinct."""
-        targets = self.refresh_target_indexes()
+    def refresh_output_indexes(self) -> Path | None:
+        """Refresh output navigation and return the primary index published now."""
+        targets, published = self._refresh_target_indexes()
         if not targets or self.pipeline_log_path is None:
-            return
+            return None
         if self.run_dir is not None:
             run_root = self.run_dir
         elif len(targets) > 1:
@@ -978,7 +985,8 @@ class Pipeline:
             # only the detailed target index is generated.
             run_root = self.pipeline_log_path.parent
         else:
-            return
+            index = targets[0].work_dir / INDEX_FILENAME
+            return index if index in published else None
         try:
             write_run_index(
                 run_root,
@@ -988,6 +996,8 @@ class Pipeline:
             )
         except Exception as exc:
             log(f"WARNING: cannot update run index: {exc}")
+            return None
+        return run_root / INDEX_FILENAME
 
     def prepare_source_snapshots(self, names: list[str]) -> None:
         if not self.keep_original:
@@ -2404,28 +2414,6 @@ class Pipeline:
         return 0
 
 
-def _result_index_path(pipeline: Pipeline) -> Path | None:
-    """Return the generated human-facing index for one successful run."""
-    if pipeline.dry_run:
-        return None
-    try:
-        targets = pipeline._index_targets()
-    except Exception:
-        return None
-    if not targets:
-        return None
-    if pipeline.run_dir is not None:
-        index = pipeline.run_dir / INDEX_FILENAME
-    elif len(targets) > 1 and pipeline.pipeline_log_path is not None:
-        index = pipeline.pipeline_log_path.parent / INDEX_FILENAME
-    else:
-        index = targets[0].work_dir / INDEX_FILENAME
-    try:
-        return None if index.is_symlink() or not index.is_file() else index
-    except (OSError, UnicodeError):
-        return None
-
-
 def main(argv: list[str]) -> int:
     # bash echo flushed per line; python block-buffers when stdout is a pipe
     # (everything below runs through the tee), which would hold progress lines
@@ -2457,7 +2445,7 @@ def main(argv: list[str]) -> int:
     tee = subprocess.Popen(["tee", str(log_path)], stdin=subprocess.PIPE)
     assert tee.stdin is not None  # stdin=PIPE
     tee_in = tee.stdin
-    terminal_stdout = os.fdopen(os.dup(1), "w", encoding="utf-8")
+    terminal_stdout = os.fdopen(os.dup(1), "w", encoding="utf-8", errors="surrogateescape")
     sys.stdout.flush()
     sys.stderr.flush()
     os.dup2(tee_in.fileno(), 1)  # fd-level: phase subprocesses inherit the tee
@@ -2497,22 +2485,21 @@ def main(argv: list[str]) -> int:
         # non-zero, so a failing tee (unwritable/full log) wins even when main
         # also failed — verified: `set -o pipefail; (exit 2)|(exit 1)` exits 1.
         tee_rc = tee.wait()
+        result_index: Path | None = None
         with contextlib.suppress(BaseException):
             # tee creates the log asynchronously. Refresh once more after EOF so
             # even an immediate pipeline failure gets a Troubleshooting link.
-            p.refresh_output_indexes()
+            result_index = p.refresh_output_indexes()
         if tee_rc != 0:
             code = tee_rc
         try:
-            if code == 0:
-                index = _result_index_path(p)
-                if index is not None:
-                    with contextlib.suppress(OSError, UnicodeError):
-                        print(
-                            f"\nView all results: {index} (final reports are listed at the top).",
-                            file=terminal_stdout,
-                            flush=True,
-                        )
+            if code == 0 and result_index is not None:
+                with contextlib.suppress(OSError, UnicodeError):
+                    print(
+                        f"\nView all results: {result_index} (final reports are listed at the top).",
+                        file=terminal_stdout,
+                        flush=True,
+                    )
         finally:
             with contextlib.suppress(OSError, UnicodeError):
                 terminal_stdout.close()

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -41,6 +41,7 @@ if __package__ in (None, ""):
 from specula import quota as _quota
 from specula.agent_config import AgentConfigError, AgentRouting, AgentSelection, load_agent_routing
 from specula.output_index import (
+    INDEX_FILENAME,
     PIPELINE_LOG_ENV,
     TargetOutput,
     is_safe_target_name,
@@ -987,6 +988,52 @@ class Pipeline:
             )
         except Exception as exc:
             log(f"WARNING: cannot update run index: {exc}")
+
+    def print_output_guide(self) -> None:
+        """Point a successful run at its human-facing result documents."""
+        if self.dry_run:
+            return
+        try:
+            targets = self._index_targets()
+        except Exception:
+            return
+        if not targets:
+            return
+
+        if self.run_dir is not None:
+            index = self.run_dir / INDEX_FILENAME
+        elif len(targets) > 1 and self.pipeline_log_path is not None:
+            index = self.pipeline_log_path.parent / INDEX_FILENAME
+        else:
+            index = targets[0].work_dir / INDEX_FILENAME
+
+        available = index.is_file() or any(
+            (target.work_dir / filename).is_file()
+            for target in targets
+            for filename in ("confirmed-bugs.md", "bug-severity.md")
+        )
+        if not available:
+            return
+
+        print()
+        print("View results:")
+        if index.is_file():
+            print(f"  All results: {index}")
+        multiple_targets = len(targets) > 1
+        for target in targets:
+            confirmation = target.work_dir / "confirmed-bugs.md"
+            severity = target.work_dir / "bug-severity.md"
+            if not confirmation.is_file() and not severity.is_file():
+                continue
+            if multiple_targets:
+                print(f"  {target.name}:")
+                indent = "    "
+            else:
+                indent = "  "
+            if confirmation.is_file():
+                print(f"{indent}Confirmation results and evidence: {confirmation}")
+            if severity.is_file():
+                print(f"{indent}Impact assessment: {severity}")
 
     def prepare_source_snapshots(self, names: list[str]) -> None:
         if not self.keep_original:
@@ -2400,6 +2447,7 @@ class Pipeline:
         elapsed = int(time.time()) - start_time
         print()
         log(f"Pipeline completed in {elapsed // 60}m {elapsed % 60}s")
+        self.print_output_guide()
         return 0
 
 

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -44,6 +44,7 @@ from specula.output_index import (
     INDEX_FILENAME,
     PIPELINE_LOG_ENV,
     TargetOutput,
+    is_safe_output_file,
     is_safe_target_name,
     write_run_index,
     write_target_index,
@@ -333,6 +334,7 @@ class Pipeline:
         self._run_id_given = False  # `--run-id=` (empty) must error, not mint a fresh id
         self.run_dir: Path | None = None
         self.pipeline_log_path: Path | None = None
+        self.elapsed_seconds: int | None = None
         self.tlc_scope = ""
         self.argv: list[str] = []
 
@@ -1007,32 +1009,37 @@ class Pipeline:
         else:
             index = targets[0].work_dir / INDEX_FILENAME
 
-        available = index.is_file() or any(
-            (target.work_dir / filename).is_file()
-            for target in targets
-            for filename in ("confirmed-bugs.md", "bug-severity.md")
-        )
-        if not available:
+        index_available = is_safe_output_file(targets[0].output_root, index)
+        reports: list[tuple[TargetOutput, Path | None, Path | None]] = []
+        for target in targets:
+            confirmation_path = target.work_dir / "confirmed-bugs.md"
+            severity_path = target.work_dir / "bug-severity.md"
+            reports.append(
+                (
+                    target,
+                    confirmation_path if is_safe_output_file(target.output_root, confirmation_path) else None,
+                    severity_path if is_safe_output_file(target.output_root, severity_path) else None,
+                )
+            )
+        if not index_available and not any(confirmation or severity for _, confirmation, severity in reports):
             return
 
         print()
         print("View results:")
-        if index.is_file():
+        if index_available:
             print(f"  All results: {index}")
         multiple_targets = len(targets) > 1
-        for target in targets:
-            confirmation = target.work_dir / "confirmed-bugs.md"
-            severity = target.work_dir / "bug-severity.md"
-            if not confirmation.is_file() and not severity.is_file():
+        for target, confirmation, severity in reports:
+            if confirmation is None and severity is None:
                 continue
             if multiple_targets:
                 print(f"  {target.name}:")
                 indent = "    "
             else:
                 indent = "  "
-            if confirmation.is_file():
+            if confirmation is not None:
                 print(f"{indent}Confirmation results and evidence: {confirmation}")
-            if severity.is_file():
+            if severity is not None:
                 print(f"{indent}Impact assessment: {severity}")
 
     def prepare_source_snapshots(self, names: list[str]) -> None:
@@ -2444,10 +2451,7 @@ class Pipeline:
         self.generate_summary()
         self.refresh_output_indexes()
 
-        elapsed = int(time.time()) - start_time
-        print()
-        log(f"Pipeline completed in {elapsed // 60}m {elapsed % 60}s")
-        self.print_output_guide()
+        self.elapsed_seconds = int(time.time()) - start_time
         return 0
 
 
@@ -2482,6 +2486,8 @@ def main(argv: list[str]) -> int:
     tee = subprocess.Popen(["tee", str(log_path)], stdin=subprocess.PIPE)
     assert tee.stdin is not None  # stdin=PIPE
     tee_in = tee.stdin
+    terminal_stdout = os.dup(1)
+    terminal_stderr = os.dup(2)
     sys.stdout.flush()
     sys.stderr.flush()
     os.dup2(tee_in.fileno(), 1)  # fd-level: phase subprocesses inherit the tee
@@ -2491,9 +2497,7 @@ def main(argv: list[str]) -> int:
     except SystemExit as e:
         code = e.code if isinstance(e.code, int) else 1
     except BaseException as e:
-        # Print while fd 2 still feeds the tee: after the finally below it is
-        # /dev/null, and an escaping exception would die with no diagnostics
-        # anywhere. bash `set -e` left the failing command's stderr in the log.
+        # Print while fd 2 still feeds the tee so the failure reaches pipeline.log.
         traceback.print_exc()
         code = 130 if isinstance(e, KeyboardInterrupt) else 1  # 128+SIGINT, like bash
     finally:
@@ -2527,6 +2531,16 @@ def main(argv: list[str]) -> int:
             p.refresh_output_indexes()
         if tee_rc != 0:
             code = tee_rc
+        os.dup2(terminal_stdout, 1)
+        os.dup2(terminal_stderr, 2)
+        os.close(terminal_stdout)
+        os.close(terminal_stderr)
+        if code == 0 and p.elapsed_seconds is not None:
+            elapsed = p.elapsed_seconds
+            print()
+            log(f"Pipeline completed in {elapsed // 60}m {elapsed % 60}s")
+            p.print_output_guide()
+            sys.stdout.flush()
     return code
 
 

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -14,6 +14,7 @@ Usage:  python3 pipelinelib.py [options] "name|github|lang|reference" [...]
 from __future__ import annotations
 
 import contextlib
+import io
 import json
 import locale
 import math
@@ -2537,9 +2538,15 @@ def main(argv: list[str]) -> int:
         os.close(terminal_stderr)
         if code == 0 and p.elapsed_seconds is not None:
             elapsed = p.elapsed_seconds
-            print()
-            log(f"Pipeline completed in {elapsed // 60}m {elapsed % 60}s")
-            p.print_output_guide()
+            footer_buffer = io.StringIO()
+            with contextlib.redirect_stdout(footer_buffer):
+                print()
+                log(f"Pipeline completed in {elapsed // 60}m {elapsed % 60}s")
+                p.print_output_guide()
+            footer = footer_buffer.getvalue()
+            with log_path.open("a", encoding="utf-8") as pipeline_log:
+                pipeline_log.write(footer)
+            sys.stdout.write(footer)
             sys.stdout.flush()
     return code
 

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -173,7 +173,8 @@ class CliE2E(unittest.TestCase):
         self.assertNotIn("tlc-resources.json", run_index)
 
         self.assertIn("# footest Results", target_index)
-        self.assertIn("## Recommended Reading", target_index)
+        self.assertIn("## Final Reports", target_index)
+        self.assertIn("## Supporting Analysis", target_index)
         self.assertIn("Modeling brief: Not available", target_index)
         self.assertIn("[pipeline.log](../../pipeline.log)", target_index)
         self.assertNotIn("## Reviews", target_index)
@@ -368,7 +369,8 @@ class CliE2E(unittest.TestCase):
 
         index = (work / ".specula-output" / "index.md").read_text()
         self.assertIn("# nocase Results", index)
-        self.assertIn("## Recommended Reading", index)
+        self.assertIn("## Final Reports", index)
+        self.assertIn("## Supporting Analysis", index)
         self.assertNotIn("# Specula Run", index)
         self.assertIn("[pipeline.log](pipeline.log)", index)
         self.assertFalse((root / "runs").exists())

--- a/tests/unit/test_output_index.py
+++ b/tests/unit/test_output_index.py
@@ -31,6 +31,9 @@ class TestRunIndex(OutputIndexCase):
         run_root = self.root / "run"
         beta = run_root / "beta" / ".specula-output"
         alpha = run_root / "alpha" / ".specula-output"
+        for work_dir in (beta, alpha):
+            self.write(work_dir, "confirmed-bugs.md")
+            self.write(work_dir, "bug-severity.md")
         self.assertTrue(oi.write_target_index("beta", beta, output_root=run_root))
         self.assertTrue(oi.write_target_index("alpha", alpha, output_root=run_root))
         pipeline_log = self.write(run_root, "pipeline.log")
@@ -46,14 +49,14 @@ class TestRunIndex(OutputIndexCase):
             """\
             # Specula Run
 
-            Select a target to browse its results.
+            Select a target to browse its results or open its final reports directly.
 
             ## Targets
 
-            | Target | Results |
-            |---|---|
-            | beta | [Open results](beta/.specula-output/index.md) |
-            | alpha | [Open results](alpha/.specula-output/index.md) |
+            | Target | Results | Confirmation | Severity |
+            |---|---|---|---|
+            | beta | [Open results](beta/.specula-output/index.md) | [Open report](beta/.specula-output/confirmed-bugs.md) | [Open report](beta/.specula-output/bug-severity.md) |
+            | alpha | [Open results](alpha/.specula-output/index.md) | [Open report](alpha/.specula-output/confirmed-bugs.md) | [Open report](alpha/.specula-output/bug-severity.md) |
 
             ## Run Status
 
@@ -83,7 +86,7 @@ class TestRunIndex(OutputIndexCase):
 
 
 class TestTargetIndex(OutputIndexCase):
-    def test_approved_seven_step_reading_order_has_no_reviews_or_machine_files(self) -> None:
+    def test_final_reports_lead_supporting_analysis_without_reviews_or_machine_files(self) -> None:
         work_dir = self.root / ".specula-output"
         for relative in (
             "modeling-brief.md",
@@ -112,12 +115,15 @@ class TestTargetIndex(OutputIndexCase):
             """\
             # demo Results
 
-            Read the documents below from top to bottom.
+            ## Final Reports
+
+            - [Confirmation report](confirmed-bugs.md) — Confirmation results and supporting evidence
+            - [Severity report](bug-severity.md) — Impact assessment
 
             > Availability means that a document exists. It does not imply review approval
             > or confirmation of every finding.
 
-            ## Recommended Reading
+            ## Supporting Analysis
 
             | Step | Document | What it contains |
             |---:|---|---|
@@ -126,8 +132,6 @@ class TestTargetIndex(OutputIndexCase):
             | 3 | [Spec coverage](spec/brief-coverage.md) · [Instrumentation map](spec/instrumentation-spec.md) | How the analysis was translated into the model |
             | 4 | [Validation changelog](spec/changelog.md) | Model corrections and validation history |
             | 5 | [Model-checking report](spec/bug-report.md) | Candidate findings from model checking |
-            | 6 | [Confirmation report](confirmed-bugs.md) | Findings checked against the real system |
-            | 7 | [Severity report](bug-severity.md) | Severity view of confirmed findings |
             """
         )
         rendered = oi.render_target_index("demo", work_dir)

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -2694,6 +2694,11 @@ class TestMainTeeTeardown(TmpCwd):
         self.assertIn("View results:", r.stdout)
         self.assertIn("confirmed-bugs.md", r.stdout)
         self.assertIn("bug-severity.md", r.stdout)
+        log_text = (self.tmp / ".specula-output" / "pipeline.log").read_text()
+        self.assertIn("Pipeline completed", log_text)
+        self.assertIn("View results:", log_text)
+        marker = "Pipeline completed"
+        self.assertEqual(log_text[log_text.index(marker) :], r.stdout[r.stdout.index(marker) :])
 
     def test_final_source_capture_failure_suppresses_success_output(self) -> None:
         r = self._run_entry(
@@ -2714,6 +2719,9 @@ class TestMainTeeTeardown(TmpCwd):
         self.assertNotIn("Pipeline completed", r.stdout)
         self.assertNotIn("View results:", r.stdout)
         self.assertNotIn("All results:", r.stdout)
+        log_text = (self.tmp / ".specula-output" / "pipeline.log").read_text()
+        self.assertNotIn("Pipeline completed", log_text)
+        self.assertNotIn("View results:", log_text)
 
     def test_failure_publishes_partial_index_without_completion_summary(self) -> None:
         r = self._run_entry(

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -902,8 +902,9 @@ class TestOutputIndexNavigation(TmpCwd):
             pipeline_log_path=pipeline_log,
         )
 
-        p.refresh_output_indexes()
+        result_index = p.refresh_output_indexes()
 
+        self.assertEqual(result_index, run / "index.md")
         index = (run / "index.md").read_text()
         self.assertLess(index.index("| alpha |"), index.index("| beta |"))
         self.assertTrue((run / "alpha" / ".specula-output" / "index.md").is_file())
@@ -2624,6 +2625,47 @@ class TestMainTeeTeardown(TmpCwd):
         self.assertEqual(r.returncode, 0, r.stdout)
         self.assertIn(f"View all results: {case / '.specula-output' / 'index.md'}", r.stdout)
         self.assertNotIn(f"View all results: {self.tmp / '.specula-output' / 'index.md'}", r.stdout)
+
+    def test_success_does_not_point_to_stale_index_when_refresh_fails(self) -> None:
+        stale = self.tmp / ".specula-output" / "index.md"
+        stale.parent.mkdir()
+        stale.write_text("# stale results\n")
+        r = self._run_entry(
+            "def fail_index(*args, **kwargs):\n"
+            "    raise OSError('injected index failure')\n"
+            "pl.write_target_index = fail_index\n"
+            "pl.Pipeline.main = lambda self: 0"
+        )
+
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertNotIn("View all results:", r.stdout)
+        self.assertEqual(stale.read_text(), "# stale results\n")
+        log_text = (self.tmp / ".specula-output" / "pipeline.log").read_text()
+        self.assertIn("injected index failure", log_text)
+
+    @unittest.skipUnless(os.name == "posix", "surrogateescaped paths are a POSIX behavior")
+    def test_terminal_guide_preserves_undecodable_path_bytes(self) -> None:
+        raw_cwd = os.fsencode(self.tmp) + b"/bad-\xff"
+        os.mkdir(raw_cwd)
+        driver = self.tmp / "byte-driver.py"
+        driver.write_text(
+            "import sys\n"
+            f"sys.path.insert(0, {str(SRC)!r})\n"
+            "from specula import pipelinelib as pl\n"
+            "pl.Pipeline.main = lambda self: 0\n"
+            "raise SystemExit(pl.main(['--no-isolate', 't|g|l|r']))\n"
+        )
+        env = os.environb.copy()
+        env[b"PWD"] = raw_cwd
+
+        r = subprocess.run([sys.executable, os.fsencode(driver)], cwd=raw_cwd, env=env, capture_output=True)
+
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        expected = raw_cwd + b"/.specula-output/index.md"
+        self.assertIn(b"View all results: " + expected, r.stdout)
+        self.assertNotIn(
+            b"View all results:", (Path(os.fsdecode(raw_cwd)) / ".specula-output/pipeline.log").read_bytes()
+        )
 
     def test_final_source_capture_failure_suppresses_terminal_guide(self) -> None:
         r = self._run_entry(

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -2700,6 +2700,41 @@ class TestMainTeeTeardown(TmpCwd):
         marker = "Pipeline completed"
         self.assertEqual(log_text[log_text.index(marker) :], r.stdout[r.stdout.index(marker) :])
 
+    def test_success_footer_stays_on_tee_log_inode_after_path_swap(self) -> None:
+        original_log = self.tmp / "original-pipeline.log"
+        outside = self.tmp / "outside.log"
+        outside.write_text("outside\n")
+        r = self._run_entry(
+            f"original_log = pl.Path({str(original_log)!r})\n"
+            f"outside = pl.Path({str(outside)!r})\n"
+            "def complete(self):\n"
+            "    print('progress before swap', flush=True)\n"
+            "    log_path = self.pipeline_log_path\n"
+            "    assert log_path is not None\n"
+            "    deadline = pl.time.time() + 5\n"
+            "    while not log_path.exists() or 'progress before swap' not in log_path.read_text():\n"
+            "        if pl.time.time() >= deadline:\n"
+            "            raise RuntimeError('tee did not write pipeline.log')\n"
+            "        pl.time.sleep(0.01)\n"
+            "    pl.os.link(log_path, original_log)\n"
+            "    log_path.unlink()\n"
+            "    log_path.symlink_to(outside)\n"
+            "    self.elapsed_seconds = 1\n"
+            "    return 0\n"
+            "pl.Pipeline.main = complete"
+        )
+
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("Pipeline completed", r.stdout)
+        self.assertTrue((self.tmp / ".specula-output" / "pipeline.log").is_symlink())
+        self.assertEqual(outside.read_text(), "outside\n")
+        original_text = original_log.read_text()
+        self.assertIn("progress before swap", original_text)
+        self.assertIn("Pipeline completed", original_text)
+        self.assertIn("View results:", original_text)
+        marker = "Pipeline completed"
+        self.assertEqual(original_text[original_text.index(marker) :], r.stdout[r.stdout.index(marker) :])
+
     def test_final_source_capture_failure_suppresses_success_output(self) -> None:
         r = self._run_entry(
             "def complete(self):\n"

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -958,6 +958,58 @@ class TestOutputIndexNavigation(TmpCwd):
         self.assertIn("cannot update output index for alpha", out)
         self.assertIn("cannot update run index", out)
 
+    def test_success_guide_points_to_index_and_available_final_reports(self) -> None:
+        run = self.tmp / "run"
+        work_dir = run / "alpha" / ".specula-output"
+        work_dir.mkdir(parents=True)
+        (work_dir / "confirmed-bugs.md").write_text("# Confirmation\n")
+        (work_dir / "bug-severity.md").write_text("# Severity\n")
+        pipeline_log = run / "pipeline.log"
+        pipeline_log.write_text("pipeline\n")
+        p = make_pipeline(
+            ["alpha|o/a|Go|ref"],
+            run_dir=run,
+            pipeline_log_path=pipeline_log,
+        )
+        p.refresh_output_indexes()
+
+        _, out = quiet(p.print_output_guide)
+
+        self.assertIn(f"All results: {run / 'index.md'}", out)
+        self.assertIn(f"Confirmation results and evidence: {work_dir / 'confirmed-bugs.md'}", out)
+        self.assertIn(f"Impact assessment: {work_dir / 'bug-severity.md'}", out)
+        self.assertNotIn("bug found", out)
+        self.assertNotIn("bugs found", out)
+
+    def test_success_guide_omits_missing_report_paths(self) -> None:
+        work_dir = self.tmp / ".specula-output"
+        work_dir.mkdir()
+        (work_dir / "confirmed-bugs.md").write_text("# Confirmation\n")
+        pipeline_log = work_dir / "pipeline.log"
+        pipeline_log.write_text("pipeline\n")
+        p = make_pipeline(
+            ["alpha|o/a|Go|ref"],
+            pipeline_log_path=pipeline_log,
+        )
+        p.refresh_output_indexes()
+
+        _, out = quiet(p.print_output_guide)
+
+        self.assertIn(f"All results: {work_dir / 'index.md'}", out)
+        self.assertIn(str(work_dir / "confirmed-bugs.md"), out)
+        self.assertNotIn(str(work_dir / "bug-severity.md"), out)
+
+    def test_dry_run_does_not_recommend_stale_results(self) -> None:
+        work_dir = self.tmp / ".specula-output"
+        work_dir.mkdir()
+        (work_dir / "index.md").write_text("# Old results\n")
+        (work_dir / "confirmed-bugs.md").write_text("# Old confirmation\n")
+        p = make_pipeline(["alpha|o/a|Go|ref"], dry_run=True)
+
+        _, out = quiet(p.print_output_guide)
+
+        self.assertEqual(out, "")
+
 
 class TestAgentRouting(TmpCwd):
     @staticmethod
@@ -2625,7 +2677,10 @@ class TestMainTeeTeardown(TmpCwd):
         run = self.tmp / "runs" / "failed-run"
         run_index = (run / "index.md").read_text()
         target_index = (run / "t" / ".specula-output" / "index.md").read_text()
-        self.assertIn("| t | [Open results](t/.specula-output/index.md) |", run_index)
+        self.assertIn(
+            "| t | [Open results](t/.specula-output/index.md) | Not available | Not available |",
+            run_index,
+        )
         self.assertIn("- Final summary: Not available", run_index)
         self.assertIn("[Modeling brief](modeling-brief.md)", target_index)
         self.assertFalse((run / "pipeline-summary.md").exists())

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -999,6 +999,37 @@ class TestOutputIndexNavigation(TmpCwd):
         self.assertIn(str(work_dir / "confirmed-bugs.md"), out)
         self.assertNotIn(str(work_dir / "bug-severity.md"), out)
 
+    def test_success_guide_rejects_symlinked_reports(self) -> None:
+        run = self.tmp / "run"
+        work_dir = run / "alpha" / ".specula-output"
+        outside = self.tmp / "outside"
+        work_dir.mkdir(parents=True)
+        outside.mkdir()
+        for filename in ("confirmed-bugs.md", "bug-severity.md"):
+            external = outside / filename
+            external.write_text("external\n")
+            (work_dir / filename).symlink_to(external)
+        pipeline_log = run / "pipeline.log"
+        pipeline_log.write_text("pipeline\n")
+        p = make_pipeline(
+            ["alpha|o/a|Go|ref"],
+            run_dir=run,
+            pipeline_log_path=pipeline_log,
+        )
+        p.refresh_output_indexes()
+
+        _, out = quiet(p.print_output_guide)
+
+        self.assertIn(f"All results: {run / 'index.md'}", out)
+        self.assertNotIn(str(work_dir / "confirmed-bugs.md"), out)
+        self.assertNotIn(str(work_dir / "bug-severity.md"), out)
+        target_index = (work_dir / "index.md").read_text()
+        run_index = (run / "index.md").read_text()
+        self.assertIn("Confirmation report: Not available", target_index)
+        self.assertIn("Severity report: Not available", target_index)
+        self.assertIn("| alpha | [Open results]", run_index)
+        self.assertIn("| Not available | Not available |", run_index)
+
     def test_dry_run_does_not_recommend_stale_results(self) -> None:
         work_dir = self.tmp / ".specula-output"
         work_dir.mkdir()
@@ -2646,6 +2677,44 @@ class TestMainTeeTeardown(TmpCwd):
         self.assertEqual(r.returncode, 7)
         self.assertEqual(marker.read_text(), "done")
 
+    def test_success_output_prints_after_teardown(self) -> None:
+        r = self._run_entry(
+            "def complete(self):\n"
+            "    out = pl.Path(self.get_work_dir('t'))\n"
+            "    out.mkdir(parents=True, exist_ok=True)\n"
+            "    (out / 'confirmed-bugs.md').write_text('# Confirmation\\n')\n"
+            "    (out / 'bug-severity.md').write_text('# Severity\\n')\n"
+            "    self.elapsed_seconds = 1\n"
+            "    return 0\n"
+            "pl.Pipeline.main = complete"
+        )
+
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertIn("Pipeline completed", r.stdout)
+        self.assertIn("View results:", r.stdout)
+        self.assertIn("confirmed-bugs.md", r.stdout)
+        self.assertIn("bug-severity.md", r.stdout)
+
+    def test_final_source_capture_failure_suppresses_success_output(self) -> None:
+        r = self._run_entry(
+            "def complete(self):\n"
+            "    out = pl.Path(self.get_work_dir('t'))\n"
+            "    out.mkdir(parents=True, exist_ok=True)\n"
+            "    (out / 'confirmed-bugs.md').write_text('# Confirmation\\n')\n"
+            "    self.elapsed_seconds = 1\n"
+            "    return 0\n"
+            "def fail_capture(self):\n"
+            "    raise RuntimeError('capture failed')\n"
+            "pl.Pipeline.main = complete\n"
+            "pl.Pipeline.finalize_source_snapshots = fail_capture"
+        )
+
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("RuntimeError: capture failed", r.stdout)
+        self.assertNotIn("Pipeline completed", r.stdout)
+        self.assertNotIn("View results:", r.stdout)
+        self.assertNotIn("All results:", r.stdout)
+
     def test_failure_publishes_partial_index_without_completion_summary(self) -> None:
         r = self._run_entry(
             "def boom(self):\n"
@@ -2694,8 +2763,13 @@ class TestMainTeeTeardown(TmpCwd):
         logf.write_text("")
         logf.chmod(0o444)
         self.addCleanup(logf.chmod, 0o644)
-        r = self._run_entry("pl.Pipeline.main = lambda self: 0")
+        (out / "confirmed-bugs.md").write_text("# Confirmation\n")
+        r = self._run_entry(
+            "def complete(self):\n    self.elapsed_seconds = 1\n    return 0\npl.Pipeline.main = complete"
+        )
         self.assertEqual(r.returncode, 1)
+        self.assertNotIn("Pipeline completed", r.stdout)
+        self.assertNotIn("View results:", r.stdout)
 
     def test_failing_tee_wins_over_failing_main(self) -> None:
         # bash pipefail returns the rightmost non-zero status: when main fails

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -2594,6 +2594,49 @@ class TestMainTeeTeardown(TmpCwd):
         self.assertEqual(r.returncode, 7)
         self.assertEqual(marker.read_text(), "done")
 
+    def test_success_points_terminal_to_run_index_without_logging_guide(self) -> None:
+        run = self.tmp / "runs" / "guide-run"
+        r = self._run_entry(
+            f"pl.SPECULA_ROOT = pl.Path({str(self.tmp)!r})\npl.Pipeline.main = lambda self: 0",
+            ["--run-id=guide-run", "t|g|l|r"],
+        )
+
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertIn(f"View all results: {run / 'index.md'}", r.stdout)
+        self.assertIn("(final reports are listed at the top).", r.stdout)
+        log_text = (run / "pipeline.log").read_text()
+        self.assertNotIn("View all results:", log_text)
+        self.assertNotIn("final reports", log_text)
+
+    def test_success_points_terminal_to_single_target_index_after_chdir(self) -> None:
+        case = self.tmp / "case-studies" / "t"
+        case.mkdir(parents=True)
+        r = self._run_entry(
+            f"pl.SPECULA_ROOT = pl.Path({str(self.tmp)!r})\n"
+            "def succeed(self):\n"
+            f"    case = pl.Path({str(case)!r})\n"
+            "    pl.os.chdir(case)\n"
+            "    pl.os.environ['PWD'] = str(case)\n"
+            "    return 0\n"
+            "pl.Pipeline.main = succeed"
+        )
+
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertIn(f"View all results: {case / '.specula-output' / 'index.md'}", r.stdout)
+        self.assertNotIn(f"View all results: {self.tmp / '.specula-output' / 'index.md'}", r.stdout)
+
+    def test_final_source_capture_failure_suppresses_terminal_guide(self) -> None:
+        r = self._run_entry(
+            "pl.Pipeline.main = lambda self: 0\n"
+            "def fail_capture(self):\n"
+            "    raise RuntimeError('capture failed')\n"
+            "pl.Pipeline.finalize_source_snapshots = fail_capture"
+        )
+
+        self.assertEqual(r.returncode, 1)
+        self.assertNotIn("View all results:", r.stdout)
+        self.assertNotIn("final reports", r.stdout)
+
     def test_failure_publishes_partial_index_without_completion_summary(self) -> None:
         r = self._run_entry(
             "def boom(self):\n"
@@ -2644,6 +2687,8 @@ class TestMainTeeTeardown(TmpCwd):
         self.addCleanup(logf.chmod, 0o644)
         r = self._run_entry("pl.Pipeline.main = lambda self: 0")
         self.assertEqual(r.returncode, 1)
+        self.assertNotIn("View all results:", r.stdout)
+        self.assertNotIn("final reports", r.stdout)
 
     def test_failing_tee_wins_over_failing_main(self) -> None:
         # bash pipefail returns the rightmost non-zero status: when main fails

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -958,89 +958,6 @@ class TestOutputIndexNavigation(TmpCwd):
         self.assertIn("cannot update output index for alpha", out)
         self.assertIn("cannot update run index", out)
 
-    def test_success_guide_points_to_index_and_available_final_reports(self) -> None:
-        run = self.tmp / "run"
-        work_dir = run / "alpha" / ".specula-output"
-        work_dir.mkdir(parents=True)
-        (work_dir / "confirmed-bugs.md").write_text("# Confirmation\n")
-        (work_dir / "bug-severity.md").write_text("# Severity\n")
-        pipeline_log = run / "pipeline.log"
-        pipeline_log.write_text("pipeline\n")
-        p = make_pipeline(
-            ["alpha|o/a|Go|ref"],
-            run_dir=run,
-            pipeline_log_path=pipeline_log,
-        )
-        p.refresh_output_indexes()
-
-        _, out = quiet(p.print_output_guide)
-
-        self.assertIn(f"All results: {run / 'index.md'}", out)
-        self.assertIn(f"Confirmation results and evidence: {work_dir / 'confirmed-bugs.md'}", out)
-        self.assertIn(f"Impact assessment: {work_dir / 'bug-severity.md'}", out)
-        self.assertNotIn("bug found", out)
-        self.assertNotIn("bugs found", out)
-
-    def test_success_guide_omits_missing_report_paths(self) -> None:
-        work_dir = self.tmp / ".specula-output"
-        work_dir.mkdir()
-        (work_dir / "confirmed-bugs.md").write_text("# Confirmation\n")
-        pipeline_log = work_dir / "pipeline.log"
-        pipeline_log.write_text("pipeline\n")
-        p = make_pipeline(
-            ["alpha|o/a|Go|ref"],
-            pipeline_log_path=pipeline_log,
-        )
-        p.refresh_output_indexes()
-
-        _, out = quiet(p.print_output_guide)
-
-        self.assertIn(f"All results: {work_dir / 'index.md'}", out)
-        self.assertIn(str(work_dir / "confirmed-bugs.md"), out)
-        self.assertNotIn(str(work_dir / "bug-severity.md"), out)
-
-    def test_success_guide_rejects_symlinked_reports(self) -> None:
-        run = self.tmp / "run"
-        work_dir = run / "alpha" / ".specula-output"
-        outside = self.tmp / "outside"
-        work_dir.mkdir(parents=True)
-        outside.mkdir()
-        for filename in ("confirmed-bugs.md", "bug-severity.md"):
-            external = outside / filename
-            external.write_text("external\n")
-            (work_dir / filename).symlink_to(external)
-        pipeline_log = run / "pipeline.log"
-        pipeline_log.write_text("pipeline\n")
-        p = make_pipeline(
-            ["alpha|o/a|Go|ref"],
-            run_dir=run,
-            pipeline_log_path=pipeline_log,
-        )
-        p.refresh_output_indexes()
-
-        _, out = quiet(p.print_output_guide)
-
-        self.assertIn(f"All results: {run / 'index.md'}", out)
-        self.assertNotIn(str(work_dir / "confirmed-bugs.md"), out)
-        self.assertNotIn(str(work_dir / "bug-severity.md"), out)
-        target_index = (work_dir / "index.md").read_text()
-        run_index = (run / "index.md").read_text()
-        self.assertIn("Confirmation report: Not available", target_index)
-        self.assertIn("Severity report: Not available", target_index)
-        self.assertIn("| alpha | [Open results]", run_index)
-        self.assertIn("| Not available | Not available |", run_index)
-
-    def test_dry_run_does_not_recommend_stale_results(self) -> None:
-        work_dir = self.tmp / ".specula-output"
-        work_dir.mkdir()
-        (work_dir / "index.md").write_text("# Old results\n")
-        (work_dir / "confirmed-bugs.md").write_text("# Old confirmation\n")
-        p = make_pipeline(["alpha|o/a|Go|ref"], dry_run=True)
-
-        _, out = quiet(p.print_output_guide)
-
-        self.assertEqual(out, "")
-
 
 class TestAgentRouting(TmpCwd):
     @staticmethod
@@ -2677,87 +2594,6 @@ class TestMainTeeTeardown(TmpCwd):
         self.assertEqual(r.returncode, 7)
         self.assertEqual(marker.read_text(), "done")
 
-    def test_success_output_prints_after_teardown(self) -> None:
-        r = self._run_entry(
-            "def complete(self):\n"
-            "    out = pl.Path(self.get_work_dir('t'))\n"
-            "    out.mkdir(parents=True, exist_ok=True)\n"
-            "    (out / 'confirmed-bugs.md').write_text('# Confirmation\\n')\n"
-            "    (out / 'bug-severity.md').write_text('# Severity\\n')\n"
-            "    self.elapsed_seconds = 1\n"
-            "    return 0\n"
-            "pl.Pipeline.main = complete"
-        )
-
-        self.assertEqual(r.returncode, 0, r.stdout)
-        self.assertIn("Pipeline completed", r.stdout)
-        self.assertIn("View results:", r.stdout)
-        self.assertIn("confirmed-bugs.md", r.stdout)
-        self.assertIn("bug-severity.md", r.stdout)
-        log_text = (self.tmp / ".specula-output" / "pipeline.log").read_text()
-        self.assertIn("Pipeline completed", log_text)
-        self.assertIn("View results:", log_text)
-        marker = "Pipeline completed"
-        self.assertEqual(log_text[log_text.index(marker) :], r.stdout[r.stdout.index(marker) :])
-
-    def test_success_footer_stays_on_tee_log_inode_after_path_swap(self) -> None:
-        original_log = self.tmp / "original-pipeline.log"
-        outside = self.tmp / "outside.log"
-        outside.write_text("outside\n")
-        r = self._run_entry(
-            f"original_log = pl.Path({str(original_log)!r})\n"
-            f"outside = pl.Path({str(outside)!r})\n"
-            "def complete(self):\n"
-            "    print('progress before swap', flush=True)\n"
-            "    log_path = self.pipeline_log_path\n"
-            "    assert log_path is not None\n"
-            "    deadline = pl.time.time() + 5\n"
-            "    while not log_path.exists() or 'progress before swap' not in log_path.read_text():\n"
-            "        if pl.time.time() >= deadline:\n"
-            "            raise RuntimeError('tee did not write pipeline.log')\n"
-            "        pl.time.sleep(0.01)\n"
-            "    pl.os.link(log_path, original_log)\n"
-            "    log_path.unlink()\n"
-            "    log_path.symlink_to(outside)\n"
-            "    self.elapsed_seconds = 1\n"
-            "    return 0\n"
-            "pl.Pipeline.main = complete"
-        )
-
-        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
-        self.assertIn("Pipeline completed", r.stdout)
-        self.assertTrue((self.tmp / ".specula-output" / "pipeline.log").is_symlink())
-        self.assertEqual(outside.read_text(), "outside\n")
-        original_text = original_log.read_text()
-        self.assertIn("progress before swap", original_text)
-        self.assertIn("Pipeline completed", original_text)
-        self.assertIn("View results:", original_text)
-        marker = "Pipeline completed"
-        self.assertEqual(original_text[original_text.index(marker) :], r.stdout[r.stdout.index(marker) :])
-
-    def test_final_source_capture_failure_suppresses_success_output(self) -> None:
-        r = self._run_entry(
-            "def complete(self):\n"
-            "    out = pl.Path(self.get_work_dir('t'))\n"
-            "    out.mkdir(parents=True, exist_ok=True)\n"
-            "    (out / 'confirmed-bugs.md').write_text('# Confirmation\\n')\n"
-            "    self.elapsed_seconds = 1\n"
-            "    return 0\n"
-            "def fail_capture(self):\n"
-            "    raise RuntimeError('capture failed')\n"
-            "pl.Pipeline.main = complete\n"
-            "pl.Pipeline.finalize_source_snapshots = fail_capture"
-        )
-
-        self.assertEqual(r.returncode, 1)
-        self.assertIn("RuntimeError: capture failed", r.stdout)
-        self.assertNotIn("Pipeline completed", r.stdout)
-        self.assertNotIn("View results:", r.stdout)
-        self.assertNotIn("All results:", r.stdout)
-        log_text = (self.tmp / ".specula-output" / "pipeline.log").read_text()
-        self.assertNotIn("Pipeline completed", log_text)
-        self.assertNotIn("View results:", log_text)
-
     def test_failure_publishes_partial_index_without_completion_summary(self) -> None:
         r = self._run_entry(
             "def boom(self):\n"
@@ -2806,13 +2642,8 @@ class TestMainTeeTeardown(TmpCwd):
         logf.write_text("")
         logf.chmod(0o444)
         self.addCleanup(logf.chmod, 0o644)
-        (out / "confirmed-bugs.md").write_text("# Confirmation\n")
-        r = self._run_entry(
-            "def complete(self):\n    self.elapsed_seconds = 1\n    return 0\npl.Pipeline.main = complete"
-        )
+        r = self._run_entry("pl.Pipeline.main = lambda self: 0")
         self.assertEqual(r.returncode, 1)
-        self.assertNotIn("Pipeline completed", r.stdout)
-        self.assertNotIn("View results:", r.stdout)
 
     def test_failing_tee_wins_over_failing_main(self) -> None:
         # bash pipefail returns the rightmost non-zero status: when main fails


### PR DESCRIPTION
## Summary

- Surface `confirmed-bugs.md` and `bug-severity.md` at the top of each target index.
- Link both reports directly from the run-level target chooser.
- Point successful runs to the generated results index in the terminal only.
- Suppress the terminal guide when finalization, tee, or index publication fails.
- Update the usage documentation to match the revised navigation.

Part of #100.

## Testing

- `uv run pytest tests/ -q`
- `PYTHONPATH=tools uv run pytest tools/inv_checking_tool/tests -q`
- `PYTHONPATH=tools/trace_debugger/src uv run python tools/trace_debugger/tests/test_basic.py`
- `uv run mypy`
- Ruff lint and format checks