### PR TITLE
Prepare Specula v0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "specula"
-version = "0.2.0"
+version = "0.3.0"
 description = "Specula: a framework for finding deep bugs in system code using TLA+."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/infra/setup_codex_plugin.py
+++ b/scripts/infra/setup_codex_plugin.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 
 PLUGIN_NAME = "specula-codex"
-PLUGIN_VERSION = "0.2.0"
+PLUGIN_VERSION = "0.3.0"
 MARKETPLACE_NAME = "specula"
 LEGACY_MCP_NAMES = ("tracedebugger", "spec_analyzer", "inv_checking_tool")
 

--- a/src/specula/cli.py
+++ b/src/specula/cli.py
@@ -20,7 +20,7 @@ import sys
 from pathlib import Path
 
 PROG = "specula"
-VERSION = "0.2.0"
+VERSION = "0.3.0"
 
 SPECULA_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = SPECULA_ROOT / "scripts"

--- a/src/specula/output_index.py
+++ b/src/specula/output_index.py
@@ -198,7 +198,7 @@ def render_target_index(name: str, work_dir: Path, *, pipeline_log: Path | None 
         "|---:|---|---|",
         (
             f"| 1 | {_document('Modeling brief', work_dir / 'modeling-brief.md', work_dir)} "
-            "| System model, bug families, and proposed invariants |"
+            "| System model, Scenarios, and proposed invariants |"
         ),
         (
             f"| 2 | {_document('Analysis report', work_dir / 'analysis-report.md', work_dir)} "

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -83,7 +83,7 @@ class TestHelp(CaptureExec):
 
     def test_version(self) -> None:
         rc, out, err = self._main(["--version"])
-        self.assertEqual((rc, out, err), (0, "specula 0.2.0\n", ""))
+        self.assertEqual((rc, out, err), (0, "specula 0.3.0\n", ""))
         self.assertEqual(self.execs, [])
 
 
@@ -150,4 +150,4 @@ class TestShim(unittest.TestCase):
             capture_output=True,
             text=True,
         )
-        self.assertEqual((r.returncode, r.stdout, r.stderr), (0, "specula 0.2.0\n", ""))
+        self.assertEqual((r.returncode, r.stdout, r.stderr), (0, "specula 0.3.0\n", ""))

--- a/tests/unit/test_output_index.py
+++ b/tests/unit/test_output_index.py
@@ -127,7 +127,7 @@ class TestTargetIndex(OutputIndexCase):
 
             | Step | Document | What it contains |
             |---:|---|---|
-            | 1 | [Modeling brief](modeling-brief.md) | System model, bug families, and proposed invariants |
+            | 1 | [Modeling brief](modeling-brief.md) | System model, Scenarios, and proposed invariants |
             | 2 | [Analysis report](analysis-report.md) | Detailed source-code investigation |
             | 3 | [Spec coverage](spec/brief-coverage.md) · [Instrumentation map](spec/instrumentation-spec.md) | How the analysis was translated into the model |
             | 4 | [Validation changelog](spec/changelog.md) | Model corrections and validation history |

--- a/tests/unit/test_setup_codex_plugin.py
+++ b/tests/unit/test_setup_codex_plugin.py
@@ -189,7 +189,7 @@ class TestCodexPluginSkillContract(unittest.TestCase):
                 lock_version,
                 cast(str, manifest["version"]),
             },
-            {"0.2.0"},
+            {"0.3.0"},
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1103,7 +1103,7 @@ wheels = [
 
 [[package]]
 name = "specula"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Set the project, CLI, lockfile, and Codex plugin versions to 0.3.0.
- Update the version consistency tests.
- Finish the Scenario terminology migration in generated output indexes.