### PR TITLE
Fix deadlock flag direction

### DIFF
--- a/scripts/tlc/run_model_check.sh
+++ b/scripts/tlc/run_model_check.sh
@@ -231,7 +231,7 @@ TLC_CMD+=("$SPEC_FILE")
 TLC_CMD+=(-workers "$WORKERS")
 
 # Add deadlock check
-if [ "$DEADLOCK_CHECK" = true ]; then
+if [ "$DEADLOCK_CHECK" = false ]; then
     TLC_CMD+=(-deadlock)
 fi
 


### PR DESCRIPTION
## Summary

- invert the wrapper condition so Specula's `-D` actually enables TLC deadlock checking
- keep the change to a single replacement