### PR TITLE
Fix Codex usage collection

### DIFF
--- a/scripts/launch/adapters/codex.sh
+++ b/scripts/launch/adapters/codex.sh
@@ -169,7 +169,10 @@ PY
     return "$write_rc"
   fi
 
-  [[ -d "$sessions_dir" ]] || return 0
+  if [[ ! -d "$sessions_dir" ]]; then
+    echo "codex adapter: usage unavailable: sessions directory not found: $sessions_dir" >&2
+    return 0
+  fi
 
   local session_path=""
   if [[ -n "$RESUME_STATE" ]]; then
@@ -208,35 +211,87 @@ for path in sorted(sessions_dir.rglob("rollout-*.jsonl")):
 PY
     )"
   else
-    session_path="$(
-      find "$sessions_dir" -type f -name 'rollout-*.jsonl' -newer "$marker_file" 2>/dev/null \
-      | sort \
-      | tail -n1
+    local session_info=""
+    session_info="$(python3 - "$sessions_dir" "$marker_file" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+sessions_dir = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+try:
+    marker_mtime = marker.stat().st_mtime_ns
+except OSError:
+    raise SystemExit(0)
+
+candidates = []
+for path in sorted(sessions_dir.rglob("rollout-*.jsonl")):
+    try:
+        if not path.is_file() or path.stat().st_mtime_ns <= marker_mtime:
+            continue
+        with path.open(encoding="utf-8") as stream:
+            first = json.loads(stream.readline())
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        continue
+    if first.get("type") != "session_meta":
+        continue
+    payload = first.get("payload")
+    if not isinstance(payload, dict):
+        continue
+    session_id = payload.get("id") or payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        continue
+    parent_id = payload.get("parent_thread_id")
+    source = payload.get("source")
+    if parent_id is None and isinstance(source, dict):
+        subagent = source.get("subagent")
+        if isinstance(subagent, dict):
+            thread_spawn = subagent.get("thread_spawn")
+            if isinstance(thread_spawn, dict):
+                parent_id = thread_spawn.get("parent_thread_id")
+    if parent_id is None:
+        candidates.append((path, session_id))
+
+if len(candidates) == 1:
+    print(f"{candidates[0][0]}\t{candidates[0][1]}")
+elif candidates:
+    print(
+        "codex adapter: usage unavailable: multiple Codex sessions started during this invocation",
+        file=sys.stderr,
+    )
+else:
+    print(
+        "codex adapter: usage unavailable: no Codex session found for this invocation",
+        file=sys.stderr,
+    )
+PY
     )"
+    if [[ -n "$session_info" ]]; then
+      session_path="${session_info%%$'\t'*}"
+      exact_session_id="${session_info#*$'\t'}"
+    fi
   fi
 
-  [[ -n "$session_path" ]] || return 0
+  if [[ -z "$session_path" ]]; then
+    if [[ -n "$exact_session_id" ]]; then
+      echo "codex adapter: usage unavailable: session $exact_session_id was not found" >&2
+    fi
+    return 0
+  fi
 
   local session_file
-  local session_id
   session_file="$(basename "$session_path" .jsonl)"
-  if [[ -n "$RESUME_STATE" ]]; then
-    session_id="$exact_session_id"
-  else
-    session_id="${session_path#${sessions_dir}/}"
-    session_id="${session_id%.jsonl}"
-  fi
 
   local ccusage_output=""
   if command -v npx >/dev/null 2>&1; then
-    ccusage_output="$(
-      npx @ccusage/codex@latest session --json 2>/dev/null \
+    if ! ccusage_output="$(
+      npx --yes ccusage@20.0.19 codex session --json 2>/dev/null \
       | python3 -c '
 import json
 import sys
 
 session_file = sys.argv[1]
-exact_session_id = sys.argv[2] or None
+exact_session_id = sys.argv[2]
 
 try:
     data = json.load(sys.stdin)
@@ -244,30 +299,39 @@ except Exception:
     sys.exit(1)
 
 for session in data.get("sessions", []):
-    if session.get("sessionFile") == session_file:
-        json.dump(
-            {
-                "agent": "codex",
-                "session_id": exact_session_id or session.get("sessionId"),
-                "session_file": session.get("sessionFile"),
-                "total_cost_usd": session.get("costUSD"),
-                "usage": {
-                    "input_tokens": session.get("inputTokens"),
-                    "cached_input_tokens": session.get("cachedInputTokens"),
-                    "output_tokens": session.get("outputTokens"),
-                    "reasoning_output_tokens": session.get("reasoningOutputTokens"),
-                    "total_tokens": session.get("totalTokens"),
-                },
+    if session.get("sessionFile") != session_file:
+        continue
+    cached_input = session.get("cacheReadTokens")
+    if cached_input is None:
+        cached_input = session.get("cachedInputTokens")
+    json.dump(
+        {
+            "agent": "codex",
+            "session_id": exact_session_id,
+            "session_file": session.get("sessionFile"),
+            "total_cost_usd": session.get("costUSD"),
+            "usage": {
+                "input_tokens": session.get("inputTokens"),
+                "cached_input_tokens": cached_input,
+                "output_tokens": session.get("outputTokens"),
+                "reasoning_output_tokens": session.get("reasoningOutputTokens"),
+                "total_tokens": session.get("totalTokens"),
             },
-            sys.stdout,
-            indent=2,
-        )
-        print()
-        sys.exit(0)
+        },
+        sys.stdout,
+        indent=2,
+    )
+    print()
+    sys.exit(0)
 
 sys.exit(1)
-' "$session_file" "$exact_session_id" 2>/dev/null
-    )" || true
+' "$session_file" "$exact_session_id"
+    )"; then
+      ccusage_output=""
+      echo "codex adapter: usage unavailable for session $exact_session_id" >&2
+    fi
+  else
+    echo "codex adapter: usage unavailable: npx was not found" >&2
   fi
 
   if [[ -n "$ccusage_output" ]]; then
@@ -276,7 +340,7 @@ sys.exit(1)
     return "$write_rc"
   fi
 
-  python3 - <<'PY' "$usage_file" "$session_id" "$session_file"
+  python3 - <<'PY' "$usage_file" "$exact_session_id" "$session_file"
 import json
 import sys
 

--- a/scripts/launch/adapters/codex.sh
+++ b/scripts/launch/adapters/codex.sh
@@ -300,9 +300,9 @@ for session in sessions:
 root = rows_by_file.get(root_session_file)
 if root is None:
     sys.exit(1)
-if not target_files.issubset(rows_by_file):
-    sys.exit(1)
-selected = [rows_by_file[name] for name in sorted(target_files)]
+# ccusage omits descendants with no incremental billable events, including
+# fully deduplicated fork history. Those sessions contribute zero usage.
+selected = [rows_by_file[name] for name in sorted(target_files) if name in rows_by_file]
 
 def token_total(key, legacy_key=None, default=None):
     total = 0

--- a/scripts/launch/adapters/codex.sh
+++ b/scripts/launch/adapters/codex.sh
@@ -134,11 +134,10 @@ fi
 
 write_usage_file() {
   local log_file="$1"
+  local exact_session_id="$2"
   local sessions_dir="${CODEX_HOME:-$HOME/.codex}/sessions"
-  local marker_file="$2"
   local usage_file="${log_file%.log}.usage.json"
   local write_rc=0
-  local exact_session_id=""
 
   if [[ -n "$RESUME_STATE" ]]; then
     if ! exact_session_id="$(read_resume_session_id)"; then
@@ -169,18 +168,21 @@ PY
     return "$write_rc"
   fi
 
+  if [[ -z "$exact_session_id" ]]; then
+    echo "codex adapter: usage unavailable: exact thread.started ID was not captured" >&2
+    return 0
+  fi
+
   if [[ ! -d "$sessions_dir" ]]; then
     echo "codex adapter: usage unavailable: sessions directory not found: $sessions_dir" >&2
     return 0
   fi
 
   local session_path=""
-  if [[ -n "$RESUME_STATE" ]]; then
-    # A resume-aware run is keyed exclusively by the ID captured from this
-    # Codex stream. Never guess with a timestamp marker (or `--last`): another
-    # concurrent Codex process may have written the newest rollout.
-    [[ -n "$exact_session_id" ]] || return 0
-    session_path="$(python3 - "$sessions_dir" "$exact_session_id" <<'PY'
+  # Every run is keyed exclusively by the documented thread.started ID from
+  # this Codex stream. Never guess with timestamps (or `--last`): another
+  # concurrent Codex process may be creating or resuming a rollout.
+  session_path="$(python3 - "$sessions_dir" "$exact_session_id" <<'PY'
 import json
 from pathlib import Path
 import sys
@@ -209,25 +211,40 @@ for path in sorted(sessions_dir.rglob("rollout-*.jsonl")):
         print(path)
         raise SystemExit(0)
 PY
-    )"
-  else
-    local session_info=""
-    session_info="$(python3 - "$sessions_dir" "$marker_file" <<'PY'
+  )"
+
+  if [[ -z "$session_path" ]]; then
+    echo "codex adapter: usage unavailable: session $exact_session_id was not found" >&2
+    return 0
+  fi
+
+  local session_file
+  session_file="$(basename "$session_path" .jsonl)"
+
+  local ccusage_output=""
+  if command -v npx >/dev/null 2>&1; then
+    if ! ccusage_output="$(
+      npx --yes ccusage@20.0.19 codex session --json 2>/dev/null \
+      | python3 -c '
 import json
+import math
 from pathlib import Path
 import sys
 
-sessions_dir = Path(sys.argv[1])
-marker = Path(sys.argv[2])
-try:
-    marker_mtime = marker.stat().st_mtime_ns
-except OSError:
-    raise SystemExit(0)
+root_session_file = sys.argv[1]
+exact_session_id = sys.argv[2]
+sessions_dir = Path(sys.argv[3])
 
-candidates = []
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+
+parents = {}
+files_by_id = {}
 for path in sorted(sessions_dir.rglob("rollout-*.jsonl")):
     try:
-        if not path.is_file() or path.stat().st_mtime_ns <= marker_mtime:
+        if not path.is_file():
             continue
         with path.open(encoding="utf-8") as stream:
             first = json.loads(stream.readline())
@@ -241,91 +258,103 @@ for path in sorted(sessions_dir.rglob("rollout-*.jsonl")):
     session_id = payload.get("id") or payload.get("session_id")
     if not isinstance(session_id, str) or not session_id:
         continue
+    files_by_id[session_id] = path.stem
     parent_id = payload.get("parent_thread_id")
     source = payload.get("source")
-    if parent_id is None and isinstance(source, dict):
-        subagent = source.get("subagent")
-        if isinstance(subagent, dict):
-            thread_spawn = subagent.get("thread_spawn")
-            if isinstance(thread_spawn, dict):
-                parent_id = thread_spawn.get("parent_thread_id")
-    if parent_id is None:
-        candidates.append((path, session_id))
+    subagent = source.get("subagent") if isinstance(source, dict) else None
+    if parent_id is None and isinstance(subagent, dict):
+        thread_spawn = subagent.get("thread_spawn")
+        if isinstance(thread_spawn, dict):
+            parent_id = thread_spawn.get("parent_thread_id")
+        if parent_id is None:
+            parent_id = payload.get("forked_from_id")
+    if isinstance(parent_id, str) and parent_id:
+        parents[session_id] = parent_id
 
-if len(candidates) == 1:
-    print(f"{candidates[0][0]}\t{candidates[0][1]}")
-elif candidates:
-    print(
-        "codex adapter: usage unavailable: multiple Codex sessions started during this invocation",
-        file=sys.stderr,
-    )
-else:
-    print(
-        "codex adapter: usage unavailable: no Codex session found for this invocation",
-        file=sys.stderr,
-    )
-PY
-    )"
-    if [[ -n "$session_info" ]]; then
-      session_path="${session_info%%$'\t'*}"
-      exact_session_id="${session_info#*$'\t'}"
-    fi
-  fi
+included_ids = {exact_session_id}
+changed = True
+while changed:
+    changed = False
+    for child_id, parent_id in parents.items():
+        if parent_id in included_ids and child_id not in included_ids:
+            included_ids.add(child_id)
+            changed = True
 
-  if [[ -z "$session_path" ]]; then
-    if [[ -n "$exact_session_id" ]]; then
-      echo "codex adapter: usage unavailable: session $exact_session_id was not found" >&2
-    fi
-    return 0
-  fi
+target_files = {root_session_file}
+target_files.update(files_by_id[session_id] for session_id in included_ids if session_id in files_by_id)
 
-  local session_file
-  session_file="$(basename "$session_path" .jsonl)"
+sessions = data.get("sessions")
+if not isinstance(sessions, list):
+    sys.exit(1)
+rows_by_file = {}
+for session in sessions:
+    if not isinstance(session, dict):
+        sys.exit(1)
+    session_file = session.get("sessionFile")
+    if not isinstance(session_file, str) or not session_file:
+        continue
+    if session_file in rows_by_file:
+        sys.exit(1)
+    rows_by_file[session_file] = session
 
-  local ccusage_output=""
-  if command -v npx >/dev/null 2>&1; then
-    if ! ccusage_output="$(
-      npx --yes ccusage@20.0.19 codex session --json 2>/dev/null \
-      | python3 -c '
-import json
-import sys
+root = rows_by_file.get(root_session_file)
+if root is None:
+    sys.exit(1)
+if not target_files.issubset(rows_by_file):
+    sys.exit(1)
+selected = [rows_by_file[name] for name in sorted(target_files)]
 
-session_file = sys.argv[1]
-exact_session_id = sys.argv[2]
+def token_total(key, legacy_key=None, default=None):
+    total = 0
+    for row in selected:
+        value = row.get(key)
+        if value is None and legacy_key is not None:
+            value = row.get(legacy_key)
+        if value is None and default is not None:
+            value = default
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(value)
+            or value < 0
+            or (isinstance(value, float) and not value.is_integer())
+        ):
+            raise ValueError(key)
+        total += int(value)
+    return total
+
+costs = []
+for row in selected:
+    cost = row.get("costUSD")
+    if isinstance(cost, bool) or not isinstance(cost, (int, float)) or not math.isfinite(cost) or cost < 0:
+        sys.exit(1)
+    costs.append(float(cost))
 
 try:
-    data = json.load(sys.stdin)
-except Exception:
+    usage = {
+        "input_tokens": token_total("inputTokens"),
+        "cached_input_tokens": token_total("cacheReadTokens", "cachedInputTokens"),
+        "cache_write_input_tokens": token_total("cacheCreationTokens", default=0),
+        "output_tokens": token_total("outputTokens"),
+        "reasoning_output_tokens": token_total("reasoningOutputTokens"),
+        "total_tokens": token_total("totalTokens"),
+    }
+except ValueError:
     sys.exit(1)
 
-for session in data.get("sessions", []):
-    if session.get("sessionFile") != session_file:
-        continue
-    cached_input = session.get("cacheReadTokens")
-    if cached_input is None:
-        cached_input = session.get("cachedInputTokens")
-    json.dump(
-        {
-            "agent": "codex",
-            "session_id": exact_session_id,
-            "session_file": session.get("sessionFile"),
-            "total_cost_usd": session.get("costUSD"),
-            "usage": {
-                "input_tokens": session.get("inputTokens"),
-                "cached_input_tokens": cached_input,
-                "output_tokens": session.get("outputTokens"),
-                "reasoning_output_tokens": session.get("reasoningOutputTokens"),
-                "total_tokens": session.get("totalTokens"),
-            },
-        },
-        sys.stdout,
-        indent=2,
-    )
-    print()
-    sys.exit(0)
-
-sys.exit(1)
-' "$session_file" "$exact_session_id"
+json.dump(
+    {
+        "agent": "codex",
+        "session_id": exact_session_id,
+        "session_file": root_session_file,
+        "total_cost_usd": math.fsum(costs),
+        "usage": usage,
+    },
+    sys.stdout,
+    indent=2,
+)
+print()
+' "$session_file" "$exact_session_id" "$sessions_dir"
     )"; then
       ccusage_output=""
       echo "codex adapter: usage unavailable for session $exact_session_id" >&2
@@ -365,24 +394,17 @@ PY
 run_codex() {
   local log_file="$1"
   local last_message_file="${log_file%.log}.last-message.txt"
-  local marker_file
-  local activity_log="${SPECULA_ACTIVITY_LOG:-}"
-  local temporary_activity_log=""
+  local activity_log="${SPECULA_ACTIVITY_LOG:-/dev/null}"
+  local session_id_file=""
   local adapter_dir
   local specula_src
   adapter_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   specula_src="$adapter_dir/../../../src"
-  marker_file="$(mktemp)"
-  if [[ -n "$RESUME_STATE" && -z "$activity_log" ]]; then
-    if ! temporary_activity_log="$(mktemp "${TMPDIR:-/tmp}/specula-codex-activity-XXXXXX.jsonl")"; then
-      rm -f "$marker_file" || true
-      echo "codex adapter: unable to create temporary activity log for session capture" >&2
-      return 1
+  if [[ -z "$RESUME_STATE" ]]; then
+    if ! session_id_file="$(mktemp "${TMPDIR:-/tmp}/specula-codex-session-XXXXXX.id")"; then
+      session_id_file=""
+      echo "codex adapter: usage unavailable: unable to create session ID file" >&2
     fi
-    # Native resume requires the exact thread.started ID. Keep JSON streaming
-    # enabled even when the user disables progress display; the temporary raw
-    # sidecar is removed below and does not opt the UI back into progress.
-    activity_log="$temporary_activity_log"
   fi
 
   # ── Optional outer srt sandbox (M1.3) ──
@@ -417,71 +439,50 @@ run_codex() {
   # Never let a failed/retried turn reuse the preceding turn's answer.
   rm -f "$last_message_file"
   set +e
-  if [[ -n "$activity_log" ]]; then
-    local -a pipeline_status
-    local -a stream_args=(codex "$activity_log" "$log_file")
-    local stream_rc
-    if [[ -n "$RESUME_STATE" ]]; then
-      stream_args+=("$RESUME_STATE" "$RESUME_CWD" "$MODEL" "$EFFORT")
+  local -a pipeline_status
+  local -a stream_args=(codex "$activity_log" "$log_file")
+  local stream_rc
+  if [[ -n "$RESUME_STATE" ]]; then
+    stream_args+=("$RESUME_STATE" "$RESUME_CWD" "$MODEL" "$EFFORT")
+  elif [[ -n "$session_id_file" ]]; then
+    stream_args+=("$session_id_file")
+  fi
+  printf '%s' "$PROMPT" | "${cmd[@]}" --json - 2>&1 | python3 -I -c \
+    'import sys; sys.path.insert(0, sys.argv.pop(1)); from specula.adapters.utils.event_stream import main; raise SystemExit(main(sys.argv[1:]))' \
+    "$specula_src" "${stream_args[@]}"
+  pipeline_status=("${PIPESTATUS[@]}")
+  codex_rc="${pipeline_status[1]}"
+  stream_rc="${pipeline_status[2]}"
+  if (( stream_rc == RESUME_STATE_FAILURE_RC )); then
+    # Session-integrity failure is fail-closed even when the native CLI also
+    # reports a retryable status. Never resume a state whose exact ID changed.
+    codex_rc=1
+  elif (( codex_rc == 75 || stream_rc == 75 )); then
+    codex_rc=75  # Rate limiting remains the highest-priority retry outcome.
+  elif (( stream_rc == POLICY_BLOCKED_RC )); then
+    codex_rc="$POLICY_BLOCKED_RC"
+  elif (( codex_rc == POLICY_BLOCKED_RC )); then
+    : # Preserve an already-normalized policy outcome over transient status.
+  elif (( codex_rc != 0 && stream_rc == PLAIN_POLICY_DIAGNOSTIC_RC )); then
+    codex_rc="$POLICY_BLOCKED_RC"
+  elif (( stream_rc == TRANSIENT_FAILURE_RC )); then
+    # A structured provider envelope is authoritative over an ordinary CLI
+    # failure (and over an accidental zero exit), but not over 75/76 above.
+    codex_rc="$TRANSIENT_FAILURE_RC"
+    transient_classified=true
+  elif (( codex_rc != 0 && stream_rc == PLAIN_TRANSIENT_DIAGNOSTIC_RC )); then
+    codex_rc="$TRANSIENT_FAILURE_RC"
+    transient_classified=true
+  elif (( codex_rc == 0 )); then
+    # A plain diagnostic is only actionable when the CLI itself failed.
+    # Structured policy failures use POLICY_BLOCKED_RC above and remain
+    # authoritative even if a provider CLI accidentally exits zero.
+    if (( stream_rc != PLAIN_POLICY_DIAGNOSTIC_RC \
+          && stream_rc != PLAIN_TRANSIENT_DIAGNOSTIC_RC )); then
+      codex_rc="$stream_rc"
     fi
-    printf '%s' "$PROMPT" | "${cmd[@]}" --json - 2>&1 | python3 -I -c \
-      'import sys; sys.path.insert(0, sys.argv.pop(1)); from specula.adapters.utils.event_stream import main; raise SystemExit(main(sys.argv[1:]))' \
-      "$specula_src" "${stream_args[@]}"
-    pipeline_status=("${PIPESTATUS[@]}")
-    codex_rc="${pipeline_status[1]}"
-    stream_rc="${pipeline_status[2]}"
-    if (( stream_rc == RESUME_STATE_FAILURE_RC )); then
-      # Session-integrity failure is fail-closed even when the native CLI also
-      # reports a retryable status. Never resume a state whose exact ID changed.
-      codex_rc=1
-    elif (( codex_rc == 75 || stream_rc == 75 )); then
-      codex_rc=75  # Rate limiting remains the highest-priority retry outcome.
-    elif (( stream_rc == POLICY_BLOCKED_RC )); then
-      codex_rc="$POLICY_BLOCKED_RC"
-    elif (( codex_rc == POLICY_BLOCKED_RC )); then
-      : # Preserve an already-normalized policy outcome over transient status.
-    elif (( codex_rc != 0 && stream_rc == PLAIN_POLICY_DIAGNOSTIC_RC )); then
-      codex_rc="$POLICY_BLOCKED_RC"
-    elif (( stream_rc == TRANSIENT_FAILURE_RC )); then
-      # A structured provider envelope is authoritative over an ordinary CLI
-      # failure (and over an accidental zero exit), but not over 75/76 above.
-      codex_rc="$TRANSIENT_FAILURE_RC"
-      transient_classified=true
-    elif (( codex_rc != 0 && stream_rc == PLAIN_TRANSIENT_DIAGNOSTIC_RC )); then
-      codex_rc="$TRANSIENT_FAILURE_RC"
-      transient_classified=true
-    elif (( codex_rc == 0 )); then
-      # A plain diagnostic is only actionable when the CLI itself failed.
-      # Structured policy failures use POLICY_BLOCKED_RC above and remain
-      # authoritative even if a provider CLI accidentally exits zero.
-      if (( stream_rc != PLAIN_POLICY_DIAGNOSTIC_RC \
-            && stream_rc != PLAIN_TRANSIENT_DIAGNOSTIC_RC )); then
-        codex_rc="$stream_rc"
-      fi
-    fi
-  else
-    local -a pipeline_status
-    printf '%s' "$PROMPT" | "${cmd[@]}" - > "$log_file" 2>&1
-    pipeline_status=("${PIPESTATUS[@]}")
-    codex_rc="${pipeline_status[1]}"
   fi
   set -e
-
-  if [[ -z "$activity_log" ]] && (( codex_rc != 0 && codex_rc != 75 )); then
-    # Without progress streaming there is no structured event status. Only
-    # classify an already-failed CLI's diagnostic log; successful agent output
-    # may quote an old policy message and must remain successful.
-    if python3 -I -c \
-      'import sys; sys.path.insert(0, sys.argv[1]); from pathlib import Path; from specula.adapters.utils.policy import failed_log_has_policy_block; raise SystemExit(0 if failed_log_has_policy_block(Path(sys.argv[2])) else 1)' \
-      "$specula_src" "$log_file"; then
-      codex_rc="$POLICY_BLOCKED_RC"
-    elif (( codex_rc != POLICY_BLOCKED_RC )) && python3 -I -c \
-      'import sys; sys.path.insert(0, sys.argv[1]); from pathlib import Path; from specula.adapters.utils.transient import failed_log_has_transient_failure; raise SystemExit(0 if failed_log_has_transient_failure(Path(sys.argv[2])) else 1)' \
-      "$specula_src" "$log_file"; then
-      codex_rc="$TRANSIENT_FAILURE_RC"
-      transient_classified=true
-    fi
-  fi
 
   if (( codex_rc == TRANSIENT_FAILURE_RC )) && [[ "$transient_classified" != true ]]; then
     # Native 74 is EX_IOERR; only a classified provider diagnostic may expose
@@ -489,13 +490,14 @@ run_codex() {
     codex_rc=1
   fi
 
-  if [[ -n "$temporary_activity_log" ]]; then
-    rm -f "$temporary_activity_log" || true
+  local exact_session_id=""
+  if [[ -n "$session_id_file" ]]; then
+    IFS= read -r exact_session_id < "$session_id_file" || true
+    rm -f "$session_id_file" || true
   fi
 
   local usage_rc=0
-  write_usage_file "$log_file" "$marker_file" || usage_rc=$?
-  rm -f "$marker_file" || true
+  write_usage_file "$log_file" "$exact_session_id" || usage_rc=$?
   if (( codex_rc != 0 )); then
     return "$codex_rc"
   fi

--- a/src/specula/adapters/utils/event_stream.py
+++ b/src/specula/adapters/utils/event_stream.py
@@ -738,8 +738,10 @@ def stream_events(
         detected_session_id = _session_id(adapter_name, record)
         if detected_session_id is not None and detected_session_id not in seen_session_ids:
             seen_session_ids.add(detected_session_id)
-            if captured_session_id is None:
-                captured_session_id = detected_session_id
+            # A best-effort caller must never guess between distinct native
+            # sessions observed in one stream. Resume-state callbacks below
+            # additionally turn the mismatch into an integrity failure.
+            captured_session_id = detected_session_id if len(seen_session_ids) == 1 else None
             if session_capture is not None:
                 try:
                     session_capture(detected_session_id)
@@ -952,14 +954,15 @@ def stream_events(
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) not in {3, 7} or argv[0] not in _ADAPTER_NAMES:
+    if len(argv) not in {3, 4, 7} or argv[0] not in _ADAPTER_NAMES:
         print(
             "usage: python -m specula.adapters.utils.event_stream "
             "{claude|codex|copilot|opencode|pi} ACTIVITY_JSONL LOG_FILE "
-            "[RESUME_STATE CWD MODEL EFFORT]",
+            "[SESSION_ID_FILE | RESUME_STATE CWD MODEL EFFORT]",
             file=sys.stderr,
         )
         return 2
+    session_id_path = Path(argv[3]) if len(argv) == 4 else None
     session_capture: Callable[[str], None] | None = None
     if len(argv) == 7:
         adapter_name = _ADAPTER_NAMES[argv[0]]
@@ -985,6 +988,17 @@ def main(argv: list[str]) -> int:
     except OSError as exc:
         print(f"adapter event stream failed: {exc}", file=sys.stderr)
         return 1
+    if session_id_path is not None:
+        try:
+            session_id_path.write_text(
+                f"{status.session_id}\n" if status.session_id is not None else "",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            # This sidecar only supports best-effort usage collection. Losing it
+            # must not turn an otherwise successful native agent run into a
+            # failure; resume-state persistence remains fail-closed above.
+            print(f"adapter event stream warning: session ID file {session_id_path}: {exc}", file=sys.stderr)
     if not status.resume_ok:
         return RESUME_STATE_FAILURE_RC
     if status.rate_limit_error is not None:

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -3702,7 +3702,7 @@ class CodexAdapter(AdapterCase):
         )
         self.assertEqual(list(base.glob("specula-codex-session-*.id")), [])
 
-    def test_usage_fails_closed_when_ccusage_omits_descendant(self) -> None:
+    def test_usage_treats_ccusage_omitted_descendant_as_zero(self) -> None:
         base = self.sandbox()
         root_id = "019f0000-0000-7000-8000-000000000016"
         child_id = "019f0000-0000-7000-8000-000000000017"
@@ -3765,12 +3765,22 @@ class CodexAdapter(AdapterCase):
         )
 
         self.assertEqual(result["returncode"], 0, result["stderr"])
-        self.assertIn(f"usage unavailable for session {root_id}", result["stderr"])
+        self.assertNotIn("usage unavailable", result["stderr"])
         usage = json.loads((base / "out.usage.json").read_text())
         self.assertEqual(usage["session_id"], root_id)
         self.assertEqual(usage["session_file"], root_file.stem)
-        self.assertIsNone(usage["total_cost_usd"])
-        self.assertEqual(usage["usage"], {})
+        self.assertEqual(usage["total_cost_usd"], 1.25)
+        self.assertEqual(
+            usage["usage"],
+            {
+                "input_tokens": 10,
+                "cached_input_tokens": 4,
+                "cache_write_input_tokens": 0,
+                "output_tokens": 3,
+                "reasoning_output_tokens": 2,
+                "total_tokens": 17,
+            },
+        )
 
     def test_usage_never_guesses_without_one_thread_started_id(self) -> None:
         fixtures = {

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -3367,7 +3367,7 @@ class CodexAdapter(AdapterCase):
                                 "sessionId": session_id,
                                 "costUSD": 1.25,
                                 "inputTokens": 10,
-                                "cachedInputTokens": 4,
+                                "cacheReadTokens": 4,
                                 "outputTokens": 3,
                                 "reasoningOutputTokens": 2,
                                 "totalTokens": 13,
@@ -3405,7 +3405,165 @@ class CodexAdapter(AdapterCase):
         self.assertEqual(usage["session_id"], session_id)
         self.assertEqual(usage["session_file"], exact_file.stem)
         self.assertEqual(usage["total_cost_usd"], 1.25)
-        self.assertEqual(usage["usage"]["total_tokens"], 13)
+        self.assertEqual(
+            usage["usage"],
+            {
+                "input_tokens": 10,
+                "cached_input_tokens": 4,
+                "output_tokens": 3,
+                "reasoning_output_tokens": 2,
+                "total_tokens": 13,
+            },
+        )
+
+    def test_usage_failure_warns_without_failing_codex(self) -> None:
+        base = self.sandbox()
+        state = base / "resume.json"
+        session_id = "019f0000-0000-7000-8000-000000000008"
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "adapter": "codex",
+                    "session_id": session_id,
+                    "cwd": str(base),
+                    "model": "",
+                    "effort": "",
+                }
+            )
+        )
+        sessions = base / ".codex" / "sessions" / "2026" / "07" / "18"
+        sessions.mkdir(parents=True)
+        session_file = sessions / f"rollout-2026-07-18T00-00-00-{session_id}.jsonl"
+        session_file.write_text(json.dumps({"type": "session_meta", "payload": {"id": session_id}}) + "\n")
+        bindir = base / "bin"
+        bindir.mkdir()
+        npx = bindir / "npx"
+        npx.write_text("#!/usr/bin/env bash\nexit 1\n")
+        npx.chmod(npx.stat().st_mode | stat.S_IEXEC)
+        fixture = "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": session_id}),
+                json.dumps({"type": "turn.completed", "usage": {}}),
+            ]
+        )
+
+        result = self.run_adapter(
+            self.CMD,
+            [*self.base_flags(base), f"--resume-state={state}"],
+            fake_name="codex",
+            fixture_text=fixture,
+            env_extra={"TMPDIR": str(base)},
+            record_extra=True,
+            run_dir=base,
+        )
+
+        self.assertEqual(result["returncode"], 0, result["stderr"])
+        self.assertIn(f"usage unavailable for session {session_id}", result["stderr"])
+        usage = json.loads((base / "out.usage.json").read_text())
+        self.assertEqual(usage["session_id"], session_id)
+        self.assertEqual(usage["session_file"], session_file.stem)
+        self.assertIsNone(usage["total_cost_usd"])
+        self.assertEqual(usage["usage"], {})
+
+    def test_usage_selects_the_unique_top_level_session(self) -> None:
+        base = self.sandbox()
+        session_id = "019f0000-0000-7000-8000-000000000009"
+        child_id = "019f0000-0000-7000-8000-000000000010"
+        sessions = base / ".codex" / "sessions" / "2026" / "07" / "18"
+        sessions.mkdir(parents=True)
+        session_file = sessions / f"rollout-2026-07-18T00-00-00-{session_id}.jsonl"
+        child_file = sessions / f"rollout-2026-07-18T00-00-01-{child_id}.jsonl"
+        session_file.write_text(json.dumps({"type": "session_meta", "payload": {"id": session_id}}) + "\n")
+        child_file.write_text(
+            json.dumps(
+                {
+                    "type": "session_meta",
+                    "payload": {"id": child_id, "parent_thread_id": session_id},
+                }
+            )
+            + "\n"
+        )
+        future = time.time() + 60
+        for path in (session_file, child_file):
+            os.utime(path, (future, future))
+
+        bindir = base / "bin"
+        bindir.mkdir()
+        npx = bindir / "npx"
+        npx.write_text(
+            "#!/usr/bin/env bash\n"
+            + f"printf '%s\\n' \"$@\" > {json.dumps(str(base / 'npx-argv.txt'))}\n"
+            + "printf '%s\\n' "
+            + json.dumps(
+                json.dumps(
+                    {
+                        "sessions": [
+                            {
+                                "sessionFile": session_file.stem,
+                                "costUSD": 1.25,
+                                "inputTokens": 10,
+                                "cacheReadTokens": 4,
+                                "outputTokens": 3,
+                                "reasoningOutputTokens": 2,
+                                "totalTokens": 13,
+                            },
+                            {
+                                "sessionFile": child_file.stem,
+                                "costUSD": 50,
+                                "totalTokens": 700,
+                            },
+                        ]
+                    }
+                )
+            )
+            + "\n"
+        )
+        npx.chmod(npx.stat().st_mode | stat.S_IEXEC)
+
+        result = self.run_adapter(
+            self.CMD,
+            self.base_flags(base),
+            fake_name="codex",
+            fixture_text="codex ran\n",
+            record_extra=True,
+            run_dir=base,
+        )
+
+        self.assertEqual(result["returncode"], 0, result["stderr"])
+        usage = json.loads((base / "out.usage.json").read_text())
+        self.assertEqual(usage["session_id"], session_id)
+        self.assertEqual(usage["session_file"], session_file.stem)
+        self.assertEqual(usage["total_cost_usd"], 1.25)
+        self.assertEqual(usage["usage"]["cached_input_tokens"], 4)
+        self.assertEqual(
+            (base / "npx-argv.txt").read_text().splitlines(),
+            ["--yes", "ccusage@20.0.19", "codex", "session", "--json"],
+        )
+
+    def test_usage_does_not_guess_between_concurrent_top_level_sessions(self) -> None:
+        base = self.sandbox()
+        sessions = base / ".codex" / "sessions" / "2026" / "07" / "18"
+        sessions.mkdir(parents=True)
+        future = time.time() + 60
+        for index in range(2):
+            session_id = f"019f0000-0000-7000-8000-00000000001{index}"
+            path = sessions / f"rollout-2026-07-18T00-00-0{index}-{session_id}.jsonl"
+            path.write_text(json.dumps({"type": "session_meta", "payload": {"id": session_id}}) + "\n")
+            os.utime(path, (future, future))
+
+        result = self.invoke(
+            self.base_flags(base),
+            env_extra={"CODEX_HOME": str(base / ".codex")},
+        )
+
+        self.assertEqual(result["returncode"], 0, result["stderr"])
+        self.assertIn("multiple Codex sessions started during this invocation", result["stderr"])
+        usage = json.loads((base / "out.usage.json").read_text())
+        self.assertIsNone(usage["session_id"])
+        self.assertIsNone(usage["session_file"])
+        self.assertIsNone(usage["total_cost_usd"])
+        self.assertEqual(usage["usage"], {})
 
     def test_large_prompt_uses_stdin_with_activity_stream(self) -> None:
         base = self.sandbox()

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -3020,8 +3020,25 @@ class CodexAdapter(AdapterCase):
         # record_extra=True captures the fake codex's stdin: the adapter feeds the
         # prompt via stdin (not argv) to stay under MAX_ARG_STRLEN, so the prompt
         # must show up there, not in argv.
+        fixture = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "thread.started",
+                        "thread_id": "019f0000-0000-7000-8000-000000000000",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {"type": "agent_message", "text": "codex ran"},
+                    }
+                ),
+                json.dumps({"type": "turn.completed", "usage": {}}),
+            ]
+        )
         return self.run_adapter(
-            self.CMD, flags, fake_name="codex", fixture_text="codex ran\n", record_extra=True, env_extra=env_extra
+            self.CMD, flags, fake_name="codex", fixture_text=fixture, record_extra=True, env_extra=env_extra
         )
 
     def base_flags(self, base: Path) -> list[str]:
@@ -3042,6 +3059,7 @@ class CodexAdapter(AdapterCase):
                 str(base / "out.last-message.txt"),
                 "-c",
                 "tool_output_token_limit=10000",
+                "--json",
                 "-",
             ],
         )
@@ -3367,10 +3385,11 @@ class CodexAdapter(AdapterCase):
                                 "sessionId": session_id,
                                 "costUSD": 1.25,
                                 "inputTokens": 10,
+                                "cacheCreationTokens": 0,
                                 "cacheReadTokens": 4,
                                 "outputTokens": 3,
                                 "reasoningOutputTokens": 2,
-                                "totalTokens": 13,
+                                "totalTokens": 17,
                             },
                             {
                                 "sessionFile": other_file.stem,
@@ -3410,13 +3429,14 @@ class CodexAdapter(AdapterCase):
             {
                 "input_tokens": 10,
                 "cached_input_tokens": 4,
+                "cache_write_input_tokens": 0,
                 "output_tokens": 3,
                 "reasoning_output_tokens": 2,
-                "total_tokens": 13,
+                "total_tokens": 17,
             },
         )
 
-    def test_usage_failure_warns_without_failing_codex(self) -> None:
+    def test_resume_usage_failure_warns_without_failing_codex(self) -> None:
         base = self.sandbox()
         state = base / "resume.json"
         session_id = "019f0000-0000-7000-8000-000000000008"
@@ -3466,26 +3486,107 @@ class CodexAdapter(AdapterCase):
         self.assertIsNone(usage["total_cost_usd"])
         self.assertEqual(usage["usage"], {})
 
-    def test_usage_selects_the_unique_top_level_session(self) -> None:
+    def test_fresh_usage_failure_preserves_native_status(self) -> None:
+        session_id = "019f0000-0000-7000-8000-000000000015"
+        for native_rc, expected in (("0", 0), ("9", 9), ("75", 75)):
+            with self.subTest(native_rc=native_rc):
+                base = self.sandbox()
+                sessions = base / ".codex" / "sessions" / "2026" / "07" / "18"
+                sessions.mkdir(parents=True)
+                session_file = sessions / f"rollout-2026-07-18T00-00-00-{session_id}.jsonl"
+                session_file.write_text(json.dumps({"type": "session_meta", "payload": {"id": session_id}}) + "\n")
+                bindir = base / "bin"
+                bindir.mkdir()
+                npx = bindir / "npx"
+                npx.write_text("#!/usr/bin/env bash\nexit 1\n")
+                npx.chmod(npx.stat().st_mode | stat.S_IEXEC)
+                fixture = "\n".join(
+                    [
+                        json.dumps({"type": "thread.started", "thread_id": session_id}),
+                        json.dumps({"type": "turn.completed", "usage": {}}),
+                    ]
+                )
+
+                result = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="codex",
+                    fixture_text=fixture,
+                    env_extra={
+                        "ADAPTER_EXIT_CODE": native_rc,
+                        "CODEX_HOME": str(base / ".codex"),
+                        "TMPDIR": str(base),
+                    },
+                    record_extra=True,
+                    run_dir=base,
+                )
+
+                self.assertEqual(result["returncode"], expected, result["stderr"])
+                self.assertIn(f"usage unavailable for session {session_id}", result["stderr"])
+                usage = json.loads((base / "out.usage.json").read_text())
+                self.assertEqual(usage["session_id"], session_id)
+                self.assertEqual(usage["session_file"], session_file.stem)
+                self.assertIsNone(usage["total_cost_usd"])
+                self.assertEqual(usage["usage"], {})
+                self.assertEqual(list(base.glob("specula-codex-session-*.id")), [])
+
+    def test_usage_uses_exact_thread_and_aggregates_descendants(self) -> None:
         base = self.sandbox()
-        session_id = "019f0000-0000-7000-8000-000000000009"
+        root_id = "019f0000-0000-7000-8000-000000000009"
         child_id = "019f0000-0000-7000-8000-000000000010"
+        grandchild_id = "019f0000-0000-7000-8000-000000000011"
+        unrelated_id = "019f0000-0000-7000-8000-000000000012"
+        unrelated_child_id = "019f0000-0000-7000-8000-000000000013"
         sessions = base / ".codex" / "sessions" / "2026" / "07" / "18"
         sessions.mkdir(parents=True)
-        session_file = sessions / f"rollout-2026-07-18T00-00-00-{session_id}.jsonl"
+        root_file = sessions / f"rollout-2026-07-18T00-00-00-{root_id}.jsonl"
         child_file = sessions / f"rollout-2026-07-18T00-00-01-{child_id}.jsonl"
-        session_file.write_text(json.dumps({"type": "session_meta", "payload": {"id": session_id}}) + "\n")
+        grandchild_file = sessions / f"rollout-2026-07-18T00-00-02-{grandchild_id}.jsonl"
+        unrelated_file = sessions / f"rollout-2026-07-18T00-00-03-{unrelated_id}.jsonl"
+        unrelated_child_file = sessions / f"rollout-2026-07-18T00-00-04-{unrelated_child_id}.jsonl"
+        root_file.write_text(json.dumps({"type": "session_meta", "payload": {"id": root_id}}) + "\n")
         child_file.write_text(
             json.dumps(
                 {
                     "type": "session_meta",
-                    "payload": {"id": child_id, "parent_thread_id": session_id},
+                    "payload": {"id": child_id, "parent_thread_id": root_id},
+                }
+            )
+            + "\n"
+        )
+        grandchild_file.write_text(
+            json.dumps(
+                {
+                    "type": "session_meta",
+                    "payload": {
+                        "id": grandchild_id,
+                        "source": {
+                            "subagent": {
+                                "thread_spawn": {
+                                    "parent_thread_id": child_id,
+                                }
+                            }
+                        },
+                    },
+                }
+            )
+            + "\n"
+        )
+        unrelated_file.write_text(json.dumps({"type": "session_meta", "payload": {"id": unrelated_id}}) + "\n")
+        unrelated_child_file.write_text(
+            json.dumps(
+                {
+                    "type": "session_meta",
+                    "payload": {
+                        "id": unrelated_child_id,
+                        "parent_thread_id": unrelated_id,
+                    },
                 }
             )
             + "\n"
         )
         future = time.time() + 60
-        for path in (session_file, child_file):
+        for path in (root_file, child_file, grandchild_file, unrelated_file, unrelated_child_file):
             os.utime(path, (future, future))
 
         bindir = base / "bin"
@@ -3500,18 +3601,55 @@ class CodexAdapter(AdapterCase):
                     {
                         "sessions": [
                             {
-                                "sessionFile": session_file.stem,
-                                "costUSD": 1.25,
-                                "inputTokens": 10,
-                                "cacheReadTokens": 4,
+                                "sessionFile": unrelated_file.stem,
+                                "costUSD": 100,
+                                "inputTokens": 100,
+                                "cacheCreationTokens": 100,
+                                "cacheReadTokens": 100,
+                                "outputTokens": 100,
+                                "reasoningOutputTokens": 50,
+                                "totalTokens": 400,
+                            },
+                            {
+                                "sessionFile": grandchild_file.stem,
+                                "costUSD": 4.0,
+                                "inputTokens": 2,
+                                "cacheCreationTokens": 7,
+                                "cacheReadTokens": 1,
                                 "outputTokens": 3,
-                                "reasoningOutputTokens": 2,
+                                "reasoningOutputTokens": 1,
                                 "totalTokens": 13,
                             },
                             {
+                                "sessionFile": root_file.stem,
+                                "costUSD": 1.25,
+                                "inputTokens": 10,
+                                "cacheCreationTokens": 3,
+                                "cacheReadTokens": 4,
+                                "cachedInputTokens": 999,
+                                "outputTokens": 3,
+                                "reasoningOutputTokens": 2,
+                                "totalTokens": 20,
+                            },
+                            {
+                                "sessionFile": unrelated_child_file.stem,
+                                "costUSD": 200,
+                                "inputTokens": 200,
+                                "cacheCreationTokens": 200,
+                                "cacheReadTokens": 200,
+                                "outputTokens": 200,
+                                "reasoningOutputTokens": 100,
+                                "totalTokens": 800,
+                            },
+                            {
                                 "sessionFile": child_file.stem,
-                                "costUSD": 50,
-                                "totalTokens": 700,
+                                "costUSD": 2.5,
+                                "inputTokens": 20,
+                                "cacheCreationTokens": 5,
+                                "cacheReadTokens": 5,
+                                "outputTokens": 6,
+                                "reasoningOutputTokens": 4,
+                                "totalTokens": 36,
                             },
                         ]
                     }
@@ -3525,45 +3663,163 @@ class CodexAdapter(AdapterCase):
             self.CMD,
             self.base_flags(base),
             fake_name="codex",
-            fixture_text="codex ran\n",
+            fixture_text="\n".join(
+                [
+                    json.dumps({"type": "thread.started", "thread_id": root_id}),
+                    json.dumps(
+                        {
+                            "type": "item.completed",
+                            "item": {"type": "agent_message", "text": "done"},
+                        }
+                    ),
+                    json.dumps({"type": "turn.completed", "usage": {}}),
+                ]
+            ),
+            env_extra={"CODEX_HOME": str(base / ".codex"), "TMPDIR": str(base)},
             record_extra=True,
             run_dir=base,
         )
 
         self.assertEqual(result["returncode"], 0, result["stderr"])
         usage = json.loads((base / "out.usage.json").read_text())
-        self.assertEqual(usage["session_id"], session_id)
-        self.assertEqual(usage["session_file"], session_file.stem)
-        self.assertEqual(usage["total_cost_usd"], 1.25)
-        self.assertEqual(usage["usage"]["cached_input_tokens"], 4)
+        self.assertEqual(usage["session_id"], root_id)
+        self.assertEqual(usage["session_file"], root_file.stem)
+        self.assertEqual(usage["total_cost_usd"], 7.75)
+        self.assertEqual(
+            usage["usage"],
+            {
+                "input_tokens": 32,
+                "cached_input_tokens": 10,
+                "cache_write_input_tokens": 15,
+                "output_tokens": 12,
+                "reasoning_output_tokens": 7,
+                "total_tokens": 69,
+            },
+        )
         self.assertEqual(
             (base / "npx-argv.txt").read_text().splitlines(),
             ["--yes", "ccusage@20.0.19", "codex", "session", "--json"],
         )
+        self.assertEqual(list(base.glob("specula-codex-session-*.id")), [])
 
-    def test_usage_does_not_guess_between_concurrent_top_level_sessions(self) -> None:
+    def test_usage_fails_closed_when_ccusage_omits_descendant(self) -> None:
         base = self.sandbox()
+        root_id = "019f0000-0000-7000-8000-000000000016"
+        child_id = "019f0000-0000-7000-8000-000000000017"
         sessions = base / ".codex" / "sessions" / "2026" / "07" / "18"
         sessions.mkdir(parents=True)
-        future = time.time() + 60
-        for index in range(2):
-            session_id = f"019f0000-0000-7000-8000-00000000001{index}"
-            path = sessions / f"rollout-2026-07-18T00-00-0{index}-{session_id}.jsonl"
-            path.write_text(json.dumps({"type": "session_meta", "payload": {"id": session_id}}) + "\n")
-            os.utime(path, (future, future))
+        root_file = sessions / f"rollout-2026-07-18T00-00-00-{root_id}.jsonl"
+        child_file = sessions / f"rollout-2026-07-18T00-00-01-{child_id}.jsonl"
+        root_file.write_text(json.dumps({"type": "session_meta", "payload": {"id": root_id}}) + "\n")
+        child_file.write_text(
+            json.dumps(
+                {
+                    "type": "session_meta",
+                    "payload": {"id": child_id, "parent_thread_id": root_id},
+                }
+            )
+            + "\n"
+        )
 
-        result = self.invoke(
+        bindir = base / "bin"
+        bindir.mkdir()
+        npx = bindir / "npx"
+        npx.write_text(
+            "#!/usr/bin/env bash\n"
+            + "printf '%s\\n' "
+            + json.dumps(
+                json.dumps(
+                    {
+                        "sessions": [
+                            {
+                                "sessionFile": root_file.stem,
+                                "costUSD": 1.25,
+                                "inputTokens": 10,
+                                "cacheCreationTokens": 0,
+                                "cacheReadTokens": 4,
+                                "outputTokens": 3,
+                                "reasoningOutputTokens": 2,
+                                "totalTokens": 17,
+                            }
+                        ]
+                    }
+                )
+            )
+            + "\n"
+        )
+        npx.chmod(npx.stat().st_mode | stat.S_IEXEC)
+
+        result = self.run_adapter(
+            self.CMD,
             self.base_flags(base),
-            env_extra={"CODEX_HOME": str(base / ".codex")},
+            fake_name="codex",
+            fixture_text="\n".join(
+                [
+                    json.dumps({"type": "thread.started", "thread_id": root_id}),
+                    json.dumps({"type": "turn.completed", "usage": {}}),
+                ]
+            ),
+            env_extra={"CODEX_HOME": str(base / ".codex"), "TMPDIR": str(base)},
+            record_extra=True,
+            run_dir=base,
         )
 
         self.assertEqual(result["returncode"], 0, result["stderr"])
-        self.assertIn("multiple Codex sessions started during this invocation", result["stderr"])
+        self.assertIn(f"usage unavailable for session {root_id}", result["stderr"])
         usage = json.loads((base / "out.usage.json").read_text())
-        self.assertIsNone(usage["session_id"])
-        self.assertIsNone(usage["session_file"])
+        self.assertEqual(usage["session_id"], root_id)
+        self.assertEqual(usage["session_file"], root_file.stem)
         self.assertIsNone(usage["total_cost_usd"])
         self.assertEqual(usage["usage"], {})
+
+    def test_usage_never_guesses_without_one_thread_started_id(self) -> None:
+        fixtures = {
+            "missing": json.dumps({"type": "turn.completed", "usage": {}}),
+            "ambiguous": "\n".join(
+                [
+                    json.dumps({"type": "thread.started", "thread_id": "thread-one"}),
+                    json.dumps({"type": "thread.started", "thread_id": "thread-two"}),
+                    json.dumps({"type": "turn.completed", "usage": {}}),
+                ]
+            ),
+        }
+        for name, fixture in fixtures.items():
+            with self.subTest(name):
+                base = self.sandbox()
+                sessions = base / ".codex" / "sessions" / "2026" / "07" / "18"
+                sessions.mkdir(parents=True)
+                stale_id = "019f0000-0000-7000-8000-000000000014"
+                stale = sessions / f"rollout-2026-07-18T00-00-00-{stale_id}.jsonl"
+                stale.write_text(json.dumps({"type": "session_meta", "payload": {"id": stale_id}}) + "\n")
+                future = time.time() + 60
+                os.utime(stale, (future, future))
+
+                bindir = base / "bin"
+                bindir.mkdir()
+                sentinel = base / "npx-ran"
+                npx = bindir / "npx"
+                npx.write_text("#!/usr/bin/env bash\n" + f"printf x > {json.dumps(str(sentinel))}\n" + "exit 1\n")
+                npx.chmod(npx.stat().st_mode | stat.S_IEXEC)
+
+                result = self.run_adapter(
+                    self.CMD,
+                    self.base_flags(base),
+                    fake_name="codex",
+                    fixture_text=fixture,
+                    env_extra={"CODEX_HOME": str(base / ".codex"), "TMPDIR": str(base)},
+                    record_extra=True,
+                    run_dir=base,
+                )
+
+                self.assertEqual(result["returncode"], 0, result["stderr"])
+                self.assertIn("exact thread.started ID was not captured", result["stderr"])
+                usage = json.loads((base / "out.usage.json").read_text())
+                self.assertIsNone(usage["session_id"])
+                self.assertIsNone(usage["session_file"])
+                self.assertIsNone(usage["total_cost_usd"])
+                self.assertEqual(usage["usage"], {})
+                self.assertFalse(sentinel.exists())
+                self.assertEqual(list(base.glob("specula-codex-session-*.id")), [])
 
     def test_large_prompt_uses_stdin_with_activity_stream(self) -> None:
         base = self.sandbox()
@@ -3952,6 +4208,7 @@ class CodexAdapter(AdapterCase):
                 "gpt-5.5",
                 "-c",
                 "model_reasoning_effort=high",
+                "--json",
                 "-",
             ],
         )
@@ -3996,6 +4253,7 @@ class CodexAdapter(AdapterCase):
                 str(base / "out.last-message.txt"),
                 "-c",
                 "tool_output_token_limit=10000",
+                "--json",
                 "-",
             ],
         )


### PR DESCRIPTION
## Summary
- switch the Codex usage collector to pinned `ccusage@20.0.19` and parse its current cache-token field
- keep usage tied to the exact root Codex session and refuse ambiguous non-resume matches
- surface usage collection failures without failing an otherwise successful agent run
