### PR TITLE
Resume unfinished agent conversations

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -262,6 +262,8 @@ To add guidance for the resumed agent, update the target's `.prompt-extra.md` be
 
 After the resumed phase finishes, later phases follow the skip options on the current command.
 
+If the previous phase or agent is still running, Specula refuses the attach. Wait for it to finish or stop it before retrying.
+
 Only unfinished conversations can be resumed. If resume state is unavailable, Specula stops instead of silently starting a new conversation. To keep the run's files but start with a fresh agent context, add `--fresh-context` and use skip flags to choose where to restart:
 
 ```bash

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -246,15 +246,13 @@ TLC workers remain unbounded by default: `-w auto` uses every CPU visible to eac
 Use a stable ID when a run may need to be resumed:
 
 ```bash
-specula run <name> \
+specula run \
   --run-id=my-run \
   --artifact=/path/to/source \
   "name|owner/repository|language|reference"
 ```
 
-If an agent call is interrupted, attach to the same run and use the existing
-skip flags to reach that phase. This example continues an interrupted
-validation call:
+If an agent call is interrupted, attach to the same run and use the skip flags to reach that phase. Specula restores omitted run settings and resumes the unfinished agent conversation. This example continues validation:
 
 ```bash
 specula run --run-id=my-run \
@@ -263,31 +261,13 @@ specula run --run-id=my-run \
   --skip-harness
 ```
 
-For Claude Code, Codex, Copilot CLI, OpenCode, and Pi, Specula resumes the exact
-unfinished native session by default. It restores the run's target, artifact,
-agent routing, model, effort, Claude profile, and retry settings when those
-options are omitted. An incompatible explicit override fails before launching
-an agent. The latest target `.prompt-extra.md`, if present, is appended once to
-the manual continuation so priorities can be clarified without replaying the
-original prompt.
+To add guidance for the resumed agent, update the target's `.prompt-extra.md` before running the command.
 
-Only unfinished calls are resumable; an accepted call is never reopened. If
-the run has no unfinished conversation, its checkpoint is missing or corrupt,
-or the native session cannot be restored safely, the attach fails closed. Use
-`--fresh-context` to keep the existing workspace while abandoning old agent
-contexts, including when attaching to a run created before manual checkpoints
-were supported. Recorded settings are still restored when omitted, while
-explicit settings establish the new context:
+Only unfinished conversations can be resumed. If resume state is unavailable, Specula stops instead of silently starting a new conversation. To keep the run's files but start with a fresh agent context, add `--fresh-context`:
 
 ```bash
 specula run --run-id=my-run --fresh-context --skip-analysis --skip-specgen --skip-harness
 ```
-
-Phase 4 restores interrupted finding conversations one at a time, then returns
-to its configured per-finding parallelism. Exact resume preserves the native
-conversation and retained files, but cannot restore an in-flight CLI process or
-child process. The run's TLC memory and worker limits remain fixed by
-`tlc-resources.json`; `run.json` remains the original audit record.
 
 ## Individual Steps
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -252,19 +252,42 @@ specula run <name> \
   "name|owner/repository|language|reference"
 ```
 
-Attach to the same run and skip completed steps. This resumes at validation:
+If an agent call is interrupted, attach to the same run and use the existing
+skip flags to reach that phase. This example continues an interrupted
+validation call:
 
 ```bash
-specula run <name> \
-  --run-id=my-run \
+specula run --run-id=my-run \
   --skip-analysis \
   --skip-specgen \
-  --skip-harness \
-  --artifact=/path/to/source \
-  "name|owner/repository|language|reference"
+  --skip-harness
 ```
 
-Specula reuses `runs/<run-id>/<name>/.specula-output/`. Pass the target and artifact again when resuming, together with either `--agent-config` or the original agent, model, and effort options. A `--keep-original` run automatically resumes against its existing private source even when that flag and the original artifact are omitted. The run's TLC memory and worker limits are restored from `tlc-resources.json`; `run.json` remains an audit record, not arguments for the new invocation.
+For Claude Code, Codex, Copilot CLI, OpenCode, and Pi, Specula resumes the exact
+unfinished native session by default. It restores the run's target, artifact,
+agent routing, model, effort, Claude profile, and retry settings when those
+options are omitted. An incompatible explicit override fails before launching
+an agent. The latest target `.prompt-extra.md`, if present, is appended once to
+the manual continuation so priorities can be clarified without replaying the
+original prompt.
+
+Only unfinished calls are resumable; an accepted call is never reopened. If
+the run has no unfinished conversation, its checkpoint is missing or corrupt,
+or the native session cannot be restored safely, the attach fails closed. Use
+`--fresh-context` to keep the existing workspace while abandoning old agent
+contexts, including when attaching to a run created before manual checkpoints
+were supported. Recorded settings are still restored when omitted, while
+explicit settings establish the new context:
+
+```bash
+specula run --run-id=my-run --fresh-context --skip-analysis --skip-specgen --skip-harness
+```
+
+Phase 4 restores interrupted finding conversations one at a time, then returns
+to its configured per-finding parallelism. Exact resume preserves the native
+conversation and retained files, but cannot restore an in-flight CLI process or
+child process. The run's TLC memory and worker limits remain fixed by
+`tlc-resources.json`; `run.json` remains the original audit record.
 
 ## Individual Steps
 
@@ -336,7 +359,8 @@ specula run [options] "name|owner/repository|language|reference"
 | `--max-repair-rounds=N` | Set the global repair-loop round cap (default `10`; `0` means unlimited) |
 | `--skip-analysis`, `--skip-specgen`, `--skip-harness` | Reuse early-phase outputs |
 | `--skip-validate`, `--skip-confirmation`, `--skip-classification` | Reuse later-phase outputs |
-| `--run-id=ID` | Create or attach to an isolated run |
+| `--run-id=ID` | Create or attach to an isolated run; attach resumes unfinished agent conversations |
+| `--fresh-context` | With `--run-id`, abandon unfinished agent contexts and continue from retained files |
 | `--no-isolate` | Use the legacy output layout described above |
 
 `--dry-run` still creates the isolated run metadata, log, and summary files. The confirmation repair loop is enabled by default. `--max-repair-rounds=N` caps rounds across the whole loop, not attempts per request; when the cap is reached, remaining open requests are deferred. For the individual `specula confirm` command, the corresponding debate flags are `--debate` and `--rounds=N` (range `1` through `5`).

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -252,18 +252,17 @@ specula run \
   "name|owner/repository|language|reference"
 ```
 
-If an agent call is interrupted, attach to the same run and use the skip flags to reach that phase. Specula restores omitted run settings and resumes the unfinished agent conversation. This example continues validation:
+If an agent call is interrupted, attach to the same run. Specula restores omitted run settings, returns to the interrupted phase, and resumes the unfinished agent conversation:
 
 ```bash
-specula run --run-id=my-run \
-  --skip-analysis \
-  --skip-specgen \
-  --skip-harness
+specula run --run-id=my-run
 ```
 
 To add guidance for the resumed agent, update the target's `.prompt-extra.md` before running the command.
 
-Only unfinished conversations can be resumed. If resume state is unavailable, Specula stops instead of silently starting a new conversation. To keep the run's files but start with a fresh agent context, add `--fresh-context`:
+After the resumed phase finishes, later phases follow the skip options on the current command.
+
+Only unfinished conversations can be resumed. If resume state is unavailable, Specula stops instead of silently starting a new conversation. To keep the run's files but start with a fresh agent context, add `--fresh-context` and use skip flags to choose where to restart:
 
 ```bash
 specula run --run-id=my-run --fresh-context --skip-analysis --skip-specgen --skip-harness

--- a/src/specula/adapters/claude_code.py
+++ b/src/specula/adapters/claude_code.py
@@ -35,6 +35,7 @@ if __package__:
     from .utils.event_stream import stream_events
     from .utils.policy import POLICY_BLOCKED_RC, final_diagnostic_has_policy_block, looks_policy_blocked
     from .utils.resume import ResumeStateError, capture_session_id, read_session_id
+    from .utils.run_lock import inherited_run_lock_fds
     from .utils.transient import TRANSIENT_FAILURE_RC, final_diagnostic_has_transient_failure, looks_transient
 else:
     from utils.event_stream import stream_events  # type: ignore[import-not-found, no-redef]
@@ -48,6 +49,7 @@ else:
         capture_session_id,
         read_session_id,
     )
+    from utils.run_lock import inherited_run_lock_fds  # type: ignore[import-not-found, no-redef]
     from utils.transient import (  # type: ignore[import-not-found, no-redef]
         TRANSIENT_FAILURE_RC,
         final_diagnostic_has_transient_failure,
@@ -517,10 +519,22 @@ def main(argv: list[str]) -> int:
         try:
             if streaming:
                 with open(prompt_input) as pin:
-                    proc = subprocess.Popen(cmd, stdin=pin, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                    proc = subprocess.Popen(
+                        cmd,
+                        stdin=pin,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        pass_fds=inherited_run_lock_fds(),
+                    )
             else:
                 with open(prompt_input) as pin, open(capture_path, "w") as out:
-                    cli_rc = subprocess.run(cmd, stdin=pin, stdout=out, stderr=subprocess.STDOUT).returncode
+                    cli_rc = subprocess.run(
+                        cmd,
+                        stdin=pin,
+                        stdout=out,
+                        stderr=subprocess.STDOUT,
+                        pass_fds=inherited_run_lock_fds(),
+                    ).returncode
         except OSError as e:
             error = f"claude-code adapter: failed to run claude: {e}\n"
             for path in (capture_path, log_file) if streaming else (capture_path,):

--- a/src/specula/adapters/utils/json_cli.py
+++ b/src/specula/adapters/utils/json_cli.py
@@ -19,6 +19,7 @@ from typing import Any
 from .event_stream import StreamStatus, stream_events
 from .policy import POLICY_BLOCKED_RC
 from .resume import capture_session_id
+from .run_lock import inherited_run_lock_fds
 from .text import summary
 from .transient import TRANSIENT_FAILURE_RC
 from .usage import augment_opencode_usage, augment_pi_usage
@@ -270,6 +271,7 @@ def run_json_cli(
                         stdout=subprocess.PIPE,
                         stderr=subprocess.STDOUT,
                         env=effective_env,
+                        pass_fds=inherited_run_lock_fds(effective_env),
                     )
                 finally:
                     prompt_stream.close()

--- a/src/specula/adapters/utils/run_lock.py
+++ b/src/specula/adapters/utils/run_lock.py
@@ -1,0 +1,29 @@
+"""Run-lock lease propagation for native provider processes."""
+
+from __future__ import annotations
+
+import os
+import stat
+from collections.abc import Mapping
+
+RUN_LOCK_FD_ENV = "SPECULA_RUN_LOCK_FD"
+
+
+class RunLockError(OSError):
+    """The inherited run-lock lease is missing or unsafe to propagate."""
+
+
+def inherited_run_lock_fds(env: Mapping[str, str] | None = None) -> tuple[int, ...]:
+    """Return the validated run-lock lease inherited from the dispatcher."""
+    source = os.environ if env is None else env
+    raw = source.get(RUN_LOCK_FD_ENV)
+    if raw is None:
+        return ()
+    try:
+        fd = int(raw)
+        info = os.fstat(fd)
+    except (OSError, ValueError) as exc:
+        raise RunLockError("inherited Specula run lock is unavailable") from exc
+    if fd < 3 or not stat.S_ISREG(info.st_mode):
+        raise RunLockError("inherited Specula run lock is invalid")
+    return (fd,)

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -41,7 +41,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from specula import quota
+from specula import quota, resumelib
 from specula.phaselib import (
     DEFAULT_POLICY_RETRIES,
     DEFAULT_TRANSIENT_RESUMES,
@@ -174,6 +174,8 @@ class _CompletedTurn:
     cwd: str | None
     verdict: str | None
     text: str
+    result_path: Path | None = None
+    result_digest: str = ""
 
 
 @dataclass
@@ -187,11 +189,13 @@ class _RepairTurn:
 
 @dataclass
 class _FindingLease:
-    """In-process state retained only across an armed reactive rc75 replay."""
+    """Per-finding state retained until a terminal verdict is durably saved."""
 
     finding_dir: Path
     repo_for_agent: str
     cleanup: Callable[[], None]
+    source_repo: str = ""
+    state_path: Path | None = None
     initialized: bool = False
     repair_retry_used: bool = False
     completed_turns: dict[tuple[int, str], _CompletedTurn] = field(default_factory=dict)
@@ -199,6 +203,294 @@ class _FindingLease:
     repair_turns: dict[tuple[int, str], _RepairTurn] = field(default_factory=dict)
     _run_lock: Any = field(default_factory=threading.RLock, repr=False, compare=False)
     _closed: bool = False
+
+
+_LEASE_VERSION = 1
+
+
+def _lease_file(f: Finding) -> Path:
+    return f.fdir / ".resume-lease.json"
+
+
+def _lease_atomic_write(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.{secrets.token_hex(4)}")
+    try:
+        tmp.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+        tmp.replace(path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            tmp.unlink()
+
+
+def _turn_result_file(cfg: ConfirmConfig, f: Finding, turn_no: int, role: str, text: str) -> Path:
+    log = f.fdir / f"turn{turn_no:02d}_{role}.log"
+    result = log.with_name(f"{log.stem}.last-message.txt") if cfg.adapter.stem == "codex" else log
+    if result.is_file() and result.read_text(errors="replace") == text:
+        return result
+    # Unit embedders may replace the adapter primitive without creating its
+    # normal result file. Keep one uniform durable result in that case.
+    result = f.fdir / f"turn{turn_no:02d}_{role}.accepted.txt"
+    result.write_text(text)
+    return result
+
+
+def _persist_lease(cfg: ConfirmConfig, f: Finding, lease: _FindingLease) -> None:
+    if not resumelib.enabled():
+        return
+    completed: list[dict[str, Any]] = []
+    for (turn_no, role), item in sorted(lease.completed_turns.items()):
+        result_path = item.result_path or _turn_result_file(cfg, f, turn_no, role, item.text)
+        try:
+            relative = result_path.absolute().relative_to(f.fdir.absolute())
+        except ValueError as exc:
+            raise ConfirmationFailed(f"{f.id}: completed turn result escapes its finding directory") from exc
+        body = result_path.read_bytes()
+        digest = hashlib.sha256(body).hexdigest()
+        completed.append(
+            {
+                "turn": turn_no,
+                "role": role,
+                "prompt_digest": item.prompt_digest,
+                "cwd": item.cwd,
+                "verdict": item.verdict,
+                "result": relative.as_posix(),
+                "result_digest": digest,
+            }
+        )
+    repair_turns = [
+        {
+            "previous_turn": previous_turn,
+            "previous_role": previous_role,
+            "turn": item.turn_no,
+            "prompt": item.prompt,
+            "original": item.original,
+            "verdict": item.verdict,
+            "disabled": item.disabled,
+        }
+        for (previous_turn, previous_role), item in sorted(lease.repair_turns.items())
+    ]
+    path = _lease_file(f)
+    value = {
+        "version": _LEASE_VERSION,
+        "finding_id": f.id,
+        "fingerprint": _verdict_fingerprint(cfg, f),
+        "source_repo": lease.source_repo or (str(Path(cfg.repo_dir).absolute()) if cfg.repo_dir else ""),
+        "repo_for_agent": lease.repo_for_agent,
+        "worktree": bool(cfg.worktree and cfg.repo_dir),
+        "initialized": lease.initialized,
+        "repair_retry_used": lease.repair_retry_used,
+        "completed_turns": completed,
+        "turn_cwds": [
+            {"turn": turn, "role": role, "path": str(path.absolute())}
+            for (turn, role), path in sorted(lease.turn_cwds.items())
+        ],
+        "repair_turns": repair_turns,
+    }
+    _lease_atomic_write(path, value)
+    lease.state_path = path
+
+
+def _safe_retained_path(path: Path, root: Path, label: str) -> Path:
+    if path.is_symlink():
+        raise ConfirmationFailed(f"unsafe retained {label} symlink: {path}")
+    try:
+        path.resolve().relative_to(root.resolve())
+    except (OSError, ValueError) as exc:
+        raise ConfirmationFailed(f"retained {label} escapes {root}: {path}") from exc
+    return path
+
+
+def _load_lease(cfg: ConfirmConfig, f: Finding) -> _FindingLease:
+    path = _lease_file(f)
+    try:
+        if path.is_symlink() or not path.is_file():
+            raise ConfirmationFailed(f"{f.id}: missing safe Phase 4 resume checkpoint")
+        value = json.loads(path.read_text())
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ConfirmationFailed(f"{f.id}: cannot read Phase 4 resume checkpoint: {exc}") from exc
+    if not isinstance(value, dict) or value.get("version") != _LEASE_VERSION or value.get("finding_id") != f.id:
+        raise ConfirmationFailed(f"{f.id}: invalid Phase 4 resume checkpoint")
+    fingerprint = value.get("fingerprint")
+    if not isinstance(fingerprint, str) or fingerprint != _verdict_fingerprint(cfg, f):
+        raise ConfirmationFailed(f"{f.id}: Phase 4 inputs changed; pass --fresh-context to start over")
+
+    source_repo = value.get("source_repo")
+    repo_for_agent = value.get("repo_for_agent")
+    retained_worktree = value.get("worktree")
+    initialized = value.get("initialized")
+    repair_retry_used = value.get("repair_retry_used")
+    if (
+        not isinstance(source_repo, str)
+        or not isinstance(repo_for_agent, str)
+        or not isinstance(retained_worktree, bool)
+        or not isinstance(initialized, bool)
+        or not isinstance(repair_retry_used, bool)
+    ):
+        raise ConfirmationFailed(f"{f.id}: invalid Phase 4 resume checkpoint fields")
+    current_source = str(Path(cfg.repo_dir).absolute()) if cfg.repo_dir else ""
+    if source_repo != current_source:
+        raise ConfirmationFailed(f"{f.id}: retained source repository no longer matches")
+    if retained_worktree != bool(cfg.worktree and cfg.repo_dir):
+        raise ConfirmationFailed(f"{f.id}: retained worktree mode no longer matches")
+    if retained_worktree:
+        repo_path = _safe_retained_path(Path(repo_for_agent), f.fdir.absolute(), "worktree")
+        probe = subprocess.run(
+            ["git", "-C", str(repo_path), "rev-parse", "--is-inside-work-tree"],
+            env=_dispatcher_git_env(repo_path),
+            capture_output=True,
+            text=True,
+        )
+        if probe.returncode != 0 or probe.stdout.strip() != "true":
+            raise ConfirmationFailed(f"{f.id}: retained worktree is unavailable")
+        cleanup = _retained_worktree_cleanup(Path(source_repo), repo_path, f.id)
+    else:
+        if repo_for_agent != current_source:
+            raise ConfirmationFailed(f"{f.id}: retained repository no longer matches")
+
+        def cleanup() -> None:
+            return None
+
+    lease = _FindingLease(
+        f.fdir.absolute(),
+        repo_for_agent,
+        cleanup,
+        source_repo=source_repo,
+        state_path=path,
+    )
+    lease.initialized = initialized
+    lease.repair_retry_used = repair_retry_used
+    raw_cwds = value.get("turn_cwds", [])
+    raw_completed = value.get("completed_turns", [])
+    raw_repairs = value.get("repair_turns", [])
+    if not isinstance(raw_cwds, list) or not isinstance(raw_completed, list) or not isinstance(raw_repairs, list):
+        raise ConfirmationFailed(f"{f.id}: invalid Phase 4 resume checkpoint lists")
+    for item in raw_cwds:
+        if not isinstance(item, dict):
+            raise ConfirmationFailed(f"{f.id}: invalid retained turn cwd")
+        turn = item.get("turn")
+        role = item.get("role")
+        raw_path = item.get("path")
+        if (
+            not isinstance(turn, int)
+            or isinstance(turn, bool)
+            or turn < 1
+            or role not in {"A", "B", "A-repair"}
+            or not isinstance(raw_path, str)
+            or not raw_path
+        ):
+            raise ConfirmationFailed(f"{f.id}: invalid retained turn cwd")
+        if (turn, role) in lease.turn_cwds:
+            raise ConfirmationFailed(f"{f.id}: duplicate retained turn cwd")
+        cwd = _safe_retained_path(Path(raw_path), f.fdir / ".agent-cwd", "turn cwd")
+        if not cwd.is_dir():
+            raise ConfirmationFailed(f"{f.id}: retained turn cwd is unavailable: {cwd}")
+        lease.turn_cwds[(turn, role)] = cwd
+    for item in raw_completed:
+        if not isinstance(item, dict):
+            raise ConfirmationFailed(f"{f.id}: invalid completed turn checkpoint")
+        turn = item.get("turn")
+        role = item.get("role")
+        result = item.get("result")
+        digest = item.get("result_digest")
+        prompt_digest = item.get("prompt_digest")
+        raw_cwd = item.get("cwd")
+        verdict = item.get("verdict")
+        if (
+            not isinstance(turn, int)
+            or isinstance(turn, bool)
+            or turn < 1
+            or role not in {"A", "B", "A-repair"}
+            or not isinstance(result, str)
+            or not result
+            or not isinstance(digest, str)
+            or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+            or not isinstance(prompt_digest, str)
+            or re.fullmatch(r"[0-9a-f]{64}", prompt_digest) is None
+            or not isinstance(raw_cwd, str)
+            or verdict not in CANON
+        ):
+            raise ConfirmationFailed(f"{f.id}: invalid completed turn checkpoint")
+        key = (turn, role)
+        if (
+            key in lease.completed_turns
+            or key not in lease.turn_cwds
+            or str(lease.turn_cwds[key].absolute()) != raw_cwd
+        ):
+            raise ConfirmationFailed(f"{f.id}: completed turn checkpoint does not match its retained cwd")
+        result_path = _safe_retained_path(f.fdir / result, f.fdir, "turn result")
+        try:
+            body = result_path.read_bytes()
+        except OSError as exc:
+            raise ConfirmationFailed(f"{f.id}: retained turn result is unavailable: {result_path}") from exc
+        if hashlib.sha256(body).hexdigest() != digest:
+            raise ConfirmationFailed(f"{f.id}: retained turn result changed: {result_path}")
+        text = body.decode(errors="replace")
+        lease.completed_turns[(turn, role)] = _CompletedTurn(
+            prompt_digest,
+            raw_cwd,
+            verdict,
+            text,
+            result_path,
+            digest,
+        )
+    for item in raw_repairs:
+        if not isinstance(item, dict):
+            raise ConfirmationFailed(f"{f.id}: invalid repair-turn checkpoint")
+        previous_turn = item.get("previous_turn")
+        previous_role = item.get("previous_role")
+        turn = item.get("turn")
+        prompt = item.get("prompt")
+        original = item.get("original")
+        verdict = item.get("verdict")
+        disabled = item.get("disabled")
+        if (
+            not isinstance(previous_turn, int)
+            or isinstance(previous_turn, bool)
+            or previous_turn < 1
+            or previous_role not in {"A", "B"}
+            or not isinstance(turn, int)
+            or isinstance(turn, bool)
+            or turn < 1
+            or not isinstance(prompt, str)
+            or not prompt
+            or (original is not None and not isinstance(original, str))
+            or (verdict is not None and verdict not in CANON)
+            or not isinstance(disabled, bool)
+        ):
+            raise ConfirmationFailed(f"{f.id}: invalid repair-turn checkpoint")
+        repair_key = (previous_turn, previous_role)
+        if repair_key in lease.repair_turns:
+            raise ConfirmationFailed(f"{f.id}: duplicate repair-turn checkpoint")
+        lease.repair_turns[repair_key] = _RepairTurn(
+            turn,
+            prompt,
+            original,
+            verdict,
+            disabled,
+        )
+    return lease
+
+
+def _remove_lease_state(lease: _FindingLease) -> None:
+    path = lease.state_path
+    if path is not None:
+        with contextlib.suppress(FileNotFoundError):
+            path.unlink()
+
+
+def _discard_persisted_lease(cfg: ConfirmConfig, f: Finding) -> None:
+    path = _lease_file(f)
+    if not path.exists() and not path.is_symlink():
+        return
+    try:
+        lease = _load_lease(cfg, f)
+        lease.cleanup()
+    except Exception as exc:
+        _log(f"  WARNING: {f.id}: could not clean stale resume lease ({exc})")
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            path.unlink()
 
 
 @dataclass
@@ -212,6 +504,7 @@ class ConfirmConfig:
     worktree: bool = True
     dry_run: bool = False
     prompt_extra: str = ""  # target's .prompt-extra.md, appended to every agent prompt
+    resume_prompt_extra: str = ""  # latest guidance, manual continuation only
     # New controls stay after the original fields to preserve positional callers.
     # None = no Specula override; "" = explicit reset to the CLI default.
     model: str | None = None
@@ -282,8 +575,18 @@ class ConfirmConfig:
                     break
                 pending.wait()
 
-            repo_for_agent, cleanup = setup_repo(self, f)
-            candidate = _FindingLease(finding_dir, repo_for_agent, cleanup)
+            resume_prefix = ("confirm", self.name, "finding", f.id)
+            if resumelib.has_prefix(resume_prefix) and not resumelib.fresh_mode():
+                candidate = _load_lease(self, f)
+            else:
+                repo_for_agent, cleanup = setup_repo(self, f)
+                candidate = _FindingLease(
+                    finding_dir,
+                    repo_for_agent,
+                    cleanup,
+                    source_repo=str(Path(self.repo_dir).absolute()) if self.repo_dir else "",
+                    state_path=_lease_file(f),
+                )
             with self._finding_leases_lock:
                 self._finding_leases[f.id] = candidate
             return candidate
@@ -294,7 +597,7 @@ class ConfirmConfig:
                 if pending is not None:
                     pending.set()
 
-    def release_finding_lease(self, finding_id: str) -> None:
+    def release_finding_lease(self, finding_id: str, *, force: bool = False) -> None:
         """Idempotently release one terminal finding's runtime-only lease."""
         with self._finding_leases_lock:
             lease = self._finding_leases.pop(finding_id, None)
@@ -304,6 +607,8 @@ class ConfirmConfig:
             if lease._closed:
                 return
             lease._closed = True
+            if not force and resumelib.has_prefix(("confirm", self.name, "finding", finding_id)):
+                return
             lease.completed_turns.clear()
             lease.turn_cwds.clear()
             lease.repair_turns.clear()
@@ -315,6 +620,7 @@ class ConfirmConfig:
                     _log(message)
                 except OSError:
                     print(message, flush=True)
+            _remove_lease_state(lease)
 
     def clear_retry_runtime(self) -> None:
         """Release every lease/cursor when no immediate reactive replay follows."""
@@ -443,6 +749,7 @@ def run_turn(
         _log(f"    [{f.id}] [DRY] turn {turn_no} {role} → {log.name}")
         return ("REPRODUCED" if role == "A" and turn_no == 1 else None), ""
     turn_key = (turn_no, role)
+    resume_logical = ("confirm", cfg.name, "finding", f.id, str(turn_no), role)
     prompt_digest = hashlib.sha256(prompt.encode()).hexdigest()
     turn_cwd = str(Path(cwd).absolute()) if cwd is not None else None
     if lease is not None:
@@ -455,6 +762,8 @@ def run_turn(
 
     state_key = ("finding", f.id, str(turn_no), role)
     policy_state = cfg.policy_state(state_key, prompt)
+    if lease is not None:
+        _persist_lease(cfg, f, lease)
     rc, text = run_agent_blocking(
         cfg.adapter,
         prompt,
@@ -471,6 +780,12 @@ def run_turn(
         policy_retries=cfg.policy_retries,
         transient_resumes=cfg.transient_resumes,
         policy_state=policy_state,
+        resume_logical=resume_logical,
+        resume_phase=PHASE_KEY,
+        resume_target=cfg.name,
+        resume_kind="finding-turn",
+        resume_finding_id=f.id,
+        manual_prompt_extra=cfg.resume_prompt_extra,
     )
     if rc == 75:
         raise RateLimited(f"{f.id} turn {turn_no} {role}")
@@ -479,12 +794,34 @@ def run_turn(
     if not text.strip():
         raise InvalidAgentOutput(f"{f.id} turn {turn_no} {role}: empty agent output")
     verdict = parse_verdict(text)
-    if lease is not None:
-        lease.completed_turns[turn_key] = _CompletedTurn(prompt_digest, turn_cwd, verdict, text)
-    # A completed turn is now represented by the lease cache; its native retry
-    # cursor is no longer needed. Only the unfinished rc75 turn keeps one.
-    cfg.clear_policy_states(state_key)
     return verdict, text
+
+
+def _accept_turn(
+    cfg: ConfirmConfig,
+    f: Finding,
+    role: str,
+    turn_no: int,
+    prompt: str,
+    cwd: str | Path | None,
+    lease: _FindingLease,
+    verdict: str | None,
+    text: str,
+) -> None:
+    """Commit a semantically accepted turn before making it non-resumable."""
+    turn_cwd = str(Path(cwd).absolute()) if cwd is not None else None
+    result_path = _turn_result_file(cfg, f, turn_no, role, text)
+    digest = hashlib.sha256(result_path.read_bytes()).hexdigest()
+    lease.completed_turns[(turn_no, role)] = _CompletedTurn(
+        hashlib.sha256(prompt.encode()).hexdigest(),
+        turn_cwd,
+        verdict,
+        text,
+        result_path,
+        digest,
+    )
+    _persist_lease(cfg, f, lease)
+    cfg.clear_policy_states(("finding", f.id, str(turn_no), role))
 
 
 def _fresh_turn_cwd(f: Finding, role: str, turn_no: int, lease: _FindingLease | None = None) -> Path:
@@ -567,6 +904,28 @@ def _consolidate_cwd(work_dir: Path, *, fresh: bool) -> Path:
 
 
 # ── per-finding git worktree (build isolation) ───────────────────────────────
+
+
+def _retained_worktree_cleanup(root: Path, wt: Path, finding_id: str) -> Callable[[], None]:
+    git_env = _dispatcher_git_env(root)
+
+    def cleanup() -> None:
+        result = subprocess.run(
+            ["git", "-C", str(root), "worktree", "remove", "--force", str(wt)],
+            env=git_env,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return
+        subprocess.run(["git", "-C", str(root), "worktree", "prune"], env=git_env, capture_output=True)
+        message = f"{finding_id}: could not remove isolated worktree (left on disk): {result.stderr.strip()[:200]}"
+        try:
+            _log(f"  WARNING: {message}")
+        except OSError:
+            print(f"  WARNING: {message}", flush=True)
+
+    return cleanup
 
 
 def setup_repo(cfg: ConfirmConfig, f: Finding) -> tuple[str, Callable[[], None]]:
@@ -679,29 +1038,7 @@ def _setup_worktree(cfg: ConfirmConfig, f: Finding, repo: str) -> tuple[str, Cal
     if dirty.stdout.strip():
         _log(f"  [{f.id}] copied tracked/untracked local changes into isolated worktree")
 
-    def cleanup() -> None:
-        # Best-effort, NEVER fatal. A worktree that cannot be removed — e.g. a
-        # containerised build (sonic-dash-ha) left artifacts root-owned that this
-        # user cannot delete — is a disk-cleanup nuisance, never a reason to discard
-        # a finding whose confirmation already finished. Drop the git registration
-        # where possible and warn; the leftover directory is harmless (each finding
-        # uses its own path).
-        result = subprocess.run(
-            ["git", "-C", str(root), "worktree", "remove", "--force", str(wt)],
-            env=git_env,
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0:
-            return
-        subprocess.run(["git", "-C", str(root), "worktree", "prune"], env=git_env, capture_output=True)
-        message = f"{f.id}: could not remove isolated worktree (left on disk): {result.stderr.strip()[:200]}"
-        try:
-            _log(f"  WARNING: {message}")
-        except OSError:
-            print(f"  WARNING: {message}", flush=True)
-
-    return str(wt), cleanup
+    return str(wt), _retained_worktree_cleanup(root, wt, f.id)
 
 
 def _worktree_candidates(base: Path) -> list[Path]:
@@ -951,14 +1288,15 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
                     return correction_turn
                 if repair.verdict is None:
                     draft_path = f.fdir / "repair-request.body.md"
+                    correction_cwd = _fresh_turn_cwd(f, "A-repair", correction_turn, lease)
                     try:
-                        correction_verdict, _ = run_turn(
+                        correction_verdict, correction_text = run_turn(
                             cfg,
                             f,
                             "A-repair",
                             correction_turn,
                             repair.prompt,
-                            cwd=_fresh_turn_cwd(f, "A-repair", correction_turn, lease),
+                            cwd=correction_cwd,
                             lease=lease,
                         )
                         repair.verdict = correction_verdict
@@ -967,6 +1305,8 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
                     except Exception as exc:
                         repair.disabled = True
                         _restore_repair_draft(draft_path, original)
+                        _persist_lease(cfg, f, lease)
+                        cfg.clear_policy_states(("finding", f.id, str(correction_turn), "A-repair"))
                         if original is None or not original.strip():
                             raise
                         _log(f"  WARNING: {f.id}: repair-draft correction failed ({exc}); keeping the original draft")
@@ -984,6 +1324,18 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
                     corrected_warning = _repair_draft_warning(cfg, f, corrected)
                     if corrected_warning is not None:
                         _log(f"  WARNING: {corrected_warning} (continuing with the non-empty draft)")
+                    _validate_turn_output(f, correction_verdict, correction_text)
+                    _accept_turn(
+                        cfg,
+                        f,
+                        "A-repair",
+                        correction_turn,
+                        repair.prompt,
+                        correction_cwd,
+                        lease,
+                        correction_verdict,
+                        correction_text,
+                    )
 
                 debate.write_text(
                     debate.read_text()
@@ -998,13 +1350,15 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
                 return correction_turn
 
         # Turn 1 — Reproducer (neutral): investigate + reproduce.
+        a_prompt = prompt_reproduce(cfg, f, repo_for_agent)
+        a_cwd = _fresh_turn_cwd(f, "A", 1, lease)
         a_verdict, a_text = run_turn(
             cfg,
             f,
             "A",
             1,
-            prompt_reproduce(cfg, f, repo_for_agent),
-            cwd=_fresh_turn_cwd(f, "A", 1, lease),
+            a_prompt,
+            cwd=a_cwd,
             lease=lease,
         )
         debate.write_text(
@@ -1014,6 +1368,9 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
         )
         _validate_turn_output(f, a_verdict, a_text)
         assert a_verdict is not None
+        if a_verdict != "PENDING REPAIR" and (a_verdict not in CONFIRM or not cfg.debate):
+            _validate_final_artifacts(cfg, f, a_verdict)
+        _accept_turn(cfg, f, "A", 1, a_prompt, a_cwd, lease, a_verdict, a_text)
         if a_verdict == "PENDING REPAIR":
             turn = prepare_pending(turn)
         initial_text = a_text
@@ -1028,18 +1385,23 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
         defenses: list[str] = []
         for rnd in range(1, cfg.rounds + 1):
             turn += 1
+            b_prompt = prompt_challenge(cfg, f, repo_for_agent, str(debate))
+            b_cwd = _fresh_turn_cwd(f, "B", turn, lease)
             b_verdict, b_text = run_turn(
                 cfg,
                 f,
                 "B",
                 turn,
-                prompt_challenge(cfg, f, repo_for_agent, str(debate)),
-                cwd=_fresh_turn_cwd(f, "B", turn, lease),
+                b_prompt,
+                cwd=b_cwd,
                 lease=lease,
             )
             debate.write_text(debate.read_text() + _debate_entry(f, "B", turn, f"B (round {rnd})", b_verdict))
             _validate_turn_output(f, b_verdict, b_text)
             assert b_verdict is not None
+            if b_verdict != "PENDING REPAIR" and b_verdict == a_verdict:
+                _validate_final_artifacts(cfg, f, b_verdict)
+            _accept_turn(cfg, f, "B", turn, b_prompt, b_cwd, lease, b_verdict, b_text)
             # B agrees with A's current verdict → consensus already. Do NOT pull A
             # into a defense it does not need: A only ever hears about the debate
             # when B actually disagrees (the defend turn is where it is introduced).
@@ -1056,18 +1418,23 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
                     _compose_evidence(initial_text, [*defenses, b_text]),
                 )
             turn += 1
+            defend_prompt = prompt_defend(cfg, f, repo_for_agent, str(debate))
+            defend_cwd = _fresh_turn_cwd(f, "A", turn, lease)
             a_verdict, a_text = run_turn(
                 cfg,
                 f,
                 "A",
                 turn,
-                prompt_defend(cfg, f, repo_for_agent, str(debate)),
-                cwd=_fresh_turn_cwd(f, "A", turn, lease),
+                defend_prompt,
+                cwd=defend_cwd,
                 lease=lease,
             )
             debate.write_text(debate.read_text() + _debate_entry(f, "A", turn, f"A (round {rnd})", a_verdict))
             _validate_turn_output(f, a_verdict, a_text)
             assert a_verdict is not None
+            if a_verdict != "PENDING REPAIR" and a_verdict == b_verdict:
+                _validate_final_artifacts(cfg, f, a_verdict)
+            _accept_turn(cfg, f, "A", turn, defend_prompt, defend_cwd, lease, a_verdict, a_text)
             if a_verdict == "PENDING REPAIR":
                 turn = prepare_pending(turn)
             defenses.append(a_text)
@@ -1493,7 +1860,9 @@ def run_finding_safe(
     to discard the whole target's report: the rest of the batch still delivers."""
     cached = _load_verdict(f, cfg)
     if cached is not None:
-        cfg.release_finding_lease(f.id)
+        resumelib.complete_prefix(("confirm", cfg.name, "finding", f.id))
+        cfg.release_finding_lease(f.id, force=True)
+        _discard_persisted_lease(cfg, f)
         cfg.clear_policy_states(("finding", f.id))
         _log(f"  [{f.id}] cached {cached.status} — skip (idempotent)")
         return cached
@@ -1503,7 +1872,8 @@ def run_finding_safe(
         if cfg.repair_round is not None:
             o.body = _merge_repair_evidence(prior, repair_evidence, o.body, cfg.repair_round)
         _save_verdict(o, cfg)
-        cfg.release_finding_lease(f.id)
+        resumelib.complete_prefix(("confirm", cfg.name, "finding", f.id))
+        cfg.release_finding_lease(f.id, force=True)
         cfg.clear_policy_states(("finding", f.id))
         return o
     except Exception as exc:  # RateLimited / ConfirmationFailed / anything unexpected
@@ -2761,10 +3131,12 @@ def consolidate(cfg: ConfirmConfig) -> None:
         and not (spec_dir / "confirmation-generation.json").is_file()
     )
     expected_scenarios = None if external_candidates else _expected_brief_scenarios(brief)
+    resume_logical = ("confirm", cfg.name, "consolidate")
     if source_errs:
         raise ConsolidateFailed(f"invalid model-checking input for {cfg.name}: {source_errs[0]}")
     if out.is_file() and _candidate_cache_valid(cfg, out, expected_mc_ids, expected_scenarios):
         cfg.clear_policy_states(("consolidate",))
+        resumelib.complete_turn(resume_logical)
         _log(f"  {cfg.name}: candidates.json present and valid — skipping consolidate")
         return
     bug_report = spec_dir / "bug-report.md"
@@ -2788,7 +3160,7 @@ def consolidate(cfg: ConfirmConfig) -> None:
         return
     spec_dir.mkdir(parents=True, exist_ok=True)
     policy_state = cfg.policy_state(("consolidate",), prompt)
-    fresh = policy_state.invocation_attempt == 0
+    fresh = policy_state.invocation_attempt == 0 and not resumelib.has_prefix(resume_logical)
     if fresh:
         # Do not let a fresh failed agent make stale output look fresh. An exact
         # rc75 continuation, however, may need candidates already written by its
@@ -2812,6 +3184,11 @@ def consolidate(cfg: ConfirmConfig) -> None:
             policy_retries=cfg.policy_retries,
             transient_resumes=cfg.transient_resumes,
             policy_state=policy_state,
+            resume_logical=resume_logical,
+            resume_phase=PHASE_KEY,
+            resume_target=cfg.name,
+            resume_kind="consolidate",
+            manual_prompt_extra=cfg.resume_prompt_extra,
         )
     except BaseException:
         cfg.clear_policy_states(("consolidate",))
@@ -2832,6 +3209,7 @@ def consolidate(cfg: ConfirmConfig) -> None:
             out.unlink()  # drop the invalid file so load_findings does not choke on it
         raise ConsolidateFailed(f"no valid candidates.json for {cfg.name}: {errs[0]}")
     _write_candidate_cache(cfg, out)
+    resumelib.complete_turn(resume_logical)
     doc = json.loads(out.read_text())
     cand = doc.get("findings", [])
     n_merged = sum(1 for c in cand if c.get("dedup_note"))
@@ -3387,8 +3765,63 @@ def _drive_confirmation(cfg: ConfirmConfig) -> int:
 
     outcomes: list[Outcome] = []
     unstarted: list[Finding] = []
+    scheduled_findings = findings
     next_finding = 0
     rate_limit_seen = threading.Event()
+
+    recovery_source = resumelib.unfinished_entries if resumelib.manual_mode() else resumelib.previous_entries
+    recovery_entries = [
+        entry for entry in recovery_source(phase=PHASE_KEY, target=cfg.name) if entry.get("kind") == "finding-turn"
+    ]
+    recovery_ids = list(dict.fromkeys(str(entry.get("finding_id") or "") for entry in recovery_entries))
+    if recovery_ids:
+        by_id = {finding.id: finding for finding in findings}
+        missing = [finding_id for finding_id in recovery_ids if finding_id not in by_id]
+        if missing:
+            return _withhold(
+                cfg,
+                "resume checkpoint no longer matches current findings: " + ", ".join(missing),
+            )
+        _log(f"Restoring {len(recovery_ids)} interrupted finding conversation(s) serially")
+        failed_recovery: Outcome | None = None
+        for finding_id in recovery_ids:
+            finding = by_id[finding_id]
+            if cfg.repair_round is None:
+                recovered = run_finding_safe(cfg, finding)
+            else:
+                recovered = run_finding_safe(
+                    cfg,
+                    finding,
+                    prior=prior_by_id.get(finding.id),
+                    repair_evidence=repair_evidence_by_id[finding.id],
+                )
+            if recovered.status == INCOMPLETE:
+                failed_recovery = recovered
+                break
+        if failed_recovery is not None:
+            outcomes.append(failed_recovery)
+            for finding in findings:
+                if finding.id == failed_recovery.finding.id:
+                    continue
+                cached = _load_verdict(finding, cfg)
+                if cached is not None:
+                    outcomes.append(cached)
+                    continue
+                outcomes.append(
+                    Outcome(
+                        finding,
+                        INCOMPLETE,
+                        consensus=False,
+                        rounds=0,
+                        body=(
+                            "## Confirmation result\n"
+                            "INCOMPLETE — this finding was not started while an interrupted conversation "
+                            "was being restored. It was NOT judged and was NOT cached. Re-run to retry."
+                        ),
+                        failure_code=failed_recovery.failure_code or 1,
+                    )
+                )
+            scheduled_findings = []
 
     def run_scheduled(finding: Finding) -> Outcome | None:
         # A future may have been submitted before another worker reports a rate
@@ -3417,8 +3850,12 @@ def _drive_confirmation(cfg: ConfirmConfig) -> int:
 
         def fill_wave() -> None:
             nonlocal next_finding
-            while not rate_limit_seen.is_set() and next_finding < len(findings) and len(in_flight) < cfg.max_parallel:
-                finding = findings[next_finding]
+            while (
+                not rate_limit_seen.is_set()
+                and next_finding < len(scheduled_findings)
+                and len(in_flight) < cfg.max_parallel
+            ):
+                finding = scheduled_findings[next_finding]
                 next_finding += 1
                 in_flight[ex.submit(run_scheduled, finding)] = finding
 
@@ -3456,7 +3893,7 @@ def _drive_confirmation(cfg: ConfirmConfig) -> int:
                 fill_wave()
 
     if rate_limit_seen.is_set():
-        unstarted.extend(findings[next_finding:])
+        unstarted.extend(scheduled_findings[next_finding:])
         for finding in unstarted:
             cached = _load_verdict(finding, cfg)
             if cached is not None:

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -201,11 +201,12 @@ class _FindingLease:
     completed_turns: dict[tuple[int, str], _CompletedTurn] = field(default_factory=dict)
     turn_cwds: dict[tuple[int, str], Path] = field(default_factory=dict)
     repair_turns: dict[tuple[int, str], _RepairTurn] = field(default_factory=dict)
+    no_correction_drafts: dict[tuple[int, str], str] = field(default_factory=dict)
     _run_lock: Any = field(default_factory=threading.RLock, repr=False, compare=False)
     _closed: bool = False
 
 
-_LEASE_VERSION = 1
+_LEASE_VERSION = 2
 
 
 def _lease_file(f: Finding) -> Path:
@@ -286,6 +287,14 @@ def _persist_lease(cfg: ConfirmConfig, f: Finding, lease: _FindingLease) -> None
             for (turn, role), path in sorted(lease.turn_cwds.items())
         ],
         "repair_turns": repair_turns,
+        "no_correction_drafts": [
+            {
+                "previous_turn": previous_turn,
+                "previous_role": previous_role,
+                "draft_digest": draft_digest,
+            }
+            for (previous_turn, previous_role), draft_digest in sorted(lease.no_correction_drafts.items())
+        ],
     }
     _lease_atomic_write(path, value)
     lease.state_path = path
@@ -363,7 +372,13 @@ def _load_lease(cfg: ConfirmConfig, f: Finding) -> _FindingLease:
     raw_cwds = value.get("turn_cwds", [])
     raw_completed = value.get("completed_turns", [])
     raw_repairs = value.get("repair_turns", [])
-    if not isinstance(raw_cwds, list) or not isinstance(raw_completed, list) or not isinstance(raw_repairs, list):
+    raw_no_corrections = value.get("no_correction_drafts")
+    if (
+        not isinstance(raw_cwds, list)
+        or not isinstance(raw_completed, list)
+        or not isinstance(raw_repairs, list)
+        or not isinstance(raw_no_corrections, list)
+    ):
         raise ConfirmationFailed(f"{f.id}: invalid Phase 4 resume checkpoint lists")
     for item in raw_cwds:
         if not isinstance(item, dict):
@@ -434,6 +449,30 @@ def _load_lease(cfg: ConfirmConfig, f: Finding) -> _FindingLease:
             result_path,
             digest,
         )
+    for item in raw_no_corrections:
+        if not isinstance(item, dict):
+            raise ConfirmationFailed(f"{f.id}: invalid no-correction draft checkpoint")
+        previous_turn = item.get("previous_turn")
+        previous_role = item.get("previous_role")
+        draft_digest = item.get("draft_digest")
+        if (
+            not isinstance(previous_turn, int)
+            or isinstance(previous_turn, bool)
+            or previous_turn < 1
+            or previous_role not in {"A", "B"}
+            or not isinstance(draft_digest, str)
+            or re.fullmatch(r"[0-9a-f]{64}", draft_digest) is None
+        ):
+            raise ConfirmationFailed(f"{f.id}: invalid no-correction draft checkpoint")
+        key = (previous_turn, previous_role)
+        completed = lease.completed_turns.get(key)
+        if key in lease.no_correction_drafts:
+            raise ConfirmationFailed(f"{f.id}: duplicate no-correction draft checkpoint")
+        if completed is None or completed.verdict != "PENDING REPAIR":
+            raise ConfirmationFailed(
+                f"{f.id}: no-correction draft checkpoint is not bound to a completed PENDING REPAIR turn"
+            )
+        lease.no_correction_drafts[key] = draft_digest
     for item in raw_repairs:
         if not isinstance(item, dict):
             raise ConfirmationFailed(f"{f.id}: invalid repair-turn checkpoint")
@@ -460,7 +499,7 @@ def _load_lease(cfg: ConfirmConfig, f: Finding) -> _FindingLease:
         ):
             raise ConfirmationFailed(f"{f.id}: invalid repair-turn checkpoint")
         repair_key = (previous_turn, previous_role)
-        if repair_key in lease.repair_turns:
+        if repair_key in lease.repair_turns or repair_key in lease.no_correction_drafts:
             raise ConfirmationFailed(f"{f.id}: duplicate repair-turn checkpoint")
         lease.repair_turns[repair_key] = _RepairTurn(
             turn,
@@ -612,6 +651,7 @@ class ConfirmConfig:
             lease.completed_turns.clear()
             lease.turn_cwds.clear()
             lease.repair_turns.clear()
+            lease.no_correction_drafts.clear()
             try:
                 lease.cleanup()
             except BaseException as exc:
@@ -1235,14 +1275,16 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
             turn = 1
 
             def prepare_pending(previous_turn: int, previous_role: str = "A") -> int:
-                """Warn about a draft problem and make at most one correction turn.
+                """Reuse the durable draft decision or make at most one correction turn.
 
-                The lease records a correction's logical turn before invoking it.
-                Therefore a later B rate-limit replay cannot renumber B merely
-                because the already-completed correction left a valid draft.
+                Both correction and no-correction decisions are recorded before
+                the next turn starts. A later rate-limit replay therefore cannot
+                renumber an already-started B turn from mutable draft contents.
                 """
                 repair_key = (previous_turn, previous_role)
                 repair = lease.repair_turns.get(repair_key)
+                if repair_key in lease.no_correction_drafts:
+                    return previous_turn
                 original = repair.original if repair is not None else None
                 if repair is None:
                     problem: Exception | str | None = None
@@ -1258,6 +1300,9 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
                                 original = draft_path.read_text()
 
                     if problem is None:
+                        assert original is not None
+                        lease.no_correction_drafts[repair_key] = hashlib.sha256(original.encode()).hexdigest()
+                        _persist_lease(cfg, f, lease)
                         return previous_turn
 
                     warning = str(problem)
@@ -1266,6 +1311,8 @@ def run_finding(cfg: ConfirmConfig, f: Finding, *, _lease: _FindingLease | None 
                         if original is None:
                             assert isinstance(problem, Exception)
                             raise problem
+                        lease.no_correction_drafts[repair_key] = hashlib.sha256(original.encode()).hexdigest()
+                        _persist_lease(cfg, f, lease)
                         return previous_turn
 
                     lease.repair_retry_used = True
@@ -3136,7 +3183,7 @@ def consolidate(cfg: ConfirmConfig) -> None:
         raise ConsolidateFailed(f"invalid model-checking input for {cfg.name}: {source_errs[0]}")
     if out.is_file() and _candidate_cache_valid(cfg, out, expected_mc_ids, expected_scenarios):
         cfg.clear_policy_states(("consolidate",))
-        resumelib.complete_turn(resume_logical)
+        resumelib.complete_turn(resume_logical, allow_previous_owner=resumelib.manual_mode())
         _log(f"  {cfg.name}: candidates.json present and valid — skipping consolidate")
         return
     bug_report = spec_dir / "bug-report.md"
@@ -3209,7 +3256,7 @@ def consolidate(cfg: ConfirmConfig) -> None:
             out.unlink()  # drop the invalid file so load_findings does not choke on it
         raise ConsolidateFailed(f"no valid candidates.json for {cfg.name}: {errs[0]}")
     _write_candidate_cache(cfg, out)
-    resumelib.complete_turn(resume_logical)
+    resumelib.complete_turn(resume_logical, allow_previous_owner=resumelib.manual_mode())
     doc = json.loads(out.read_text())
     cand = doc.get("findings", [])
     n_merged = sum(1 for c in cand if c.get("dedup_note"))

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -34,7 +34,7 @@ from typing import Any, TypedDict
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import specula.progress as progress
-from specula import quota
+from specula import quota, resumelib
 from specula.adapters.utils.policy import POLICY_BLOCKED_RC
 from specula.adapters.utils.transient import TRANSIENT_FAILURE_RC
 from specula.output_index import PIPELINE_LOG_ENV, is_safe_target_name, write_target_index
@@ -102,6 +102,8 @@ The previous invocation was interrupted because the provider blocked a response 
 """
 
 _SESSION_RESUME_PROMPT = """Continue the current Specula task from this exact session. The previous invocation was interrupted by a temporary provider, capacity, or transport failure. Preserve completed work, inspect the current workspace, and finish every remaining deliverable. Do not restart completed analysis."""
+
+_MANUAL_SESSION_RESUME_PROMPT = """Continue the current Specula task from this exact session. The previous run ended before this work was accepted. Preserve completed work, inspect the current workspace, and finish every remaining deliverable. Do not restart completed analysis."""
 
 _POLICY_SESSION_RESUME_PROMPT = """Continue the same legitimate formal-verification task from this exact session. The previous response was interrupted by the provider's content policy. Preserve completed work, rephrase the interrupted portion in neutral formal-verification terms, and finish every remaining deliverable without restarting the phase."""
 
@@ -171,11 +173,13 @@ def _transient_resume_delay(attempt: int) -> float:
     return min(TRANSIENT_RESUME_BACKOFF_MAX_SECONDS, float(2 ** min(attempt + 1, 6)))
 
 
-def _retry_prompt(original: str, reason: str, *, resumable: bool) -> str:
+def _retry_prompt(original: str, reason: str, *, resumable: bool, manual_extra: str = "") -> str:
     if not resumable:
         return _policy_recovery_prompt(original) if reason == "policy" else original
     if reason == "policy":
         return _POLICY_SESSION_RESUME_PROMPT
+    if reason == "manual":
+        return _MANUAL_SESSION_RESUME_PROMPT + manual_extra
     if reason in {"rate_limit", "transient"}:
         return _SESSION_RESUME_PROMPT
     return original
@@ -642,11 +646,8 @@ class Phase:
         )
 
     # ── shared prompt-extra injection (identical across phases) ──
-    def _read_prompt_extra(self, ws: Workspace, name: str) -> str:
-        """The target's .prompt-extra.md as an appendable block (with its section
-        header), or '' if none. Isolated runs never cd into the case dir, so the
-        cwd fallback would silently drop the canonical case-studies/<name> extra —
-        target-specific instructions must survive isolation."""
+    def _latest_prompt_extra(self, ws: Workspace, name: str) -> str:
+        """Read the current target guidance without consulting its frozen copy."""
         extra = ws.work_dir(name) / ".prompt-extra.md"
         if not extra.is_file():
             fallback = ws.case_dir(name) if ws.run_dir else ws.cwd
@@ -656,6 +657,30 @@ class Phase:
             # non-UTF-8 byte in a user's .prompt-extra.md must not crash the run.
             return "\n## Target-Specific Instructions\n\n" + extra.read_text(errors="replace")
         return ""
+
+    def _read_prompt_extra(self, ws: Workspace, name: str) -> str:
+        """Return run-frozen guidance so manual supplements do not invalidate caches."""
+        if ws.run_dir is None:
+            return self._latest_prompt_extra(ws, name)
+        frozen = ws.work_dir(name) / ".prompt-extra.initial.md"
+        if frozen.is_file() and not frozen.is_symlink():
+            content = frozen.read_text(errors="replace")
+            return "\n## Target-Specific Instructions\n\n" + content if content else ""
+        current = self._latest_prompt_extra(ws, name)
+        marker = "\n## Target-Specific Instructions\n\n"
+        raw = current[len(marker) :] if current.startswith(marker) else ""
+        frozen.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with frozen.open("x", encoding="utf-8") as stream:
+                stream.write(raw)
+        except FileExistsError as exc:
+            if frozen.is_symlink() or not frozen.is_file():
+                raise RuntimeError(f"unsafe frozen prompt-extra path: {frozen}") from exc
+            raw = frozen.read_text(errors="replace")
+        return marker + raw if raw else ""
+
+    def _manual_prompt_extra(self, ws: Workspace, name: str) -> str:
+        return self._latest_prompt_extra(ws, name) if resumelib.manual_mode() else ""
 
     def _with_extra(self, ws: Workspace, name: str, prompt: str) -> str:
         return prompt + self._read_prompt_extra(ws, name)
@@ -819,6 +844,43 @@ class Phase:
             print(f"ERROR: cannot restore private source: {exc}")
             return 1
 
+        phase_prefix = ("phase", self.key)
+        try:
+            if resumelib.manual_mode():
+                completed_calls = resumelib.completed_logicals(phase_prefix)
+                for logical in completed_calls:
+                    # Reconcile the safe write-before-unlink crash window in
+                    # mark_completed(). The accepted call must not run again.
+                    resumelib.complete_turn(logical)
+            else:
+                resumelib.clear_completed(phase_prefix)
+                completed_calls = set()
+        except resumelib.ResumeError as exc:
+            print(f"ERROR: {exc}")
+            return 1
+        accepted_names = {
+            logical[2] for logical in completed_calls if len(logical) == 3 and logical[:2] == phase_prefix
+        }
+
+        try:
+            resumelib.ensure_phase(self.key)
+            recovering = resumelib.previous_entries(phase=self.key)
+        except resumelib.ResumeError as exc:
+            print(f"ERROR: {exc}")
+            return 1
+        if recovering:
+            order = {str(entry.get("target")): index for index, entry in enumerate(recovering)}
+            original_order = {id(target): index for index, target in enumerate(targets)}
+            targets.sort(
+                key=lambda target: (order.get(self.target_name(target), len(order)), original_order[id(target)])
+            )
+            names = [self.target_name(target) for target in targets]
+            # Ordinary target agents recover one at a time. Phase 4 owns a
+            # finer per-finding recovery frontier and restores its normal
+            # parallelism after those interrupted turns are settled.
+            if self.key != "bug_confirmation" or ws.opts.get("legacy"):
+                max_parallel = 1
+
         print("========================================")
         print(f" {self.title}")
         print("========================================")
@@ -869,9 +931,9 @@ class Phase:
         show_progress = progress.enabled()
         running: list[progress.RunningAgent] = []
         failures: list[tuple[str, int]] = []
-        successful_names: set[str] = set()
-        completed_names: set[str] = set()
-        pending = [_LaunchRequest(target) for target in targets]
+        successful_names: set[str] = set(accepted_names)
+        completed_names: set[str] = set(accepted_names)
+        pending = [_LaunchRequest(target) for target in targets if self.target_name(target) not in accepted_names]
         rate_limited: list[_LaunchRequest] = []
         pause_for_rate_limit = False
         stop_launching = False
@@ -1067,6 +1129,15 @@ class Phase:
             dry_run=dry_run,
         )
 
+        invalid_names.update(name for name, _ in handoff_failures)
+        if not dry_run:
+            for name in sorted(successful_names - invalid_names):
+                try:
+                    resumelib.mark_completed(("phase", self.key, name))
+                except resumelib.ResumeError as exc:
+                    finalized.append((name, 1))
+                    print(f"ERROR: {exc}")
+
         self.summarize(ws, names)
         if not dry_run:
             _refresh_target_indexes(ws, names)
@@ -1091,7 +1162,14 @@ class Phase:
             print("Output integrity failures:")
             for name, rc in integrity_failures:
                 print(f"  FAILED  {name}: protected output was restored (exit {rc})")
-        return self._failure_code(failures + integrity_failures + finalized + handoff_failures)
+        result = self._failure_code(failures + integrity_failures + finalized + handoff_failures)
+        if result == 0 and not dry_run:
+            try:
+                resumelib.clear_completed(phase_prefix)
+            except resumelib.ResumeError as exc:
+                print(f"ERROR: {exc}")
+                return 1
+        return result
 
     def run_alternate(
         self,
@@ -1218,6 +1296,12 @@ class Phase:
         for d in files["mkdirs"]:
             d.mkdir(parents=True, exist_ok=True)
         resume_state = _resume_state_path(files["log"])
+        repo_dir = ws.find_repo_dir(name)
+        launch_cwd = Path.cwd().resolve()
+        if ws.uses_private_source():
+            if not repo_dir:
+                raise RuntimeError(f"private source is missing for {name!r}")
+            launch_cwd = Path(repo_dir)
         activity_sidecar = files["log"].with_suffix(".activity.jsonl")
         attempt_files = (
             files["prompt"],
@@ -1227,15 +1311,54 @@ class Phase:
             files["log"].with_suffix(".raw.json"),
             files["log"].with_suffix(".usage.json"),
         )
+        resume_logical = ("phase", self.key, name)
+        claim = resumelib.ResumeClaim(attempt=invocation_attempt, manual=False, resumable=False)
+        if not dry_run and resumelib.enabled():
+            checkpoint_model, checkpoint_effort = _checkpoint_tuning(adapter, self._model, self._effort)
+            claim = resumelib.prepare_turn(
+                resume_logical,
+                phase=self.key,
+                target=name,
+                kind="phase",
+                adapter=adapter,
+                model=checkpoint_model,
+                effort=checkpoint_effort,
+                claude_alias=claude_alias,
+                cwd=launch_cwd,
+                resume_state=resume_state,
+                prompt_file=files["prompt"],
+                log_file=files["log"],
+            )
         if not dry_run:
+            if claim.manual:
+                attempt = claim.rate_limit_attempt
+                policy_attempt = claim.policy_attempt
+                transient_attempt = claim.transient_attempt
+            invocation_attempt = claim.attempt
+            if resumelib.enabled():
+                resumelib.update_turn(
+                    resume_logical,
+                    rate_limit_attempt=attempt,
+                    policy_attempt=policy_attempt,
+                    transient_attempt=transient_attempt,
+                    invocation_attempt=invocation_attempt,
+                    retry_reason="manual" if claim.manual else retry_reason,
+                )
             if invocation_attempt == 1:
                 _clear_attempt_archives(attempt_files)
                 _clear_resume_state(resume_state)
             else:
                 _archive_attempt(attempt_files, invocation_attempt - 1)
         resumable = resume_state.is_file()
-        prompt_reason = "policy" if policy_attempt > 0 and not resumable else retry_reason
-        prompt = _retry_prompt(prompt, prompt_reason, resumable=resumable)
+        prompt_reason = (
+            "manual" if claim.manual else ("policy" if policy_attempt > 0 and not resumable else retry_reason)
+        )
+        prompt = _retry_prompt(
+            prompt,
+            prompt_reason,
+            resumable=resumable,
+            manual_extra=self._manual_prompt_extra(ws, name) if claim.manual else "",
+        )
         prompt = materialize_skill_refs(prompt, adapter)
         files["prompt"].write_text(prompt)
         print(f"[{_ts()}] Launching agent: {name}")
@@ -1257,16 +1380,13 @@ class Phase:
         env["SPECULA_PHASE"] = self.key
         env["SPECULA_WORK_DIR"] = str(ws.work_dir(name))
         env["SPECULA_ROOT"] = str(SPECULA_ROOT)
-        repo_dir = ws.find_repo_dir(name)
         if repo_dir:
             env["SPECULA_TARGET_REPO_DIR"] = repo_dir
-        launch_cwd: Path | None = None
         if ws.uses_private_source():
-            if not repo_dir:
-                raise RuntimeError(f"private source is missing for {name!r}")
-            launch_cwd = Path(repo_dir)
             env["PWD"] = str(launch_cwd)
             sanitize_snapshot_git_environment(env, ceiling=ws.private_git_ceiling([name]))
+        else:
+            env["PWD"] = str(launch_cwd)
         work_dir = ws.work_dir(name)
         with contextlib.suppress(OSError):
             activity_sidecar.unlink()
@@ -1372,6 +1492,18 @@ def _model_effort_argv(adapter: Path, model: str | None, effort: str | None) -> 
     return argv
 
 
+def _checkpoint_tuning(adapter: Path, model: str | None, effort: str | None) -> tuple[str | None, str | None]:
+    """Return the exact tuning values forwarded to the adapter."""
+    forwarded_model: str | None = None
+    forwarded_effort: str | None = None
+    for arg in _model_effort_argv(adapter, model, effort):
+        if arg.startswith("--model="):
+            forwarded_model = arg.removeprefix("--model=")
+        elif arg.startswith("--effort="):
+            forwarded_effort = arg.removeprefix("--effort=")
+    return forwarded_model, forwarded_effort
+
+
 def _last_message_path(log_file: Path) -> Path:
     """Mirror the Codex adapter's bash `${log_file%.log}` derivation."""
     raw = str(log_file)
@@ -1397,6 +1529,12 @@ def run_agent_blocking(
     policy_retries: int = DEFAULT_POLICY_RETRIES,
     transient_resumes: int = DEFAULT_TRANSIENT_RESUMES,
     policy_state: PolicyRetryState | None = None,
+    resume_logical: tuple[str, ...] | None = None,
+    resume_phase: str | None = None,
+    resume_target: str = "",
+    resume_kind: str = "turn",
+    resume_finding_id: str | None = None,
+    manual_prompt_extra: str = "",
 ) -> tuple[int, str]:
     """Run an agent turn, blocking, and return (returncode, log text).
 
@@ -1481,28 +1619,73 @@ def run_agent_blocking(
         f"--resume-state={resume_state}",
     ]
     state = policy_state if policy_state is not None else PolicyRetryState()
+    claim = resumelib.ResumeClaim(attempt=1, manual=False, resumable=False)
+    if resume_logical is not None:
+        checkpoint_model, checkpoint_effort = _checkpoint_tuning(adapter, model, effort)
+        claim = resumelib.prepare_turn(
+            resume_logical,
+            phase=resume_phase or phase_key,
+            target=resume_target,
+            kind=resume_kind,
+            adapter=adapter,
+            model=checkpoint_model,
+            effort=checkpoint_effort,
+            claude_alias=claude_alias,
+            cwd=run_cwd,
+            resume_state=resume_state,
+            prompt_file=prompt_file,
+            log_file=log_file,
+            finding_id=resume_finding_id,
+        )
     with state._lock:
+        if claim.attempt > 1:
+            state.policy_attempt = max(state.policy_attempt, claim.policy_attempt)
+            state.transient_attempt = max(state.transient_attempt, claim.transient_attempt)
+            state.invocation_attempt = max(
+                state.invocation_attempt,
+                claim.invocation_attempt,
+                claim.attempt - 1,
+            )
+            if not claim.manual and state.retry_reason == "fresh":
+                state.retry_reason = claim.retry_reason
         if not 0 <= state.policy_attempt <= policy_retries:
             raise ValueError("policy_state attempt must be within policy_retries")
         if not 0 <= state.transient_attempt <= transient_resumes:
             raise ValueError("policy_state transient attempt must be within transient_resumes")
+        if claim.manual:
+            state.resume_state = resume_state
+            state.retry_reason = "manual"
         if state.resume_state is None:
             _clear_attempt_archives(attempt_files)
             _clear_resume_state(resume_state)
             state.resume_state = resume_state
         elif state.resume_state != resume_state:
             raise ValueError("policy_state belongs to a different logical turn")
+
+        def persist_cursor() -> None:
+            if resume_logical is not None:
+                resumelib.update_turn(
+                    resume_logical,
+                    rate_limit_attempt=claim.rate_limit_attempt,
+                    policy_attempt=state.policy_attempt,
+                    transient_attempt=state.transient_attempt,
+                    invocation_attempt=state.invocation_attempt,
+                    retry_reason=state.retry_reason,
+                )
+
         while True:
             policy_attempt = state.policy_attempt
             state.invocation_attempt += 1
             if state.invocation_attempt > 1:
                 _archive_attempt(attempt_files, state.invocation_attempt - 1)
+            persist_cursor()
             resumable = resume_state.is_file()
             prompt_reason = "policy" if policy_attempt > 0 and not resumable else state.retry_reason
             current_prompt = _retry_prompt(
                 prompt,
                 prompt_reason,
                 resumable=resumable,
+                manual_extra=manual_prompt_extra if state.retry_reason == "manual" else "",
             )
             prompt_file.write_text(current_prompt)
             with contextlib.suppress(OSError):
@@ -1512,6 +1695,7 @@ def run_agent_blocking(
                     last_message_file.unlink()
 
             rc = subprocess.run(cmd, env=env, cwd=run_cwd).returncode
+            persist_cursor()
             # Codex stdout is a complete CLI transcript, not the assistant's final
             # response. The adapter keeps that transcript in `log_file` for
             # diagnosis and asks `codex exec --output-last-message` for the response
@@ -1523,6 +1707,7 @@ def run_agent_blocking(
             if rc == TRANSIENT_FAILURE_RC and state.transient_attempt < transient_resumes:
                 state.transient_attempt += 1
                 state.retry_reason = "transient"
+                persist_cursor()
                 delay = _transient_resume_delay(state.transient_attempt)
                 mode = "resuming the exact session" if resume_state.is_file() else "retrying the original request"
                 print(
@@ -1534,6 +1719,7 @@ def run_agent_blocking(
             if rc == POLICY_BLOCKED_RC and policy_attempt < policy_retries:
                 state.policy_attempt = policy_attempt + 1
                 state.retry_reason = "policy"
+                persist_cursor()
                 print(
                     f"[{_ts()}] Provider policy interrupted the agent turn; retrying with a revised request "
                     f"({state.policy_attempt}/{policy_retries})"
@@ -1541,6 +1727,7 @@ def run_agent_blocking(
                 continue
             if rc == quota.RATE_LIMIT_RC:
                 state.retry_reason = "rate_limit"
+                persist_cursor()
             return rc, text
 
 
@@ -2369,6 +2556,7 @@ Prerequisites:
                 repair_token=repair_token,
                 dry_run=dry_run,
                 prompt_extra=self._read_prompt_extra(ws, name),
+                resume_prompt_extra=self._manual_prompt_extra(ws, name),
             )
             attempt = 1
             try:
@@ -2714,6 +2902,34 @@ Output:
             print(f"ERROR: cannot restore private source: {exc}")
             return 1
 
+        completed_prefix = ("review", phase)
+        try:
+            if resumelib.manual_mode():
+                completed_calls = resumelib.completed_logicals(completed_prefix)
+                for logical in completed_calls:
+                    resumelib.complete_turn(logical)
+            else:
+                resumelib.clear_completed(completed_prefix)
+                completed_calls = set()
+        except resumelib.ResumeError as exc:
+            print(f"ERROR: {exc}")
+            return 1
+        accepted_names = {
+            logical[2] for logical in completed_calls if len(logical) == 3 and logical[:2] == completed_prefix
+        }
+
+        resume_phase = f"review:{phase}"
+        try:
+            resumelib.ensure_phase(resume_phase)
+            recovering = resumelib.previous_entries(phase=resume_phase)
+        except resumelib.ResumeError as exc:
+            print(f"ERROR: {exc}")
+            return 1
+        if recovering:
+            order = {str(entry.get("target")): index for index, entry in enumerate(recovering)}
+            names = sorted(names, key=lambda name: order.get(name, len(order)))
+        recovery_cursors = {str(entry["target"]): entry for entry in recovering}
+
         _refresh_target_indexes(ws, names)
 
         print("========================================")
@@ -2725,7 +2941,21 @@ Output:
 
         with _cleanup_on_signal():
             for name in names:
-                request = _LaunchRequest(name)
+                if name in accepted_names:
+                    continue
+                cursor = recovery_cursors.get(name)
+                request = (
+                    _LaunchRequest(
+                        name,
+                        rate_limit_attempt=cursor.get("rate_limit_attempt", 1),
+                        policy_attempt=cursor.get("policy_attempt", 0),
+                        transient_attempt=cursor.get("transient_attempt", 0),
+                        invocation_attempt=max(1, cursor.get("invocation_attempt", 0)),
+                        retry_reason=cursor.get("retry_reason", "fresh"),
+                    )
+                    if cursor is not None
+                    else _LaunchRequest(name)
+                )
                 while True:
                     try:
                         rc = self._launch_review(
@@ -2734,6 +2964,7 @@ Output:
                             phase,
                             adapter,
                             claude_alias,
+                            rate_limit_attempt=request.rate_limit_attempt,
                             policy_attempt=request.policy_attempt,
                             transient_attempt=request.transient_attempt,
                             invocation_attempt=request.invocation_attempt,
@@ -2791,6 +3022,7 @@ Output:
                         continue
                     if rc != 0:
                         return self._failure_code([(name, rc)])
+                    resumelib.mark_completed(("review", phase, name))
                     break
 
         print()
@@ -2814,6 +3046,11 @@ Output:
                 print(f"  {name}: review empty (check log)")
             else:
                 print(f"  {name}: (no review file generated — check log)")
+        try:
+            resumelib.clear_completed(completed_prefix)
+        except resumelib.ResumeError as exc:
+            print(f"ERROR: {exc}")
+            return 1
         return 0
 
     def _launch_review(
@@ -2824,6 +3061,7 @@ Output:
         adapter: Path,
         claude_alias: str,
         *,
+        rate_limit_attempt: int = 1,
         policy_attempt: int = 0,
         transient_attempt: int = 0,
         invocation_attempt: int = 1,
@@ -2845,14 +3083,52 @@ Output:
         print(f"[{_ts()}] Reviewing {name} ({phase})...")
         log_dir.mkdir(parents=True, exist_ok=True)
         pid_file = log_dir / f"review-{phase}.pid"
+        prompt_file = log_dir / f".review-{phase}-prompt.md"
         activity_log = log_file.with_suffix(".activity.jsonl")
         resume_state = _resume_state_path(log_file)
         attempt_files = (
+            prompt_file,
             log_file,
             _last_message_path(log_file),
             activity_log,
             log_file.with_suffix(".raw.json"),
             log_file.with_suffix(".usage.json"),
+        )
+        repo_dir = ws.find_repo_dir(name)
+        launch_cwd = Path.cwd().resolve()
+        if ws.uses_private_source():
+            if not repo_dir:
+                raise RuntimeError(f"private source is missing for {name!r}")
+            launch_cwd = Path(repo_dir)
+        resume_logical = ("review", phase, name)
+        checkpoint_model, checkpoint_effort = _checkpoint_tuning(adapter, self._model, self._effort)
+        claim = resumelib.prepare_turn(
+            resume_logical,
+            phase=f"review:{phase}",
+            target=name,
+            kind="review",
+            adapter=adapter,
+            model=checkpoint_model,
+            effort=checkpoint_effort,
+            claude_alias=claude_alias,
+            cwd=launch_cwd,
+            resume_state=resume_state,
+            prompt_file=prompt_file,
+            log_file=log_file,
+        )
+        if claim.manual:
+            rate_limit_attempt = claim.rate_limit_attempt
+            policy_attempt = claim.policy_attempt
+            transient_attempt = claim.transient_attempt
+            retry_reason = "manual"
+        invocation_attempt = claim.attempt
+        resumelib.update_turn(
+            resume_logical,
+            rate_limit_attempt=rate_limit_attempt,
+            policy_attempt=policy_attempt,
+            transient_attempt=transient_attempt,
+            invocation_attempt=invocation_attempt,
+            retry_reason=retry_reason,
         )
         if invocation_attempt == 1:
             _clear_attempt_archives(attempt_files)
@@ -2860,21 +3136,26 @@ Output:
         else:
             _archive_attempt(attempt_files, invocation_attempt - 1)
         resumable = resume_state.is_file()
-        prompt_reason = "policy" if policy_attempt > 0 and not resumable else retry_reason
-        prompt = _retry_prompt(prompt, prompt_reason, resumable=resumable)
+        prompt_reason = (
+            "manual" if claim.manual else ("policy" if policy_attempt > 0 and not resumable else retry_reason)
+        )
+        prompt = _retry_prompt(
+            prompt,
+            prompt_reason,
+            resumable=resumable,
+            manual_extra=self._manual_prompt_extra(ws, name) if claim.manual else "",
+        )
+        prompt_file.write_text(prompt)
         with contextlib.suppress(OSError):
             activity_log.unlink()
         env = os.environ.copy()
         env["SPECULA_WORK_DIR"] = str(wd)
-        repo_dir = ws.find_repo_dir(name)
-        launch_cwd: Path | None = None
         if ws.uses_private_source():
-            if not repo_dir:
-                raise RuntimeError(f"private source is missing for {name!r}")
-            launch_cwd = Path(repo_dir)
             env["SPECULA_TARGET_REPO_DIR"] = repo_dir
             env["PWD"] = str(launch_cwd)
             sanitize_snapshot_git_environment(env, ceiling=ws.private_git_ceiling([name]))
+        else:
+            env["PWD"] = str(launch_cwd)
         env.pop("SPECULA_ACTIVITY_LOG", None)
         show_progress = progress.enabled()
         if show_progress:

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -851,7 +851,7 @@ class Phase:
                 for logical in completed_calls:
                     # Reconcile the safe write-before-unlink crash window in
                     # mark_completed(). The accepted call must not run again.
-                    resumelib.complete_turn(logical)
+                    resumelib.reconcile_completed(logical)
             else:
                 resumelib.clear_completed(phase_prefix)
                 completed_calls = set()
@@ -1436,6 +1436,7 @@ class Phase:
                 env=env,
                 cwd=launch_cwd,
                 start_new_session=True,
+                pass_fds=resumelib.inherited_run_lock_fds(),
             )
             launched = progress.RunningAgent(
                 name=name,
@@ -1694,7 +1695,12 @@ def run_agent_blocking(
                 with contextlib.suppress(OSError):
                     last_message_file.unlink()
 
-            rc = subprocess.run(cmd, env=env, cwd=run_cwd).returncode
+            rc = subprocess.run(
+                cmd,
+                env=env,
+                cwd=run_cwd,
+                pass_fds=resumelib.inherited_run_lock_fds(),
+            ).returncode
             persist_cursor()
             # Codex stdout is a complete CLI transcript, not the assistant's final
             # response. The adapter keeps that transcript in `log_file` for
@@ -2907,7 +2913,7 @@ Output:
             if resumelib.manual_mode():
                 completed_calls = resumelib.completed_logicals(completed_prefix)
                 for logical in completed_calls:
-                    resumelib.complete_turn(logical)
+                    resumelib.reconcile_completed(logical)
             else:
                 resumelib.clear_completed(completed_prefix)
                 completed_calls = set()
@@ -3196,6 +3202,7 @@ Output:
                 env=env,
                 cwd=launch_cwd,
                 start_new_session=True,
+                pass_fds=resumelib.inherited_run_lock_fds(),
             )
             running = progress.RunningAgent(
                 name=name,

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -156,8 +156,8 @@ Options:
                          (a single target cd's into case-studies/<name>/ when
                          it exists)
   --run-id=ID            Attach to runs/ID — reuse an existing run's workspace,
-                         resuming unfinished agent conversations by default
-                         (use the original --skip-* flags; implies --isolate)
+                         resume unfinished agent conversations at their phase
+                         (implies --isolate)
   --fresh-context        With --run-id, abandon unfinished conversations and
                          start the selected phases with fresh agent context
 
@@ -857,6 +857,34 @@ class Pipeline:
             self.artifact = artifact
             self._artifact_given = True
 
+    def _position_at_manual_resume_phase(self) -> None:
+        phase = self._manual_resume_phase
+        if phase is None:
+            return
+        preceding = {
+            "code_analysis": (),
+            "review:analysis": ("skip_analysis",),
+            "spec_generation": ("skip_analysis",),
+            "review:specgen": ("skip_analysis", "skip_specgen"),
+            "harness_generation": ("skip_analysis", "skip_specgen"),
+            "spec_validation": ("skip_analysis", "skip_specgen", "skip_harness"),
+            "review:validation": ("skip_analysis", "skip_specgen", "skip_harness", "skip_validation"),
+            "bug_confirmation": ("skip_analysis", "skip_specgen", "skip_harness", "skip_validation"),
+            "bug_classification": (
+                "skip_analysis",
+                "skip_specgen",
+                "skip_harness",
+                "skip_validation",
+                "skip_confirmation",
+            ),
+        }.get(phase)
+        if preceding is None:
+            raise resumelib.ResumeError(
+                f"cannot position the pipeline at interrupted phase {phase!r}; pass --fresh-context to start over"
+            )
+        for field in preceding:
+            setattr(self, field, True)
+
     def _acquire_run_lock(self) -> None:
         if self.run_dir is None or self._run_lock_fd is not None:
             return
@@ -1003,6 +1031,7 @@ class Pipeline:
                             "unfinished conversations span multiple phases; pass --fresh-context to start over"
                         )
                     self._manual_resume_phase = phases.pop()
+                    self._position_at_manual_resume_phase()
                     if not self.keep_original:
                         launch_cwds = {entry.get("cwd") for entry in active if entry.get("kind") in {"phase", "review"}}
                         if launch_cwds:
@@ -3101,13 +3130,13 @@ class Pipeline:
         else:
             log("Skipping Phase 2.5 (--skip-harness)")
 
-        # An uncommitted interrupted repair is OPEN again after recovery. Keep
-        # the established ordering for that case: upstream phases run first,
-        # then the repair loop resumes before ordinary Phase 3.
+        # Resume OPEN repairs before ordinary Phase 3. An unfinished Phase 4
+        # conversation must settle first because it owns the active session.
         if (
             not resumed_repair
             and not self.skip_confirmation
             and not self.skip_repair_loop
+            and self._manual_resume_phase != "bug_confirmation"
             and self.has_open_repair_requests()
         ):
             log("Resuming pending repair requests before the ordinary Phase 3 pass")

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -857,10 +857,37 @@ class Pipeline:
             self.artifact = artifact
             self._artifact_given = True
 
-    def _position_at_manual_resume_phase(self) -> None:
+    def _position_at_manual_resume_phase(self, active: list[dict[str, Any]] | None = None) -> None:
         phase = self._manual_resume_phase
         if phase is None:
             return
+        controlling_skip: tuple[str, str] | None = {
+            "code_analysis": ("skip_analysis", "--skip-analysis"),
+            "spec_generation": ("skip_specgen", "--skip-specgen"),
+            "harness_generation": ("skip_harness", "--skip-harness"),
+            "bug_confirmation": ("skip_confirmation", "--skip-confirmation"),
+            "bug_classification": ("skip_classification", "--skip-classification"),
+        }.get(phase)
+        if phase == "spec_validation":
+            prompt_names = {
+                Path(str(entry.get("prompt_file"))).name
+                for entry in active or []
+                if isinstance(entry.get("prompt_file"), str)
+            }
+            if len(prompt_names) > 1:
+                raise resumelib.ResumeError(
+                    "unfinished validation conversations mix ordinary and repair inputs; "
+                    "pass --fresh-context to start over"
+                )
+            repair = prompt_names == {".spec-repair-prompt.md"}
+            conflicts = (
+                (("skip_confirmation", "--skip-confirmation"), ("skip_repair_loop", "--skip-repair-loop"))
+                if repair
+                else (("skip_validation", "--skip-validate"),)
+            )
+            controlling_skip = next((item for item in conflicts if getattr(self, item[0])), None)
+        if controlling_skip is not None and getattr(self, controlling_skip[0]):
+            raise resumelib.ResumeError(f"cannot use {controlling_skip[1]} while resuming unfinished phase {phase!r}")
         preceding = {
             "code_analysis": (),
             "review:analysis": ("skip_analysis",),
@@ -903,16 +930,24 @@ class Pipeline:
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError as exc:
             os.close(fd)
-            raise resumelib.ResumeError(f"run {self.run_id} is already active") from exc
+            raise resumelib.ResumeError(
+                f"run {self.run_id} still has a live phase or agent; "
+                "wait for it to finish or terminate it manually before attaching"
+            ) from exc
         self._run_lock_fd = fd
+        os.environ[resumelib.RUN_LOCK_FD_ENV] = str(fd)
 
     def _release_run_lock(self) -> None:
         if self._run_lock_fd is None:
             return
+        fd = self._run_lock_fd
+        if os.environ.get(resumelib.RUN_LOCK_FD_ENV) == str(fd):
+            os.environ.pop(resumelib.RUN_LOCK_FD_ENV, None)
         with contextlib.suppress(OSError):
-            fcntl.flock(self._run_lock_fd, fcntl.LOCK_UN)
-        with contextlib.suppress(OSError):
-            os.close(self._run_lock_fd)
+            # Do not explicitly unlock: phase/agent children inherit this open
+            # file description, so the kernel releases the lease only after the
+            # last live owner exits.
+            os.close(fd)
         self._run_lock_fd = None
 
     def resolve_run_dir(self, *, acquire_lock: bool = False) -> int | None:
@@ -1031,7 +1066,7 @@ class Pipeline:
                             "unfinished conversations span multiple phases; pass --fresh-context to start over"
                         )
                     self._manual_resume_phase = phases.pop()
-                    self._position_at_manual_resume_phase()
+                    self._position_at_manual_resume_phase(active)
                     if not self.keep_original:
                         launch_cwds = {entry.get("cwd") for entry in active if entry.get("kind") in {"phase", "review"}}
                         if launch_cwds:
@@ -2401,6 +2436,12 @@ class Pipeline:
             env[PIPELINE_LOG_ENV] = str(self.pipeline_log_path)
         if self._manual_launch_cwd is not None:
             env["PWD"] = str(self._manual_launch_cwd)
+        pass_fds: tuple[int, ...] = ()
+        if self._run_lock_fd is not None:
+            env[resumelib.RUN_LOCK_FD_ENV] = str(self._run_lock_fd)
+            pass_fds = (self._run_lock_fd,)
+        else:
+            env.pop(resumelib.RUN_LOCK_FD_ENV, None)
 
         proc: subprocess.Popen[bytes] | None = None
         received: list[tuple[int, float]] = []
@@ -2425,6 +2466,7 @@ class Pipeline:
                 env=env,
                 cwd=self._manual_launch_cwd,
                 start_new_session=True,
+                pass_fds=pass_fds,
             )
             if received:
                 with contextlib.suppress(ProcessLookupError):
@@ -3183,6 +3225,17 @@ class Pipeline:
             self.run_phase4b_classification()
         else:
             log("Skipping Phase 4b (--skip-classification)")
+
+        if not self.dry_run and self.run_dir is not None:
+            try:
+                active = resumelib.active_entries(self.run_dir)
+            except resumelib.ResumeError as exc:
+                log(f"ERROR: cannot verify completed conversation state: {exc}")
+                return 1
+            if active:
+                phases = ", ".join(sorted({str(entry.get("phase")) for entry in active}))
+                log(f"ERROR: pipeline cannot complete with unfinished conversation(s) in {phases}")
+                return 1
 
         self.generate_summary()
         self.refresh_output_indexes()

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -14,6 +14,7 @@ Usage:  python3 pipelinelib.py [options] "name|github|lang|reference" [...]
 from __future__ import annotations
 
 import contextlib
+import fcntl
 import json
 import locale
 import math
@@ -21,6 +22,7 @@ import os
 import re
 import secrets
 import signal
+import stat
 import subprocess
 import sys
 import time
@@ -39,6 +41,7 @@ from typing import Any
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from specula import quota as _quota
+from specula import resumelib
 from specula.agent_config import AgentConfigError, AgentRouting, AgentSelection, load_agent_routing
 from specula.output_index import (
     INDEX_FILENAME,
@@ -153,7 +156,10 @@ Options:
                          (a single target cd's into case-studies/<name>/ when
                          it exists)
   --run-id=ID            Attach to runs/ID — reuse an existing run's workspace,
-                         e.g. to resume with --skip-* flags (implies --isolate)
+                         resuming unfinished agent conversations by default
+                         (use the original --skip-* flags; implies --isolate)
+  --fresh-context        With --run-id, abandon unfinished conversations and
+                         start the selected phases with fresh agent context
 
 Output navigation (default isolated layout):
   runs/<run-id>/
@@ -287,8 +293,12 @@ class Pipeline:
         # including "", is an explicit value forwarded for launcher validation.
         self.max_parallel: str | None = None
         self.max_turns = "0"  # deprecated verbatim passthrough
+        self._max_parallel_given = False
+        self._max_turns_given = False
         self.policy_retries = DEFAULT_POLICY_RETRIES
         self.transient_resumes = DEFAULT_TRANSIENT_RESUMES
+        self._policy_retries_given = False
+        self._transient_resumes_given = False
         self.dry_run = False
         self.skip_analysis = False
         self.skip_specgen = False
@@ -299,19 +309,26 @@ class Pipeline:
         self.skip_repair_loop = False
         self.confirm_legacy = False  # --legacy-confirm: single-agent Phase 4a instead of the default parallel
         self.confirm_debate = False  # --confirm-debate: add the adversarial Challenger (parallel mode)
+        self._confirm_legacy_given = False
+        self._confirm_debate_given = False
         # `or`: bash ${VAR:-default} treats an exported-but-empty var as unset
         self.max_repair_rounds = os.environ.get("MAX_REPAIR_ROUNDS") or "10"
+        self._max_repair_rounds_given = False
         self.skip_reviews = True
+        self._enable_reviews_given = False
         self.agent = "claude-code"
         self._agent_given = False
         self.agent_config_path: Path | None = None
         self.agent_routing: AgentRouting | None = None
         self.claude_alias = os.environ.get("CLAUDE_ALIAS") or "claude"
+        self._claude_alias_given = False
         # None means no pipeline CLI override: phase launchers may consult
         # SPECULA_MODEL / SPECULA_EFFORT.  "" is an explicit empty flag and
         # must survive into the child so it can clear those environment values.
         self.model: str | None = None
         self.effort: str | None = None
+        self._model_given = False
+        self._effort_given = False
         self.artifact = ""
         self._artifact_given = False
         self.keep_original = False
@@ -324,6 +341,7 @@ class Pipeline:
         self.quota_5h = os.environ.get("QUOTA_5H") or "85"
         self.quota_7d = os.environ.get("QUOTA_7D") or "95"
         self.quota_max_waits = os.environ.get("QUOTA_MAX_WAITS") or "6"
+        self._targets_given = False
         # workspace isolation (step 4; default since step 7d) — run_dir stays
         # None only in legacy mode (--no-isolate)
         self.isolate = True
@@ -331,6 +349,13 @@ class Pipeline:
         self._no_isolate_given = False
         self.run_id = ""
         self._run_id_given = False  # `--run-id=` (empty) must error, not mint a fresh id
+        self.fresh_context = False
+        self._attached_existing_run = False
+        self._restored_routes: dict[str, AgentSelection] | None = None
+        self._restored_default: AgentSelection | None = None
+        self._manual_resume_phase: str | None = None
+        self._manual_launch_cwd: Path | None = None
+        self._run_lock_fd: int | None = None
         self.run_dir: Path | None = None
         self.pipeline_log_path: Path | None = None
         self.tlc_scope = ""
@@ -360,12 +385,16 @@ class Pipeline:
                 self.skip_repair_loop = True
             elif arg == "--legacy-confirm":
                 self.confirm_legacy = True
+                self._confirm_legacy_given = True
             elif arg == "--confirm-debate":
                 self.confirm_debate = True
+                self._confirm_debate_given = True
             elif arg.startswith("--max-repair-rounds="):
                 self.max_repair_rounds = arg.split("=", 1)[1]
+                self._max_repair_rounds_given = True
             elif arg == "--enable-reviews":
                 self.skip_reviews = False
+                self._enable_reviews_given = True
             elif arg == "--isolate":
                 self.isolate = True
                 self._isolate_explicit = True
@@ -378,11 +407,16 @@ class Pipeline:
                 self._run_id_given = True
                 self.isolate = True  # attaching implies isolation
                 self._isolate_explicit = True
+            elif arg == "--fresh-context":
+                self.fresh_context = True
             elif arg.startswith("--max-parallel="):
                 self.max_parallel = arg.split("=", 1)[1]
+                self._max_parallel_given = True
             elif arg.startswith("--max-turns="):
                 self.max_turns = arg.split("=", 1)[1]
+                self._max_turns_given = True
             elif arg.startswith("--policy-retries="):
+                self._policy_retries_given = True
                 raw = arg.split("=", 1)[1]
                 try:
                     self.policy_retries = _parse_policy_retries(raw)
@@ -393,6 +427,7 @@ class Pipeline:
                     )
                     return 1
             elif arg.startswith("--transient-resumes="):
+                self._transient_resumes_given = True
                 raw = arg.split("=", 1)[1]
                 try:
                     self.transient_resumes = _parse_transient_resumes(raw)
@@ -420,10 +455,13 @@ class Pipeline:
                     return 1
             elif arg.startswith("--claude-alias="):
                 self.claude_alias = arg.split("=", 1)[1]
+                self._claude_alias_given = True
             elif arg.startswith("--model="):
                 self.model = arg.split("=", 1)[1]
+                self._model_given = True
             elif arg.startswith("--effort="):
                 self.effort = arg.split("=", 1)[1]
+                self._effort_given = True
             elif arg.startswith("--artifact="):
                 self.artifact = arg.split("=", 1)[1]
                 self._artifact_given = True
@@ -459,12 +497,17 @@ class Pipeline:
             except (AgentConfigError, OSError) as exc:
                 print(f"ERROR: {exc}", file=sys.stderr)
                 return 1
+        targets_given = bool(self.targets)
         if not self.targets:
             self.targets.append(_logical_cwd().name)  # bash `basename "$PWD"` (logical)
+        self._targets_given = targets_given
         # order-independent: the two are contradictory however they arrive
         # (e.g. scheduler-injected --run-id + a --no-isolate from queue flags)
         if self._run_id_given and self._no_isolate_given:
             print("ERROR: --no-isolate conflicts with --run-id", file=sys.stderr)
+            return 1
+        if self.fresh_context and not self._run_id_given:
+            print("ERROR: --fresh-context requires --run-id", file=sys.stderr)
             return 1
         if self.keep_original and not self.isolate:
             print("ERROR: --keep-original conflicts with --no-isolate", file=sys.stderr)
@@ -554,7 +597,297 @@ class Pipeline:
             if run_root == source or run_root.is_relative_to(source) or source.is_relative_to(run_root):
                 raise SnapshotError(f"run storage must be outside the source tree: {source}")
 
-    def resolve_run_dir(self) -> int | None:
+    @staticmethod
+    def _route_specs() -> dict[str, tuple[str, str | None]]:
+        return {
+            "analyze": ("analyze", None),
+            "specgen": ("specgen", None),
+            "harness": ("harness", None),
+            "validate": ("validate", None),
+            "confirm": ("confirm", None),
+            "repair": ("repair", "validate"),
+            "classify": ("classify", None),
+            "review:analysis": ("review", "analyze"),
+            "review:specgen": ("review", "specgen"),
+            "review:validation": ("review", "validate"),
+        }
+
+    def _resumable_selection(self, selection: AgentSelection) -> AgentSelection:
+        """Freeze values known at run creation while preserving explicit resets."""
+        resolved_model, resolved_effort = self._resolved_run_tuning(selection)
+        return AgentSelection(
+            agent=selection.agent,
+            model=selection.model if selection.model is not None else resolved_model,
+            effort=selection.effort if selection.effort is not None else resolved_effort,
+        )
+
+    @staticmethod
+    def _selection_document(selection: AgentSelection) -> dict[str, str | None]:
+        return {"agent": selection.agent, "model": selection.model, "effort": selection.effort}
+
+    @staticmethod
+    def _selection_from_document(value: object, label: str) -> AgentSelection:
+        if not isinstance(value, dict):
+            raise resumelib.ResumeError(f"invalid {label}: expected an object")
+        agent = value.get("agent")
+        model = value.get("model")
+        effort = value.get("effort")
+        if not isinstance(agent, str) or not agent:
+            raise resumelib.ResumeError(f"invalid {label} agent")
+        if model is not None and not isinstance(model, str):
+            raise resumelib.ResumeError(f"invalid {label} model")
+        if effort is not None and not isinstance(effort, str):
+            raise resumelib.ResumeError(f"invalid {label} effort")
+        return AgentSelection(agent=agent, model=model, effort=effort)
+
+    def _resumable_routes(self) -> dict[str, AgentSelection] | None:
+        if self.agent_routing is None and self._restored_routes is None:
+            return None
+        return {
+            route: self._resumable_selection(self._agent_selection(phase, fallback=fallback))
+            for route, (phase, fallback) in self._route_specs().items()
+        }
+
+    def _resume_configuration_document(self) -> dict[str, Any]:
+        default = self._resumable_selection(self._agent_selection())
+        routes = self._resumable_routes()
+        return {
+            "version": 1,
+            "default": self._selection_document(default),
+            "routes": (
+                {name: self._selection_document(selection) for name, selection in routes.items()}
+                if routes is not None
+                else None
+            ),
+            "agent_config": str(self.agent_config_path) if self.agent_config_path is not None else None,
+            "claude_alias": self.claude_alias,
+            "policy_retries": self.policy_retries,
+            "transient_resumes": self.transient_resumes,
+            "max_parallel": self.max_parallel,
+            "max_turns": self.max_turns,
+            "confirm_legacy": self.confirm_legacy,
+            "confirm_debate": self.confirm_debate,
+            "max_repair_rounds": self.max_repair_rounds,
+            "skip_reviews": self.skip_reviews,
+            "targets": list(self.targets),
+            "artifact": self.artifact,
+        }
+
+    def _restore_resume_configuration(self, raw: dict[str, Any], *, allow_overrides: bool = False) -> None:
+        if raw.get("version") != 1:
+            raise resumelib.ResumeError(
+                "this run was created without manual conversation checkpoints; pass --fresh-context to continue"
+            )
+        stored_default = self._selection_from_document(raw.get("default"), "resume default")
+        raw_routes = raw.get("routes")
+        stored_routes: dict[str, AgentSelection] | None = None
+        if raw_routes is not None:
+            if not isinstance(raw_routes, dict) or set(raw_routes) != set(self._route_specs()):
+                raise resumelib.ResumeError("invalid stored agent routes")
+            stored_routes = {
+                name: self._selection_from_document(value, f"stored route {name}") for name, value in raw_routes.items()
+            }
+
+        selection_overridden = (
+            self.agent_config_path is not None or self._agent_given or self._model_given or self._effort_given
+        )
+        if allow_overrides:
+            if stored_routes is not None and not selection_overridden:
+                self._restored_routes = stored_routes
+                self._restored_default = stored_default
+                stored_path = raw.get("agent_config")
+                if isinstance(stored_path, str):
+                    self.agent_config_path = Path(stored_path)
+            elif self.agent_config_path is None:
+                if not self._agent_given:
+                    self.agent = stored_default.agent
+                if not self._agent_given and not self._model_given:
+                    self.model = stored_default.model
+                if not self._agent_given and not self._effort_given:
+                    self.effort = stored_default.effort
+        elif stored_routes is None:
+            if self.agent_config_path is not None:
+                raise resumelib.ResumeError(
+                    "this run did not use --agent-config; pass --fresh-context to change agent routing"
+                )
+            if self._agent_given and self.agent != stored_default.agent:
+                raise resumelib.ResumeError(
+                    f"this run uses agent {stored_default.agent}; pass --fresh-context to use {self.agent}"
+                )
+            if self._model_given and self.model != stored_default.model:
+                raise resumelib.ResumeError(
+                    f"this run uses model {stored_default.model!r}; pass --fresh-context to change it"
+                )
+            if self._effort_given and self.effort != stored_default.effort:
+                raise resumelib.ResumeError(
+                    f"this run uses effort {stored_default.effort!r}; pass --fresh-context to change it"
+                )
+            self.agent = stored_default.agent
+            self.model = stored_default.model
+            self.effort = stored_default.effort
+        else:
+            if self._agent_given or self._model_given or self._effort_given:
+                raise resumelib.ResumeError("this run uses phase agent routing; pass --fresh-context to override it")
+            if self.agent_config_path is not None:
+                current_routes = self._resumable_routes()
+                if current_routes != stored_routes:
+                    raise resumelib.ResumeError(
+                        "--agent-config differs from this run; pass --fresh-context to change it"
+                    )
+            else:
+                self._restored_routes = stored_routes
+                self._restored_default = stored_default
+                stored_path = raw.get("agent_config")
+                if isinstance(stored_path, str):
+                    self.agent_config_path = Path(stored_path)
+
+        alias = raw.get("claude_alias")
+        if not isinstance(alias, str):
+            raise resumelib.ResumeError("invalid stored claude alias")
+        if self._claude_alias_given:
+            if not allow_overrides and self.claude_alias != alias:
+                raise resumelib.ResumeError(
+                    f"this run uses Claude profile {alias!r}; pass --fresh-context to change it"
+                )
+        else:
+            self.claude_alias = alias
+
+        confirmation_mode_overridden = self._confirm_legacy_given or self._confirm_debate_given
+        for field, given, attr in (
+            ("policy_retries", self._policy_retries_given, "policy_retries"),
+            ("transient_resumes", self._transient_resumes_given, "transient_resumes"),
+        ):
+            value = raw.get(field)
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise resumelib.ResumeError(f"invalid stored {field}")
+            if given:
+                if not allow_overrides and getattr(self, attr) != value:
+                    raise resumelib.ResumeError(
+                        f"this run uses {field.replace('_', ' ')} {value}; pass --fresh-context to change it"
+                    )
+            else:
+                setattr(self, attr, value)
+
+        stored_repair_rounds = raw.get("max_repair_rounds")
+        if not isinstance(stored_repair_rounds, str) or re.fullmatch(r"[0-9]+", stored_repair_rounds) is None:
+            raise resumelib.ResumeError("invalid stored max_repair_rounds")
+        if self._max_repair_rounds_given:
+            if not allow_overrides and self.max_repair_rounds != stored_repair_rounds:
+                raise resumelib.ResumeError(
+                    f"this run uses max repair rounds {stored_repair_rounds}; pass --fresh-context to change it"
+                )
+        else:
+            self.max_repair_rounds = stored_repair_rounds
+
+        stored_skip_reviews = raw.get("skip_reviews")
+        if not isinstance(stored_skip_reviews, bool):
+            raise resumelib.ResumeError("invalid stored skip_reviews")
+        if self._enable_reviews_given:
+            if not allow_overrides and self.skip_reviews != stored_skip_reviews:
+                raise resumelib.ResumeError("this run uses a different review mode; pass --fresh-context to change it")
+        else:
+            self.skip_reviews = stored_skip_reviews
+
+        stored_max_parallel = raw.get("max_parallel")
+        if stored_max_parallel is not None and not isinstance(stored_max_parallel, str):
+            raise resumelib.ResumeError("invalid stored max_parallel")
+        if self._max_parallel_given:
+            if not allow_overrides and self.max_parallel != stored_max_parallel:
+                raise resumelib.ResumeError(
+                    f"this run uses max parallel {stored_max_parallel!r}; pass --fresh-context to change it"
+                )
+        else:
+            self.max_parallel = stored_max_parallel
+
+        stored_max_turns = raw.get("max_turns")
+        if not isinstance(stored_max_turns, str):
+            raise resumelib.ResumeError("invalid stored max_turns")
+        if self._max_turns_given:
+            if not allow_overrides and self.max_turns != stored_max_turns:
+                raise resumelib.ResumeError(
+                    f"this run uses max turns {stored_max_turns!r}; pass --fresh-context to change it"
+                )
+        else:
+            self.max_turns = stored_max_turns
+
+        for field, given, attr in (
+            ("confirm_legacy", self._confirm_legacy_given, "confirm_legacy"),
+            ("confirm_debate", self._confirm_debate_given, "confirm_debate"),
+        ):
+            value = raw.get(field)
+            if not isinstance(value, bool):
+                raise resumelib.ResumeError(f"invalid stored {field}")
+            if given:
+                if not allow_overrides and getattr(self, attr) != value:
+                    raise resumelib.ResumeError(
+                        f"this run uses {field.replace('_', ' ')}={value}; pass --fresh-context to change it"
+                    )
+            elif not (allow_overrides and confirmation_mode_overridden):
+                setattr(self, attr, value)
+        if self.confirm_legacy and self.confirm_debate:
+            raise resumelib.ResumeError("invalid stored confirmation mode")
+
+        stored_targets = raw.get("targets")
+        if (
+            not isinstance(stored_targets, list)
+            or not stored_targets
+            or not all(isinstance(target, str) for target in stored_targets)
+        ):
+            raise resumelib.ResumeError("invalid stored targets")
+        if self._targets_given:
+            if not allow_overrides and self.targets != stored_targets:
+                raise resumelib.ResumeError("targets differ from this run; pass --fresh-context to change them")
+        else:
+            self.targets = list(stored_targets)
+
+        stored_artifact = raw.get("artifact")
+        if not isinstance(stored_artifact, str):
+            raise resumelib.ResumeError("invalid stored artifact")
+        if self._artifact_given:
+            if not allow_overrides and (
+                not stored_artifact or Path(self.artifact).resolve() != Path(stored_artifact).resolve()
+            ):
+                raise resumelib.ResumeError(
+                    "--artifact differs from this run; pass --fresh-context to use another source"
+                )
+        elif stored_artifact and not self.keep_original:
+            artifact = _normalize_artifact_dir(stored_artifact)
+            if artifact is None:
+                raise resumelib.ResumeError(f"this run's artifact is unavailable: {stored_artifact}")
+            self.artifact = artifact
+            self._artifact_given = True
+
+    def _acquire_run_lock(self) -> None:
+        if self.run_dir is None or self._run_lock_fd is not None:
+            return
+        resumelib.ensure_storage(self.run_dir)
+        lock_path = resumelib.resume_dir(self.run_dir) / "run.lock"
+        flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            fd = os.open(lock_path, flags, 0o600)
+        except OSError as exc:
+            raise resumelib.ResumeError(f"cannot open safe run lock {lock_path}: {exc}") from exc
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            os.close(fd)
+            raise resumelib.ResumeError(f"run lock is not a regular file: {lock_path}")
+        os.set_inheritable(fd, False)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            os.close(fd)
+            raise resumelib.ResumeError(f"run {self.run_id} is already active") from exc
+        self._run_lock_fd = fd
+
+    def _release_run_lock(self) -> None:
+        if self._run_lock_fd is None:
+            return
+        with contextlib.suppress(OSError):
+            fcntl.flock(self._run_lock_fd, fcntl.LOCK_UN)
+        with contextlib.suppress(OSError):
+            os.close(self._run_lock_fd)
+        self._run_lock_fd = None
+
+    def resolve_run_dir(self, *, acquire_lock: bool = False) -> int | None:
         """Establish the per-run root. Returns an exit code for an invalid
         --run-id (pre-tee, like the option errors), None to proceed.
 
@@ -589,12 +922,44 @@ class Pipeline:
                 self.run_id = generate_run_id()
             self.run_dir = SPECULA_ROOT / "runs" / self.run_id
 
+        run_preexisting = self.run_dir.exists()
+        locked_here = False
+
+        def fail(code: int = 1) -> int:
+            if locked_here:
+                self._release_run_lock()
+            return code
+
+        if run_preexisting:
+            try:
+                run_info = self.run_dir.lstat()
+                if not stat.S_ISDIR(run_info.st_mode):
+                    raise resumelib.ResumeError(f"run directory is not a real directory: {self.run_dir}")
+            except (OSError, resumelib.ResumeError) as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return 1
+        if acquire_lock:
+            try:
+                self.run_dir.mkdir(parents=True, exist_ok=True)
+                run_info = self.run_dir.lstat()
+                if not stat.S_ISDIR(run_info.st_mode):
+                    raise resumelib.ResumeError(f"run directory is not a real directory: {self.run_dir}")
+                self._acquire_run_lock()
+                locked_here = True
+            except (OSError, resumelib.ResumeError) as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return 1
+        os.environ[resumelib.INVOCATION_ENV] = secrets.token_hex(16)
+        os.environ.pop(resumelib.MANUAL_ENV, None)
+        os.environ.pop(resumelib.FRESH_ENV, None)
         fallback_artifact = ""
         meta_file = self.run_dir / "run.json"
+        metadata: dict[str, Any] | None = None
         if meta_file.is_file():
             with contextlib.suppress(OSError, UnicodeError, json.JSONDecodeError):
                 meta = json.loads(meta_file.read_text())
                 if isinstance(meta, dict):
+                    metadata = meta
                     mode = meta.get("source_mode", "in-place")
                     if mode == "snapshot":
                         self.keep_original = True
@@ -603,10 +968,66 @@ class Pipeline:
                             "ERROR: --keep-original cannot be enabled when resuming an in-place run",
                             file=sys.stderr,
                         )
-                        return 1
+                        return fail()
                     stored_artifact = meta.get("artifact")
                     if isinstance(stored_artifact, str):
                         fallback_artifact = stored_artifact
+
+        if self._run_id_given and run_preexisting:
+            self._attached_existing_run = True
+            try:
+                if self.fresh_context:
+                    resumelib.initialize_run(self.run_dir, reset=True)
+                    try:
+                        stored_configuration = resumelib.load_configuration(self.run_dir)
+                    except resumelib.ResumeError:
+                        # Runs created before checkpoints have no configuration to
+                        # restore. The fresh invocation becomes their baseline.
+                        pass
+                    else:
+                        self._restore_resume_configuration(stored_configuration, allow_overrides=True)
+                    os.environ[resumelib.FRESH_ENV] = "1"
+                else:
+                    resumelib.require_supported_run(self.run_dir)
+                    if metadata is None:
+                        raise resumelib.ResumeError(f"cannot read run metadata from {meta_file}")
+                    self._restore_resume_configuration(resumelib.load_configuration(self.run_dir))
+                    active = resumelib.active_entries(self.run_dir)
+                    if not active:
+                        raise resumelib.ResumeError(
+                            "this run has no unfinished agent conversation; pass --fresh-context to start over"
+                        )
+                    phases = {str(entry.get("phase")) for entry in active}
+                    if len(phases) != 1:
+                        raise resumelib.ResumeError(
+                            "unfinished conversations span multiple phases; pass --fresh-context to start over"
+                        )
+                    self._manual_resume_phase = phases.pop()
+                    if not self.keep_original:
+                        launch_cwds = {entry.get("cwd") for entry in active if entry.get("kind") in {"phase", "review"}}
+                        if launch_cwds:
+                            raw_launch_cwd = next(iter(launch_cwds))
+                            if len(launch_cwds) != 1 or not isinstance(raw_launch_cwd, str):
+                                raise resumelib.ResumeError(
+                                    "unfinished conversations do not share one safe launch directory; "
+                                    "pass --fresh-context to start over"
+                                )
+                            launch_cwd = Path(raw_launch_cwd)
+                            try:
+                                launch_info = launch_cwd.lstat()
+                            except OSError as exc:
+                                raise resumelib.ResumeError(
+                                    f"recorded agent launch directory is unavailable: {launch_cwd}"
+                                ) from exc
+                            if not stat.S_ISDIR(launch_info.st_mode):
+                                raise resumelib.ResumeError(
+                                    f"recorded agent launch directory is not safe: {launch_cwd}"
+                                )
+                            self._manual_launch_cwd = launch_cwd
+                    os.environ[resumelib.MANUAL_ENV] = "1"
+            except resumelib.ResumeError as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return fail()
 
         source_map = self.run_dir / SOURCE_MAP
         if source_map.exists() or source_map.is_symlink():
@@ -614,7 +1035,7 @@ class Pipeline:
                 snapshots = load_sources(self.run_dir)
             except SnapshotError as exc:
                 print(f"ERROR: cannot restore private source: {exc}", file=sys.stderr)
-                return 1
+                return fail()
             self.keep_original = True
             self._snapshot_sources = {name: item.original for name, item in snapshots.items()}
             self._snapshot_paths = [item.source for item in snapshots.values()]
@@ -622,21 +1043,30 @@ class Pipeline:
                 source != Path(self.artifact).resolve() for source in self._snapshot_sources.values()
             ):
                 print("ERROR: --artifact differs from this run's private source", file=sys.stderr)
-                return 1
+                return fail()
         elif self.keep_original:
             try:
                 self._snapshot_sources = self._resolve_snapshot_sources(fallback_artifact)
             except SnapshotError as exc:
                 print(f"ERROR: cannot prepare private source: {exc}", file=sys.stderr)
-                return 1
+                return fail()
         if self.keep_original:
             try:
                 self._check_snapshot_overlap()
             except SnapshotError as exc:
                 print(f"ERROR: {exc}", file=sys.stderr)
-                return 1
+                return fail()
 
         self.run_dir.mkdir(parents=True, exist_ok=True)
+        if not stat.S_ISDIR(self.run_dir.lstat().st_mode):
+            print(f"ERROR: run directory is not a real directory: {self.run_dir}", file=sys.stderr)
+            return fail()
+        if not self._attached_existing_run:
+            try:
+                resumelib.initialize_run(self.run_dir)
+            except resumelib.ResumeError as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return fail()
         os.environ["SPECULA_RUN_DIR"] = str(self.run_dir)  # phase subprocesses inherit
         if self.keep_original:
             os.environ[SNAPSHOT_MODE_ENV] = "1"
@@ -646,8 +1076,14 @@ class Pipeline:
         os.environ[SCOPE_ENV] = self.tlc_scope
         resource_rc = self._restore_run_resource_config()
         if resource_rc is not None:
-            return resource_rc
+            return fail(resource_rc)
         self._write_run_meta()
+        if not self._attached_existing_run or self.fresh_context:
+            try:
+                resumelib.save_configuration(self.run_dir, self._resume_configuration_document())
+            except resumelib.ResumeError as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return fail()
         if not attached_ambient:
             # runs/latest -> <run-id>; symlink+rename so readers never see a gap
             with contextlib.suppress(OSError):
@@ -774,6 +1210,7 @@ class Pipeline:
                     artifact_sha = lines[1]
         default_selection = self._agent_selection()
         model, effort = self._resolved_run_tuning(default_selection)
+        resume_configuration = self._resume_configuration_document()
         meta: dict[str, object] = {
             "run_id": self.run_id,
             "created": _date_iseconds(),
@@ -789,23 +1226,12 @@ class Pipeline:
             "artifact_git_sha": artifact_sha,
             "tlc_memory_limit": self.tlc_memory_limit or os.environ.get(MEMORY_LIMIT_ENV) or "auto",
             "tlc_worker_limit": self.tlc_worker_limit or os.environ.get(WORKER_LIMIT_ENV) or None,
+            "resume_configuration": resume_configuration,
         }
         if self.agent_routing is not None:
             assert self.agent_config_path is not None
-            route_specs: dict[str, tuple[str, str | None]] = {
-                "analyze": ("analyze", None),
-                "specgen": ("specgen", None),
-                "harness": ("harness", None),
-                "validate": ("validate", None),
-                "confirm": ("confirm", None),
-                "repair": ("repair", "validate"),
-                "classify": ("classify", None),
-                "review:analysis": ("review", "analyze"),
-                "review:specgen": ("review", "specgen"),
-                "review:validation": ("review", "validate"),
-            }
             routes: dict[str, dict[str, str | None]] = {}
-            for route_name, (phase, fallback) in route_specs.items():
+            for route_name, (phase, fallback) in self._route_specs().items():
                 selection = self._agent_selection(phase, fallback=fallback)
                 route_model, route_effort = self._resolved_run_tuning(selection)
                 routes[route_name] = {
@@ -822,6 +1248,12 @@ class Pipeline:
             meta_file.write_text(json.dumps(meta, indent=2) + "\n")
 
     def _agent_selection(self, phase: str | None = None, *, fallback: str | None = None) -> AgentSelection:
+        if self._restored_routes is not None:
+            if phase is None:
+                assert self._restored_default is not None
+                return self._restored_default
+            route = f"review:{fallback}" if phase == "review" and fallback is not None else phase
+            return self._restored_routes[route]
         if self.agent_routing is None:
             return AgentSelection(agent=self.agent, model=self.model, effort=self.effort)
         if phase is None:
@@ -894,7 +1326,9 @@ class Pipeline:
 
     def validate_agent_adapter(self) -> None:
         agents = {self.agent}
-        if self.agent_routing is not None:
+        if self._restored_routes is not None:
+            agents = {selection.agent for selection in self._restored_routes.values()}
+        elif self.agent_routing is not None:
             agents = {selection.agent for selection in self.agent_routing.profiles.values()}
         for agent in sorted(agents):
             adapter = LAUNCH_DIR / "adapters" / f"{agent}.sh"
@@ -1936,6 +2370,8 @@ class Pipeline:
             env[SCOPE_ENV] = self.tlc_scope
         if self.pipeline_log_path is not None:
             env[PIPELINE_LOG_ENV] = str(self.pipeline_log_path)
+        if self._manual_launch_cwd is not None:
+            env["PWD"] = str(self._manual_launch_cwd)
 
         proc: subprocess.Popen[bytes] | None = None
         received: list[tuple[int, float]] = []
@@ -1958,6 +2394,7 @@ class Pipeline:
             proc = subprocess.Popen(
                 ["bash", str(LAUNCH_DIR / script), *args],
                 env=env,
+                cwd=self._manual_launch_cwd,
                 start_new_session=True,
             )
             if received:
@@ -2019,8 +2456,8 @@ class Pipeline:
             self._phase_args(self.targets, phase="analyze"),
         )
 
-    def run_review(self, phase: str, names: list[str]) -> None:
-        if self.skip_reviews:
+    def run_review(self, phase: str, names: list[str], *, force: bool = False) -> None:
+        if self.skip_reviews and not force:
             log(f"Skipping {phase} review (--skip-reviews)")
             return
         # launch_review.sh's contract is `<phase> <name...>`: it reads the phase
@@ -2036,7 +2473,7 @@ class Pipeline:
             "validation": "validate",
         }[phase]
         selection = self._agent_selection("review", fallback=fallback)
-        if self.agent_routing is not None:
+        if self.agent_routing is not None or self._restored_routes is not None:
             self.wait_for_phase_quota("review", fallback=fallback)
         args = [
             phase,
@@ -2611,6 +3048,15 @@ class Pipeline:
 
         start_time = int(time.time())
 
+        if self._manual_resume_phase is not None and self._manual_resume_phase.startswith("review:"):
+            review_phase = self._manual_resume_phase.split(":", 1)[1]
+            if review_phase not in {"analysis", "specgen", "validation"}:
+                log(f"ERROR: invalid interrupted review phase {review_phase!r}")
+                raise SystemExit(1)
+            log(f"Restoring interrupted {review_phase} review before continuing the pipeline")
+            self.run_review(review_phase, names, force=True)
+            self._manual_resume_phase = None
+
         # Recover before Phase 1/2/2.5 can mutate the artifacts that the
         # snapshot token commits. Skip flags control later work, never whether
         # durable crash state is reconciled.
@@ -2731,7 +3177,7 @@ def main(argv: list[str]) -> int:
         # --help / unknown option exit before the tee starts, like the bash
         # top-level parse: no .specula-output/, no pipeline.log.
         return rc
-    rc = p.resolve_run_dir()
+    rc = p.resolve_run_dir(acquire_lock=True)
     if rc is not None:
         return rc  # invalid --run-id: pre-tee exit, like the option errors
 
@@ -2807,6 +3253,7 @@ def main(argv: list[str]) -> int:
         finally:
             with contextlib.suppress(OSError, UnicodeError):
                 terminal_stdout.close()
+            p._release_run_lock()
     return code
 
 

--- a/src/specula/resumelib.py
+++ b/src/specula/resumelib.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .adapters.utils import run_lock as adapter_run_lock
+
 RESUME_DIRNAME = ".specula-resume"
 CONFIG_FILENAME = "config.json"
 ACTIVE_DIRNAME = "active"
@@ -33,7 +35,7 @@ SCHEMA_VERSION = 1
 INVOCATION_ENV = "SPECULA_INVOCATION_ID"
 MANUAL_ENV = "SPECULA_MANUAL_RESUME"
 FRESH_ENV = "SPECULA_FRESH_CONTEXT"
-RUN_LOCK_FD_ENV = "SPECULA_RUN_LOCK_FD"
+RUN_LOCK_FD_ENV = adapter_run_lock.RUN_LOCK_FD_ENV
 
 
 class ResumeError(RuntimeError):
@@ -141,17 +143,10 @@ def _clear_native_state(path: Path) -> None:
 
 def inherited_run_lock_fds() -> tuple[int, ...]:
     """Return the validated run-lock lease inherited from the dispatcher."""
-    raw = os.environ.get(RUN_LOCK_FD_ENV)
-    if raw is None:
-        return ()
     try:
-        fd = int(raw)
-        info = os.fstat(fd)
-    except (OSError, ValueError) as exc:
-        raise ResumeError("inherited Specula run lock is unavailable") from exc
-    if fd < 3 or not stat.S_ISREG(info.st_mode):
-        raise ResumeError("inherited Specula run lock is invalid")
-    return (fd,)
+        return adapter_run_lock.inherited_run_lock_fds()
+    except adapter_run_lock.RunLockError as exc:
+        raise ResumeError(str(exc)) from exc
 
 
 def _read_object(path: Path, label: str) -> dict[str, Any]:

--- a/src/specula/resumelib.py
+++ b/src/specula/resumelib.py
@@ -1,0 +1,563 @@
+"""Durable ownership for unfinished agent conversations in an isolated run.
+
+Native ``*.resume.json`` files bind an adapter invocation to an exact provider
+session.  They intentionally outlive successful calls, so they cannot also say
+whether a logical turn is unfinished.  This module supplies that lifecycle bit:
+one active record per resumable call and a short-lived accepted-call marker so
+a partially completed multi-target phase does not repeat finished work.
+
+The owning phase removes accepted markers when the whole phase settles.  No
+general pipeline cursor or scheduler state is persisted here.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import stat
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+RESUME_DIRNAME = ".specula-resume"
+CONFIG_FILENAME = "config.json"
+ACTIVE_DIRNAME = "active"
+COMPLETED_DIRNAME = "completed"
+SCHEMA_VERSION = 1
+
+INVOCATION_ENV = "SPECULA_INVOCATION_ID"
+MANUAL_ENV = "SPECULA_MANUAL_RESUME"
+FRESH_ENV = "SPECULA_FRESH_CONTEXT"
+
+
+class ResumeError(RuntimeError):
+    """A manual resume cannot safely continue the recorded conversation."""
+
+
+@dataclass(frozen=True)
+class ResumeClaim:
+    """Result of claiming one logical turn for an adapter invocation."""
+
+    attempt: int
+    manual: bool
+    resumable: bool
+    rate_limit_attempt: int = 1
+    policy_attempt: int = 0
+    transient_attempt: int = 0
+    invocation_attempt: int = 0
+    retry_reason: str = "fresh"
+
+
+_lock = threading.RLock()
+
+
+def _run_dir() -> Path | None:
+    raw = os.environ.get("SPECULA_RUN_DIR")
+    return Path(raw).expanduser().absolute() if raw else None
+
+
+def resume_dir(run_dir: Path) -> Path:
+    return run_dir / RESUME_DIRNAME
+
+
+def config_path(run_dir: Path) -> Path:
+    return resume_dir(run_dir) / CONFIG_FILENAME
+
+
+def active_dir(run_dir: Path) -> Path:
+    return resume_dir(run_dir) / ACTIVE_DIRNAME
+
+
+def completed_dir(run_dir: Path) -> Path:
+    return resume_dir(run_dir) / COMPLETED_DIRNAME
+
+
+def _require_directory(path: Path, label: str) -> None:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise ResumeError(f"cannot inspect {label} {path}: {exc}") from exc
+    if not stat.S_ISDIR(info.st_mode):
+        raise ResumeError(f"{label} is not a real directory: {path}")
+
+
+def ensure_storage(run_dir: Path) -> None:
+    """Create and verify the dispatcher-owned resume directories."""
+    root = resume_dir(run_dir)
+    try:
+        root.mkdir(mode=0o700, parents=False, exist_ok=True)
+    except OSError as exc:
+        raise ResumeError(f"cannot create resume directory {root}: {exc}") from exc
+    _require_directory(root, "resume directory")
+    for path, label in (
+        (active_dir(run_dir), "active conversation directory"),
+        (completed_dir(run_dir), "completed call directory"),
+    ):
+        try:
+            path.mkdir(mode=0o700, exist_ok=True)
+        except OSError as exc:
+            raise ResumeError(f"cannot create {label} {path}: {exc}") from exc
+        _require_directory(path, label)
+
+
+def _atomic_write(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(data, indent=2, sort_keys=True) + "\n"
+    fd, raw_tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    tmp = Path(raw_tmp)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(tmp, path)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            tmp.unlink()
+
+
+def _read_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        info = path.lstat()
+        if not stat.S_ISREG(info.st_mode):
+            raise ResumeError(f"{label} is not a regular file: {path}")
+        value: object = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise ResumeError(f"missing {label}: {path}") from exc
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ResumeError(f"cannot read {label} {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ResumeError(f"invalid {label}: expected a JSON object in {path}")
+    return value
+
+
+def initialize_run(run_dir: Path, *, reset: bool = False) -> None:
+    """Create the version marker, optionally abandoning all unfinished turns."""
+    with _lock:
+        ensure_storage(run_dir)
+        marker = config_path(run_dir)
+        if marker.exists() or marker.is_symlink():
+            data = _read_object(marker, "resume config")
+            if data.get("version") != SCHEMA_VERSION:
+                raise ResumeError(f"unsupported resume config version in {marker}")
+        else:
+            _atomic_write(marker, {"version": SCHEMA_VERSION})
+        if reset:
+            for directory in (active_dir(run_dir), completed_dir(run_dir)):
+                for path in directory.iterdir():
+                    if path.name.endswith(".json") or path.is_symlink():
+                        try:
+                            path.unlink()
+                        except OSError as exc:
+                            raise ResumeError(f"cannot abandon saved agent state {path}: {exc}") from exc
+
+
+def require_supported_run(run_dir: Path) -> None:
+    data = _read_object(config_path(run_dir), "resume config")
+    if data.get("version") != SCHEMA_VERSION:
+        raise ResumeError(f"unsupported resume config version in {config_path(run_dir)}")
+    if not isinstance(data.get("configuration"), dict):
+        raise ResumeError(
+            "this run was created without manual conversation checkpoints; pass --fresh-context to continue"
+        )
+
+
+def save_configuration(run_dir: Path, configuration: dict[str, Any]) -> None:
+    with _lock:
+        marker = _read_object(config_path(run_dir), "resume config")
+        if marker.get("version") != SCHEMA_VERSION:
+            raise ResumeError(f"unsupported resume config version in {config_path(run_dir)}")
+        marker["configuration"] = configuration
+        _atomic_write(config_path(run_dir), marker)
+
+
+def load_configuration(run_dir: Path) -> dict[str, Any]:
+    marker = _read_object(config_path(run_dir), "resume config")
+    if marker.get("version") != SCHEMA_VERSION or not isinstance(marker.get("configuration"), dict):
+        raise ResumeError(f"invalid resume configuration in {config_path(run_dir)}")
+    return dict(marker["configuration"])
+
+
+def _logical_id(logical: tuple[str, ...]) -> str:
+    encoded = json.dumps(list(logical), ensure_ascii=False, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _entry_path(run_dir: Path, logical: tuple[str, ...]) -> Path:
+    return active_dir(run_dir) / f"{_logical_id(logical)}.json"
+
+
+def _binding(
+    *,
+    phase: str,
+    target: str,
+    kind: str,
+    adapter: Path,
+    model: str | None,
+    effort: str | None,
+    claude_alias: str,
+    cwd: Path | None,
+    resume_state: Path,
+    prompt_file: Path,
+    log_file: Path,
+    finding_id: str | None,
+) -> dict[str, Any]:
+    return {
+        "phase": phase,
+        "target": target,
+        "kind": kind,
+        "finding_id": finding_id,
+        "adapter": adapter.stem,
+        "model": model,
+        "effort": effort,
+        "claude_alias": claude_alias,
+        "cwd": str(cwd.absolute()) if cwd is not None else None,
+        "resume_state": str(resume_state.absolute()),
+        "prompt_file": str(prompt_file.absolute()),
+        "log_file": str(log_file.absolute()),
+    }
+
+
+def enabled() -> bool:
+    run_dir = _run_dir()
+    if run_dir is None or not os.environ.get(INVOCATION_ENV):
+        return False
+    root = resume_dir(run_dir)
+    if not root.exists() and not root.is_symlink():
+        return False
+    ensure_storage(run_dir)
+    try:
+        info = config_path(run_dir).lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise ResumeError(f"cannot inspect resume config {config_path(run_dir)}: {exc}") from exc
+    if not stat.S_ISREG(info.st_mode):
+        raise ResumeError(f"resume config is not a regular file: {config_path(run_dir)}")
+    return True
+
+
+def manual_mode() -> bool:
+    return enabled() and os.environ.get(MANUAL_ENV) == "1"
+
+
+def fresh_mode() -> bool:
+    return enabled() and os.environ.get(FRESH_ENV) == "1"
+
+
+def _validate_entry(entry: dict[str, Any], path: Path, label: str) -> None:
+    logical = entry.get("logical")
+    if (
+        entry.get("version") != SCHEMA_VERSION
+        or not isinstance(logical, list)
+        or not logical
+        or not all(isinstance(part, str) and part for part in logical)
+    ):
+        raise ResumeError(f"invalid {label} record: {path}")
+    for field in ("phase", "target", "kind", "adapter", "claude_alias", "resume_state", "prompt_file", "log_file"):
+        if not isinstance(entry.get(field), str) or not entry[field]:
+            raise ResumeError(f"invalid {label} {field} in {path}")
+    for field in ("model", "effort", "cwd", "finding_id"):
+        if entry.get(field) is not None and not isinstance(entry[field], str):
+            raise ResumeError(f"invalid {label} {field} in {path}")
+    if not isinstance(entry.get("owner"), str) or not entry["owner"]:
+        raise ResumeError(f"invalid {label} owner in {path}")
+    for field in ("attempt", "started_ns", "updated_ns"):
+        value = entry.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ResumeError(f"invalid {label} {field} in {path}")
+    for field, minimum in (
+        ("rate_limit_attempt", 1),
+        ("policy_attempt", 0),
+        ("transient_attempt", 0),
+        ("invocation_attempt", 0),
+    ):
+        value = entry.get(field, minimum)
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            raise ResumeError(f"invalid {label} {field} in {path}")
+    retry_reason = entry.get("retry_reason", "fresh")
+    if retry_reason not in {"fresh", "manual", "policy", "transient", "rate_limit"}:
+        raise ResumeError(f"invalid {label} retry_reason in {path}")
+
+
+def _claim(entry: dict[str, Any], *, attempt: int, manual: bool, resumable: bool) -> ResumeClaim:
+    return ResumeClaim(
+        attempt=attempt,
+        manual=manual,
+        resumable=resumable,
+        rate_limit_attempt=entry.get("rate_limit_attempt", 1),
+        policy_attempt=entry.get("policy_attempt", 0),
+        transient_attempt=entry.get("transient_attempt", 0),
+        invocation_attempt=entry.get("invocation_attempt", 0),
+        retry_reason=entry.get("retry_reason", "fresh"),
+    )
+
+
+def _entries(directory: Path, label: str) -> list[dict[str, Any]]:
+    _require_directory(directory, f"{label} directory")
+    entries: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        entry = _read_object(path, label)
+        _validate_entry(entry, path, label)
+        logical = tuple(entry["logical"])
+        if path.name != f"{_logical_id(logical)}.json":
+            raise ResumeError(f"invalid {label} filename for {logical!r}: {path}")
+        entry["_path"] = str(path)
+        entries.append(entry)
+    return sorted(entries, key=lambda item: (item["started_ns"], str(item["_path"])))
+
+
+def active_entries(run_dir: Path | None = None) -> list[dict[str, Any]]:
+    root = run_dir or _run_dir()
+    if root is None:
+        return []
+    storage = resume_dir(root)
+    if not storage.exists() and not storage.is_symlink():
+        return []
+    with _lock:
+        ensure_storage(root)
+        return _entries(active_dir(root), "active conversation")
+
+
+def completed_entries(run_dir: Path | None = None) -> list[dict[str, Any]]:
+    root = run_dir or _run_dir()
+    if root is None:
+        return []
+    storage = resume_dir(root)
+    if not storage.exists() and not storage.is_symlink():
+        return []
+    with _lock:
+        ensure_storage(root)
+        return _entries(completed_dir(root), "completed call")
+
+
+def unfinished_entries(*, phase: str | None = None, target: str | None = None) -> list[dict[str, Any]]:
+    entries = active_entries()
+    if phase is not None:
+        entries = [entry for entry in entries if entry.get("phase") == phase]
+    if target is not None:
+        entries = [entry for entry in entries if entry.get("target") == target]
+    return entries
+
+
+def previous_entries(*, phase: str | None = None, target: str | None = None) -> list[dict[str, Any]]:
+    invocation = os.environ.get(INVOCATION_ENV)
+    return [entry for entry in unfinished_entries(phase=phase, target=target) if entry.get("owner") != invocation]
+
+
+def ensure_phase(phase: str) -> None:
+    """Refuse to start a different phase while an old conversation is pending."""
+    if not manual_mode():
+        return
+    old = previous_entries()
+    if not old:
+        return
+    phases = {str(entry.get("phase")) for entry in old}
+    if phases != {phase}:
+        waiting = ", ".join(sorted(phases))
+        raise ResumeError(
+            f"this run has unfinished conversation(s) in {waiting}; "
+            "use the original --skip-* flags to reach that phase, or pass --fresh-context"
+        )
+
+
+def prepare_turn(
+    logical: tuple[str, ...],
+    *,
+    phase: str,
+    target: str,
+    kind: str,
+    adapter: Path,
+    model: str | None,
+    effort: str | None,
+    claude_alias: str,
+    cwd: Path | None,
+    resume_state: Path,
+    prompt_file: Path,
+    log_file: Path,
+    finding_id: str | None = None,
+) -> ResumeClaim:
+    """Register a fresh turn or claim its exact unfinished predecessor."""
+    if not enabled():
+        return ResumeClaim(attempt=1, manual=False, resumable=False)
+    run_dir = _run_dir()
+    assert run_dir is not None
+    invocation = os.environ[INVOCATION_ENV]
+    path = _entry_path(run_dir, logical)
+    expected = _binding(
+        phase=phase,
+        target=target,
+        kind=kind,
+        adapter=adapter,
+        model=model,
+        effort=effort,
+        claude_alias=claude_alias,
+        cwd=cwd,
+        resume_state=resume_state,
+        prompt_file=prompt_file,
+        log_file=log_file,
+        finding_id=finding_id,
+    )
+    with _lock:
+        if path.exists() or path.is_symlink():
+            entry = _read_object(path, "active conversation")
+            if entry.get("version") != SCHEMA_VERSION or entry.get("logical") != list(logical):
+                raise ResumeError(f"active conversation identity mismatch in {path}")
+            for field, value in expected.items():
+                if entry.get(field) != value:
+                    raise ResumeError(
+                        f"cannot resume {target} {phase}: recorded {field}={entry.get(field)!r}, "
+                        f"current value is {value!r}; pass --fresh-context to start over"
+                    )
+            previous_owner = entry.get("owner")
+            manual = previous_owner != invocation
+            if manual and not manual_mode():
+                raise ResumeError(f"unfinished conversation {logical!r} requires specula run --run-id")
+            if manual:
+                try:
+                    state_info = resume_state.lstat()
+                except OSError as exc:
+                    raise ResumeError(
+                        f"cannot resume {target} {phase}: native session state is unavailable at {resume_state}; "
+                        "pass --fresh-context to start over"
+                    ) from exc
+                if not stat.S_ISREG(state_info.st_mode):
+                    raise ResumeError(f"unsafe native session state for {target} {phase}: {resume_state}")
+            _validate_entry(entry, path, "active conversation")
+            attempt = entry["attempt"] + 1
+            entry.update(expected)
+            entry.update({"owner": invocation, "attempt": attempt, "updated_ns": time.time_ns()})
+            _atomic_write(path, entry)
+            return _claim(
+                entry,
+                attempt=attempt,
+                manual=manual,
+                resumable=resume_state.is_file(),
+            )
+
+        for entry in active_entries(run_dir):
+            if entry.get("resume_state") == expected["resume_state"]:
+                raise ResumeError(
+                    f"native session state path already belongs to unfinished conversation {entry['logical']!r}"
+                )
+        now = time.time_ns()
+        entry = {
+            "version": SCHEMA_VERSION,
+            "logical": list(logical),
+            **expected,
+            "owner": invocation,
+            "attempt": 1,
+            "started_ns": now,
+            "updated_ns": now,
+        }
+        _atomic_write(path, entry)
+        return ResumeClaim(attempt=1, manual=False, resumable=False)
+
+
+def update_turn(logical: tuple[str, ...], **updates: Any) -> None:
+    if not enabled():
+        return
+    run_dir = _run_dir()
+    assert run_dir is not None
+    path = _entry_path(run_dir, logical)
+    with _lock:
+        allowed = {
+            "rate_limit_attempt",
+            "policy_attempt",
+            "transient_attempt",
+            "invocation_attempt",
+            "retry_reason",
+        }
+        if set(updates) - allowed:
+            raise ResumeError(f"unsupported conversation cursor update for {logical!r}")
+        entry = _read_object(path, "active conversation")
+        if entry.get("logical") != list(logical):
+            raise ResumeError(f"active conversation identity mismatch in {path}")
+        entry.update(updates)
+        entry["updated_ns"] = time.time_ns()
+        _validate_entry(entry, path, "active conversation")
+        _atomic_write(path, entry)
+
+
+def complete_turn(logical: tuple[str, ...]) -> None:
+    if not enabled():
+        return
+    run_dir = _run_dir()
+    assert run_dir is not None
+    path = _entry_path(run_dir, logical)
+    with _lock:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            raise ResumeError(f"cannot complete conversation {logical!r}: {exc}") from exc
+
+
+def mark_completed(logical: tuple[str, ...]) -> None:
+    """Remember an accepted call so a partial multi-target resume skips it."""
+    if not enabled():
+        return
+    run_dir = _run_dir()
+    assert run_dir is not None
+    active_path = _entry_path(run_dir, logical)
+    done_path = completed_dir(run_dir) / active_path.name
+    with _lock:
+        if active_path.exists() or active_path.is_symlink():
+            entry = _read_object(active_path, "active conversation")
+            _validate_entry(entry, active_path, "active conversation")
+            if entry["logical"] != list(logical):
+                raise ResumeError(f"active conversation identity mismatch in {active_path}")
+            entry["updated_ns"] = time.time_ns()
+            _atomic_write(done_path, entry)
+            try:
+                active_path.unlink()
+            except OSError as exc:
+                raise ResumeError(f"cannot complete call {logical!r}: {exc}") from exc
+            return
+        if done_path.exists() or done_path.is_symlink():
+            entry = _read_object(done_path, "completed call")
+            _validate_entry(entry, done_path, "completed call")
+            if entry["logical"] != list(logical):
+                raise ResumeError(f"completed call identity mismatch in {done_path}")
+            return
+        raise ResumeError(f"missing active conversation for accepted call {logical!r}")
+
+
+def completed_logicals(prefix: tuple[str, ...] = ()) -> set[tuple[str, ...]]:
+    result: set[tuple[str, ...]] = set()
+    for entry in completed_entries():
+        logical = tuple(str(part) for part in entry["logical"])
+        if logical[: len(prefix)] == prefix:
+            result.add(logical)
+    return result
+
+
+def clear_completed(prefix: tuple[str, ...] = ()) -> None:
+    for logical in completed_logicals(prefix):
+        run_dir = _run_dir()
+        if run_dir is None:
+            return
+        path = completed_dir(run_dir) / f"{_logical_id(logical)}.json"
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise ResumeError(f"cannot clear completed call {logical!r}: {exc}") from exc
+
+
+def complete_prefix(prefix: tuple[str, ...]) -> None:
+    for entry in active_entries():
+        logical = tuple(str(part) for part in entry["logical"])
+        if logical[: len(prefix)] == prefix:
+            complete_turn(logical)
+
+
+def has_prefix(prefix: tuple[str, ...]) -> bool:
+    return any(tuple(str(part) for part in entry["logical"])[: len(prefix)] == prefix for entry in active_entries())

--- a/src/specula/resumelib.py
+++ b/src/specula/resumelib.py
@@ -33,6 +33,7 @@ SCHEMA_VERSION = 1
 INVOCATION_ENV = "SPECULA_INVOCATION_ID"
 MANUAL_ENV = "SPECULA_MANUAL_RESUME"
 FRESH_ENV = "SPECULA_FRESH_CONTEXT"
+RUN_LOCK_FD_ENV = "SPECULA_RUN_LOCK_FD"
 
 
 class ResumeError(RuntimeError):
@@ -119,6 +120,38 @@ def _atomic_write(path: Path, data: dict[str, Any]) -> None:
     finally:
         with contextlib.suppress(FileNotFoundError):
             tmp.unlink()
+
+
+def _clear_native_state(path: Path) -> None:
+    """Remove a previous logical turn's provider session before publication."""
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise ResumeError(f"cannot clear stale native session state {path}: {exc}") from exc
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise ResumeError(f"cannot verify cleared native session state {path}: {exc}") from exc
+    raise ResumeError(f"stale native session state still exists after removal: {path}")
+
+
+def inherited_run_lock_fds() -> tuple[int, ...]:
+    """Return the validated run-lock lease inherited from the dispatcher."""
+    raw = os.environ.get(RUN_LOCK_FD_ENV)
+    if raw is None:
+        return ()
+    try:
+        fd = int(raw)
+        info = os.fstat(fd)
+    except (OSError, ValueError) as exc:
+        raise ResumeError("inherited Specula run lock is unavailable") from exc
+    if fd < 3 or not stat.S_ISREG(info.st_mode):
+        raise ResumeError("inherited Specula run lock is invalid")
+    return (fd,)
 
 
 def _read_object(path: Path, label: str) -> dict[str, Any]:
@@ -298,6 +331,14 @@ def _claim(entry: dict[str, Any], *, attempt: int, manual: bool, resumable: bool
     )
 
 
+def _require_owner(entry: dict[str, Any], path: Path, action: str) -> None:
+    invocation = os.environ.get(INVOCATION_ENV)
+    if entry.get("owner") != invocation:
+        raise ResumeError(
+            f"cannot {action} conversation {tuple(entry.get('logical', []))!r}: checkpoint ownership changed in {path}"
+        )
+
+
 def _entries(directory: Path, label: str) -> list[dict[str, Any]]:
     _require_directory(directory, f"{label} directory")
     entries: list[dict[str, Any]] = []
@@ -362,7 +403,7 @@ def ensure_phase(phase: str) -> None:
         waiting = ", ".join(sorted(phases))
         raise ResumeError(
             f"this run has unfinished conversation(s) in {waiting}; "
-            "use the original --skip-* flags to reach that phase, or pass --fresh-context"
+            "resume that recorded phase, or pass --fresh-context to start over"
         )
 
 
@@ -445,6 +486,12 @@ def prepare_turn(
                 raise ResumeError(
                     f"native session state path already belongs to unfinished conversation {entry['logical']!r}"
                 )
+        # A native state file outlives the adapter call that created it.  For a
+        # new logical turn, remove that stale binding before making the active
+        # checkpoint visible.  A crash can now leave neither record, or an
+        # active record with no session yet, but never a new record that points
+        # at an old completed provider session.
+        _clear_native_state(resume_state)
         now = time.time_ns()
         entry = {
             "version": SCHEMA_VERSION,
@@ -478,25 +525,62 @@ def update_turn(logical: tuple[str, ...], **updates: Any) -> None:
         entry = _read_object(path, "active conversation")
         if entry.get("logical") != list(logical):
             raise ResumeError(f"active conversation identity mismatch in {path}")
+        _validate_entry(entry, path, "active conversation")
+        _require_owner(entry, path, "update")
         entry.update(updates)
         entry["updated_ns"] = time.time_ns()
         _validate_entry(entry, path, "active conversation")
         _atomic_write(path, entry)
 
 
-def complete_turn(logical: tuple[str, ...]) -> None:
+def complete_turn(logical: tuple[str, ...], *, allow_previous_owner: bool = False) -> None:
     if not enabled():
         return
     run_dir = _run_dir()
     assert run_dir is not None
     path = _entry_path(run_dir, logical)
     with _lock:
+        if not path.exists() and not path.is_symlink():
+            return
+        entry = _read_object(path, "active conversation")
+        _validate_entry(entry, path, "active conversation")
+        if entry.get("logical") != list(logical):
+            raise ResumeError(f"active conversation identity mismatch in {path}")
+        if not (allow_previous_owner and manual_mode()):
+            _require_owner(entry, path, "complete")
         try:
             path.unlink()
-        except FileNotFoundError:
-            return
         except OSError as exc:
             raise ResumeError(f"cannot complete conversation {logical!r}: {exc}") from exc
+
+
+def reconcile_completed(logical: tuple[str, ...]) -> None:
+    """Close mark_completed's safe write-before-unlink crash window."""
+    if not enabled():
+        return
+    run_dir = _run_dir()
+    assert run_dir is not None
+    active_path = _entry_path(run_dir, logical)
+    done_path = completed_dir(run_dir) / active_path.name
+    with _lock:
+        done = _read_object(done_path, "completed call")
+        _validate_entry(done, done_path, "completed call")
+        if done.get("logical") != list(logical):
+            raise ResumeError(f"completed call identity mismatch in {done_path}")
+        if not active_path.exists() and not active_path.is_symlink():
+            return
+        active = _read_object(active_path, "active conversation")
+        _validate_entry(active, active_path, "active conversation")
+        if active.get("logical") != list(logical):
+            raise ResumeError(f"active conversation identity mismatch in {active_path}")
+        comparable_active = {key: value for key, value in active.items() if key != "updated_ns"}
+        comparable_done = {key: value for key, value in done.items() if key != "updated_ns"}
+        if comparable_active != comparable_done or done["updated_ns"] < active["updated_ns"]:
+            raise ResumeError(f"completed call does not match active conversation {logical!r}")
+        try:
+            active_path.unlink()
+        except OSError as exc:
+            raise ResumeError(f"cannot reconcile completed call {logical!r}: {exc}") from exc
 
 
 def mark_completed(logical: tuple[str, ...]) -> None:
@@ -513,6 +597,7 @@ def mark_completed(logical: tuple[str, ...]) -> None:
             _validate_entry(entry, active_path, "active conversation")
             if entry["logical"] != list(logical):
                 raise ResumeError(f"active conversation identity mismatch in {active_path}")
+            _require_owner(entry, active_path, "complete")
             entry["updated_ns"] = time.time_ns()
             _atomic_write(done_path, entry)
             try:
@@ -539,11 +624,16 @@ def completed_logicals(prefix: tuple[str, ...] = ()) -> set[tuple[str, ...]]:
 
 
 def clear_completed(prefix: tuple[str, ...] = ()) -> None:
-    for logical in completed_logicals(prefix):
+    for entry in completed_entries():
+        logical = tuple(str(part) for part in entry["logical"])
+        if logical[: len(prefix)] != prefix:
+            continue
         run_dir = _run_dir()
         if run_dir is None:
             return
         path = completed_dir(run_dir) / f"{_logical_id(logical)}.json"
+        if not manual_mode():
+            _require_owner(entry, path, "clear completed")
         try:
             path.unlink()
         except FileNotFoundError:
@@ -556,7 +646,7 @@ def complete_prefix(prefix: tuple[str, ...]) -> None:
     for entry in active_entries():
         logical = tuple(str(part) for part in entry["logical"])
         if logical[: len(prefix)] == prefix:
-            complete_turn(logical)
+            complete_turn(logical, allow_previous_owner=True)
 
 
 def has_prefix(prefix: tuple[str, ...]) -> bool:

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -19,13 +19,16 @@ stdlib unittest, collected natively by pytest:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -61,6 +64,7 @@ _VOLATILE = (
     "SPECULA_INVOCATION_ID",
     "SPECULA_MANUAL_RESUME",
     "SPECULA_FRESH_CONTEXT",
+    "SPECULA_RUN_LOCK_FD",
 )
 
 ALL_PHASE_SKIPS = (
@@ -259,6 +263,92 @@ class CliE2E(unittest.TestCase):
         self.assertTrue((wd / "bug-severity.md").is_file())
         self.assertEqual(list((run / ".specula-resume" / "active").glob("*.json")), [])
         self.assertEqual(list((run / ".specula-resume" / "completed").glob("*.json")), [])
+
+    def test_attach_refuses_live_orphan_after_dispatcher_sigkill(self) -> None:
+        root = self.specroot()
+        work = self.workdir()
+        artifact = work / "artifact"
+        artifact.mkdir()
+        adapter = root / "scripts" / "launch" / "adapters" / "fake.sh"
+        adapter.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            "resume=\n"
+            'for arg do case "$arg" in --resume-state=*) resume=${arg#*=} ;; esac; done\n'
+            'printf "orphan-session\\n" > "$resume"\n'
+            'printf "%s\\n" "$$" > "$0.pid"\n'
+            'printf "%s\\n" "$PPID" > "$0.phase-pid"\n'
+            'printf x >> "$0.started"\n'
+            "trap 'exit 143' TERM INT HUP\n"
+            "while :; do sleep 1; done\n"
+        )
+        adapter.chmod(0o755)
+        env = {key: value for key, value in os.environ.items() if key not in _VOLATILE}
+        env["HOME"] = str(work)
+        run_id = "orphaned-agent"
+        first = subprocess.Popen(
+            [
+                sys.executable,
+                str(root / "src" / "specula" / "cli.py"),
+                "run",
+                f"--run-id={run_id}",
+                "--agent=fake",
+                f"--artifact={artifact}",
+                "--skip-specgen",
+                "--skip-harness",
+                "--skip-validate",
+                "--skip-confirmation",
+                "--skip-classification",
+                "--skip-repair-loop",
+                "footest|owner/repo|Go|reference",
+            ],
+            cwd=work,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        agent_pid_file = Path(f"{adapter}.pid")
+
+        def cleanup() -> None:
+            with contextlib.suppress(OSError, ValueError):
+                os.kill(first.pid, signal.SIGKILL)
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                first.wait(timeout=2)
+            if agent_pid_file.is_file():
+                with contextlib.suppress(OSError, ValueError):
+                    os.killpg(int(agent_pid_file.read_text()), signal.SIGKILL)
+            if first.stdout is not None:
+                first.stdout.close()
+
+        self.addCleanup(cleanup)
+        run = root / "runs" / run_id
+        active_dir = run / ".specula-resume" / "active"
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if Path(f"{adapter}.started").is_file() and list(active_dir.glob("*.json")):
+                break
+            if first.poll() is not None:
+                output = first.stdout.read() if first.stdout is not None else ""
+                self.fail(f"dispatcher exited before the agent started: {output}")
+            time.sleep(0.02)
+        self.assertTrue(Path(f"{adapter}.started").is_file())
+        active_paths = list(active_dir.glob("*.json"))
+        self.assertEqual(len(active_paths), 1)
+        before = active_paths[0].read_bytes()
+
+        os.kill(first.pid, signal.SIGKILL)
+        first.wait(timeout=5)
+        phase_pid = int(Path(f"{adapter}.phase-pid").read_text())
+        os.kill(phase_pid, signal.SIGKILL)
+        os.kill(int(agent_pid_file.read_text()), 0)
+        attached = self.run_cli(root, ["run", f"--run-id={run_id}"], cwd=work)
+
+        self.assertNotEqual(attached.returncode, 0, attached.stdout + attached.stderr)
+        self.assertIn("live phase or agent", attached.stderr)
+        self.assertIn("terminate it manually", attached.stderr)
+        self.assertEqual(Path(f"{adapter}.started").read_text(), "x")
+        self.assertEqual(active_paths[0].read_bytes(), before)
 
     def test_noop_run_writes_two_level_human_indexes(self) -> None:
         root = self.specroot()

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -29,6 +29,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from specula import phaselib
+
 REAL_ROOT = Path(__file__).resolve().parents[2]
 REAL_PKG = REAL_ROOT / "src" / "specula"
 REAL_LAUNCH = REAL_ROOT / "scripts" / "launch"
@@ -56,6 +58,9 @@ _VOLATILE = (
     "CODEX_MODEL",
     "CODEX_EFFORT",
     "COPILOT_MODEL",
+    "SPECULA_INVOCATION_ID",
+    "SPECULA_MANUAL_RESUME",
+    "SPECULA_FRESH_CONTEXT",
 )
 
 ALL_PHASE_SKIPS = (
@@ -155,6 +160,105 @@ class CliE2E(unittest.TestCase):
         self.assertIn("Specula", out)
         self.assertIn("[DRY RUN] bash scripts/launch/launch_code_analysis.sh", out)
         self.assertIn("Pipeline completed", out)
+
+    def test_run_id_resumes_interrupted_validation_without_phase_skip_flags(self) -> None:
+        root = self.specroot()
+        work = self.workdir()
+        artifact = work / "artifact"
+        artifact.mkdir()
+        adapter = root / "scripts" / "launch" / "adapters" / "fake.sh"
+        adapter.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            "prompt= log= resume=\n"
+            'for arg do case "$arg" in\n'
+            "  --prompt-file=*) prompt=${arg#*=} ;;\n"
+            "  --log=*) log=${arg#*=} ;;\n"
+            "  --resume-state=*) resume=${arg#*=} ;;\n"
+            "esac; done\n"
+            'case "$SPECULA_PHASE" in\n'
+            "  spec_validation)\n"
+            '    printf x >> "$0.validation-count"\n'
+            '    attempt=$(wc -c < "$0.validation-count")\n'
+            '    if [ "$attempt" -eq 1 ]; then\n'
+            '      printf "validation-session\n" > "$resume"\n'
+            '      printf "interrupted\n" > "$log"\n'
+            "      exit 9\n"
+            "    fi\n"
+            '    test "$(cat "$resume")" = "validation-session"\n'
+            '    cp "$prompt" "$0.validation-prompt"\n'
+            '    printf "bug report\n" > "$SPECULA_WORK_DIR/spec/bug-report.md"\n'
+            "    ;;\n"
+            "  bug_confirmation_turn)\n"
+            '    printf \'{"generated_by":"consolidate","findings":[]}\\n\' '
+            '> "$SPECULA_WORK_DIR/spec/candidates.json"\n'
+            "    ;;\n"
+            "  bug_classification)\n"
+            '    printf "severity\n" > "$SPECULA_WORK_DIR/bug-severity.md"\n'
+            "    ;;\n"
+            "  *) exit 97 ;;\n"
+            "esac\n"
+            'printf "continued\n" > "$log"\n'
+        )
+        adapter.chmod(0o755)
+        target = "footest|owner/repo|Go|reference"
+        run_id = "resume-validation"
+
+        setup = self.run_cli(
+            root,
+            [
+                "run",
+                f"--run-id={run_id}",
+                "--agent=fake",
+                f"--artifact={artifact}",
+                *ALL_PHASE_SKIPS,
+                target,
+            ],
+            cwd=work,
+        )
+        self.assertEqual(setup.returncode, 0, setup.stderr)
+        run = root / "runs" / run_id
+        wd = run / "footest" / ".specula-output"
+        for rel in (
+            "modeling-brief.md",
+            "spec/base.tla",
+            "spec/MC.tla",
+            "spec/Trace.tla",
+            "spec/instrumentation-spec.md",
+        ):
+            path = wd / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("seeded\n")
+
+        first = self.run_cli(
+            root,
+            [
+                "run",
+                f"--run-id={run_id}",
+                "--fresh-context",
+                "--skip-analysis",
+                "--skip-specgen",
+                "--skip-harness",
+                "--skip-confirmation",
+                "--skip-classification",
+                "--skip-repair-loop",
+            ],
+            cwd=work,
+        )
+        self.assertEqual(first.returncode, 9, first.stdout + first.stderr)
+
+        resumed = self.run_cli(root, ["run", f"--run-id={run_id}"], cwd=work)
+
+        self.assertEqual(resumed.returncode, 0, resumed.stdout + resumed.stderr)
+        self.assertEqual(Path(f"{adapter}.validation-count").read_text(), "xx")
+        self.assertEqual(
+            Path(f"{adapter}.validation-prompt").read_text(),
+            phaselib._MANUAL_SESSION_RESUME_PROMPT,
+        )
+        self.assertTrue((wd / "confirmed-bugs.md").is_file())
+        self.assertTrue((wd / "bug-severity.md").is_file())
+        self.assertEqual(list((run / ".specula-resume" / "active").glob("*.json")), [])
+        self.assertEqual(list((run / ".specula-resume" / "completed").glob("*.json")), [])
 
     def test_noop_run_writes_two_level_human_indexes(self) -> None:
         root = self.specroot()

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -19,6 +19,7 @@ stdlib unittest, collected natively by pytest:
 from __future__ import annotations
 
 import contextlib
+import fcntl
 import json
 import os
 import signal
@@ -32,6 +33,8 @@ import unittest
 from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any, TypedDict
+
+from specula.adapters.utils.run_lock import RUN_LOCK_FD_ENV, RunLockError, inherited_run_lock_fds
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CLAUDE_PY = REPO_ROOT / "src" / "specula" / "adapters" / "claude_code.py"
@@ -99,8 +102,10 @@ _VOLATILE = (
     "ADAPTER_EXIT_CODE",
     "COPILOT_HELP_TEXT",
     "ADAPTER_PI_SESSION_FIXTURE",
+    "ADAPTER_PROVIDER_PID_FILE",
     "ADAPTER_READY_FILE",
     "ADAPTER_WAIT_SECONDS",
+    "SPECULA_RUN_LOCK_FD",
 )
 
 
@@ -199,6 +204,9 @@ class AdapterCase(unittest.TestCase):
                 '  cp "$ADAPTER_PI_SESSION_FIXTURE" "$TMPDIR/pi-subagent-session-test/run-0/session.jsonl"',
                 "fi",
             ]
+        lines.append(
+            'if [[ -n "${ADAPTER_PROVIDER_PID_FILE:-}" ]]; then printf "%s\\n" "$$" > "$ADAPTER_PROVIDER_PID_FILE"; fi'
+        )
         lines += [
             'if [[ -n "${ADAPTER_READY_FILE:-}" ]]; then',
             '  printf "ready\\n" > "$ADAPTER_READY_FILE"',
@@ -279,6 +287,121 @@ class AdapterCase(unittest.TestCase):
         p.write_text(text)
         return f"--prompt-file={p}"
 
+    def assert_provider_keeps_run_lock(
+        self,
+        base: Path,
+        cmd: list[str],
+        flags: list[str],
+        *,
+        fake_name: str,
+        fixture_text: str,
+    ) -> None:
+        bindir = base / "bin"
+        fixture = base / "fixture.txt"
+        fixture.write_text(fixture_text)
+        self._write_fake(bindir, fake_name, fixture, record_extra=False)
+        ready = base / "provider.ready"
+        provider_pid_file = base / "provider.pid"
+        lock_path = base / "run.lock"
+        owner_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        owner_closed = False
+        probe_fd: int | None = None
+        adapter: subprocess.Popen[str] | None = None
+
+        try:
+            fcntl.flock(owner_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            env = {key: value for key, value in os.environ.items() if key not in _VOLATILE}
+            env.update(
+                {
+                    "HOME": str(base),
+                    "PATH": f"{bindir}:/usr/bin:/bin",
+                    "SPECULA_RUN_LOCK_FD": str(owner_fd),
+                    "ADAPTER_PROVIDER_PID_FILE": str(provider_pid_file),
+                    "ADAPTER_READY_FILE": str(ready),
+                    "ADAPTER_WAIT_SECONDS": "30",
+                }
+            )
+            adapter = subprocess.Popen(
+                [*cmd, *flags],
+                cwd=base,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                pass_fds=(owner_fd,),
+                start_new_session=True,
+            )
+
+            deadline = time.monotonic() + 5
+            while not ready.is_file() and adapter.poll() is None and time.monotonic() < deadline:
+                time.sleep(0.01)
+            self.assertTrue(ready.is_file(), "fake provider did not become ready")
+            provider_pid = int(provider_pid_file.read_text().strip())
+
+            os.kill(adapter.pid, signal.SIGKILL)
+            adapter.wait(timeout=5)
+            self.assertEqual(adapter.returncode, -signal.SIGKILL)
+            os.close(owner_fd)
+            owner_closed = True
+
+            os.kill(provider_pid, 0)
+            probe_fd = os.open(lock_path, os.O_RDWR)
+            with self.assertRaises(BlockingIOError):
+                fcntl.flock(probe_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+            os.killpg(adapter.pid, signal.SIGKILL)
+            acquired = False
+            deadline = time.monotonic() + 5
+            while not acquired and time.monotonic() < deadline:
+                try:
+                    fcntl.flock(probe_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    acquired = True
+                except BlockingIOError:
+                    time.sleep(0.01)
+            self.assertTrue(acquired, "provider process group did not release the run lock")
+        finally:
+            if adapter is not None:
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(adapter.pid, signal.SIGKILL)
+                if adapter.poll() is None:
+                    with contextlib.suppress(subprocess.TimeoutExpired):
+                        adapter.wait(timeout=5)
+                if adapter.stdout is not None:
+                    adapter.stdout.close()
+                if adapter.stderr is not None:
+                    adapter.stderr.close()
+            if not owner_closed:
+                os.close(owner_fd)
+            if probe_fd is not None:
+                os.close(probe_fd)
+
+
+class RunLockLease(unittest.TestCase):
+    def test_missing_and_valid_inherited_lease(self) -> None:
+        self.assertEqual(inherited_run_lock_fds({}), ())
+        with tempfile.TemporaryFile() as lock_file:
+            self.assertEqual(
+                inherited_run_lock_fds({RUN_LOCK_FD_ENV: str(lock_file.fileno())}),
+                (lock_file.fileno(),),
+            )
+
+    def test_invalid_inherited_lease_fails_closed(self) -> None:
+        with self.assertRaisesRegex(RunLockError, "unavailable"):
+            inherited_run_lock_fds({RUN_LOCK_FD_ENV: "not-an-fd"})
+
+        read_fd, write_fd = os.pipe()
+        try:
+            with self.assertRaisesRegex(RunLockError, "invalid"):
+                inherited_run_lock_fds({RUN_LOCK_FD_ENV: str(read_fd)})
+        finally:
+            os.close(read_fd)
+            os.close(write_fd)
+
+        closed_fd = os.open(os.devnull, os.O_RDONLY)
+        os.close(closed_fd)
+        with self.assertRaisesRegex(RunLockError, "unavailable"):
+            inherited_run_lock_fds({RUN_LOCK_FD_ENV: str(closed_fd)})
+
 
 # ── claude-code (Python port) ────────────────────────────────────────────────
 class ClaudeCodeAdapter(AdapterCase):
@@ -292,6 +415,22 @@ class ClaudeCodeAdapter(AdapterCase):
 
     def base_flags(self, base: Path) -> list[str]:
         return [self.with_prompt_file(base), f"--log={base}/out.log"]
+
+    @unittest.skipUnless(hasattr(os, "killpg"), "requires POSIX process groups")
+    def test_native_provider_keeps_run_lock_after_adapter_is_killed(self) -> None:
+        for streaming in (False, True):
+            with self.subTest(streaming=streaming):
+                base = self.sandbox()
+                flags = self.base_flags(base)
+                if streaming:
+                    flags.append(f"--resume-state={base}/resume.json")
+                self.assert_provider_keeps_run_lock(
+                    base,
+                    self.CMD,
+                    flags,
+                    fake_name="claude",
+                    fixture_text=self.FIXTURE,
+                )
 
     def test_resume_state_captures_then_resumes_exact_claude_session(self) -> None:
         base = self.sandbox()
@@ -2268,6 +2407,17 @@ class PiAdapter(AdapterCase):
         },
     ]
     FIXTURE = "\n".join(json.dumps(record) for record in RECORDS) + "\n"
+
+    @unittest.skipUnless(hasattr(os, "killpg"), "requires POSIX process groups")
+    def test_native_provider_keeps_run_lock_after_adapter_is_killed(self) -> None:
+        base = self.sandbox()
+        self.assert_provider_keeps_run_lock(
+            base,
+            self.CMD,
+            [self.with_prompt_file(base), f"--log={base}/out.log"],
+            fake_name="pi",
+            fixture_text=self.FIXTURE,
+        )
 
     @staticmethod
     def expected_activity(records: list[dict[str, Any]]) -> str:

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -1127,6 +1127,62 @@ class TestDriver(ConfirmCase):
         )
         self.assertEqual(cfg._policy_states, {})
 
+    def test_manual_resume_restores_interrupted_consolidate_session(self) -> None:
+        ws = Workspace(["T"])
+        root = Path(self.tmp)
+        spec = ws.work_dir("T") / "spec"
+        spec.mkdir(parents=True)
+        adapter = root / "manual-consolidate.sh"
+        adapter.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            "prompt= log= resume=\n"
+            'for arg do case "$arg" in\n'
+            "  --prompt-file=*) prompt=${arg#*=} ;;\n"
+            "  --log=*) log=${arg#*=} ;;\n"
+            "  --resume-state=*) resume=${arg#*=} ;;\n"
+            "esac; done\n"
+            'printf x >> "$CAPTURE/consolidate-count"\n'
+            'attempt=$(wc -c < "$CAPTURE/consolidate-count")\n'
+            'cp "$prompt" "$CAPTURE/consolidate-prompt-$attempt"\n'
+            'if [ "$attempt" -eq 1 ]; then\n'
+            '  printf PARTIAL-CANDIDATES > "$CANDIDATES"\n'
+            '  printf consolidate-session > "$resume"\n'
+            '  printf "rate limited\n" > "$log"\n'
+            "  exit 75\n"
+            "fi\n"
+            'test "$(cat "$CANDIDATES")" = PARTIAL-CANDIDATES\n'
+            'test "$(cat "$resume")" = consolidate-session\n'
+            'printf \'{"generated_by":"consolidate","findings":[]}\\n\' > "$CANDIDATES"\n'
+            'printf "continued\n" > "$log"\n'
+        )
+        adapter.chmod(0o755)
+        resumelib.initialize_run(root)
+        resumelib.save_configuration(root, {"agent": adapter.stem})
+        env = {
+            "CAPTURE": str(root),
+            "CANDIDATES": str(spec / "candidates.json"),
+            resumelib.INVOCATION_ENV: "invocation-1",
+        }
+
+        with mock.patch.dict(os.environ, env, clear=False):
+            os.environ.pop(resumelib.MANUAL_ENV, None)
+            os.environ.pop(resumelib.FRESH_ENV, None)
+            self.assertEqual(C.run_parallel_confirmation(self.cfg(ws, "T", adapter=adapter)), 75)
+            self.assertEqual([entry["kind"] for entry in resumelib.active_entries(root)], ["consolidate"])
+
+            os.environ[resumelib.INVOCATION_ENV] = "invocation-2"
+            os.environ[resumelib.MANUAL_ENV] = "1"
+            resumed_cfg = self.cfg(ws, "T", adapter=adapter)
+            self.assertEqual(C.run_parallel_confirmation(resumed_cfg), 0)
+
+        self.assertEqual((root / "consolidate-count").read_text(), "xx")
+        self.assertEqual(
+            (root / "consolidate-prompt-2").read_text(),
+            PhaseLib._MANUAL_SESSION_RESUME_PROMPT,
+        )
+        self.assertEqual(resumelib.active_entries(root), [])
+
     def test_consolidate_failure_withholds_not_raises(self) -> None:
         # No candidates.json → consolidate runs the agent. A non-75 failure that
         # yields no valid candidates.json must withhold and return failure.

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -10,6 +10,7 @@ partial-delivery return codes, and idempotent retry.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -789,6 +790,146 @@ class TestDriver(ConfirmCase):
         self.assertEqual(resumed_cfg._finding_leases, {})
         self.assertEqual(resumed_cfg._policy_states, {})
         self.assertFalse(leased_repo.exists())
+
+    def test_manual_resume_keeps_no_correction_decision_and_exact_interrupted_b(self) -> None:
+        ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
+        root = Path(self.tmp)
+        valid_draft = root / "valid-repair-draft.md"
+        valid_draft.write_text(TestMergeRR.AGENT_BODY)
+        adapter = root / "resume-pending-debate.sh"
+        adapter.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            "prompt= log= resume=\n"
+            'for arg do case "$arg" in\n'
+            "  --prompt-file=*) prompt=${arg#*=} ;;\n"
+            "  --log=*) log=${arg#*=} ;;\n"
+            "  --resume-state=*) resume=${arg#*=} ;;\n"
+            "esac; done\n"
+            'stem=$(basename "$prompt")\n'
+            'printf "%s\\n" "$stem" >> "$CAPTURE/calls"\n'
+            'fdir="$SPECULA_WORK_DIR/confirmation/MC-1"\n'
+            'case "$stem" in\n'
+            '  turn01_A.prompt.md) printf \'%s\\n\' "$REPRODUCED" > "$log" ;;\n'
+            '  turn02_B.prompt.md) printf \'%s\\n\' "$FALSE_POSITIVE" > "$log" ;;\n'
+            "  turn03_A.prompt.md)\n"
+            '    cp "$VALID_DRAFT" "$fdir/repair-request.body.md"\n'
+            '    printf \'%s\\n\' "$PENDING_REPAIR" > "$log"\n'
+            "    ;;\n"
+            "  turn04_B.prompt.md)\n"
+            '    printf x >> "$CAPTURE/b-count"\n'
+            '    attempt=$(wc -c < "$CAPTURE/b-count")\n'
+            '    pwd >> "$CAPTURE/b-cwds"\n'
+            '    if [ "$attempt" -eq 1 ]; then\n'
+            '      printf "damaged by interrupted B\\n" > "$fdir/repair-request.body.md"\n'
+            "      printf retained > cwd-marker\n"
+            '      printf exact-b4-session > "$resume"\n'
+            '      printf "rate limited\\n" > "$log"\n'
+            "      exit 75\n"
+            "    fi\n"
+            '    test "$(cat "$resume")" = exact-b4-session\n'
+            "    test -f cwd-marker\n"
+            '    cp "$prompt" "$CAPTURE/b-resume-prompt"\n'
+            '    cp "$VALID_DRAFT" "$fdir/repair-request.body.md"\n'
+            '    printf passed > "$CAPTURE/resume-check"\n'
+            '    printf \'%s\\n\' "$PENDING_REPAIR" > "$log"\n'
+            "    ;;\n"
+            "  *) exit 97 ;;\n"
+            "esac\n"
+        )
+        adapter.chmod(0o755)
+        resumelib.initialize_run(root)
+        resumelib.save_configuration(root, {"agent": adapter.stem})
+        cfg = C.ConfirmConfig(
+            name="T",
+            ws=ws,
+            adapter=adapter,
+            worktree=False,
+            max_parallel=1,
+            debate=True,
+            rounds=2,
+        )
+        with mock.patch.dict(
+            os.environ,
+            {
+                "CAPTURE": str(root),
+                "VALID_DRAFT": str(valid_draft),
+                "REPRODUCED": _response("REPRODUCED"),
+                "FALSE_POSITIVE": _response("FALSE POSITIVE"),
+                "PENDING_REPAIR": _response("PENDING REPAIR"),
+                resumelib.INVOCATION_ENV: "invocation-1",
+            },
+            clear=False,
+        ):
+            os.environ.pop(resumelib.MANUAL_ENV, None)
+            os.environ.pop(resumelib.FRESH_ENV, None)
+            self.assertEqual(C.run_parallel_confirmation(cfg), 75)
+
+            fdir = ws.work_dir("T") / "confirmation" / "MC-1"
+            lease_checkpoint = fdir / ".resume-lease.json"
+            lease_doc = json.loads(lease_checkpoint.read_text())
+            expected_digest = hashlib.sha256(TestMergeRR.AGENT_BODY.encode()).hexdigest()
+            self.assertEqual(
+                lease_doc["no_correction_drafts"],
+                [{"previous_turn": 3, "previous_role": "A", "draft_digest": expected_digest}],
+            )
+            self.assertEqual(lease_doc["repair_turns"], [])
+            completed = {(item["turn"], item["role"]) for item in lease_doc["completed_turns"]}
+            self.assertEqual(completed, {(1, "A"), (2, "B"), (3, "A")})
+            active = {
+                (int(entry["logical"][-2]), str(entry["logical"][-1])) for entry in resumelib.active_entries(root)
+            }
+            self.assertEqual(active - completed, {(4, "B")})
+
+            finding = C.load_findings(cfg)[0]
+            malformed = json.loads(lease_checkpoint.read_text())
+            malformed["no_correction_drafts"][0]["draft_digest"] = "bad"
+            lease_checkpoint.write_text(json.dumps(malformed))
+            with self.assertRaisesRegex(C.ConfirmationFailed, "invalid no-correction draft checkpoint"):
+                C._load_lease(cfg, finding)
+            malformed = json.loads(json.dumps(lease_doc))
+            malformed["no_correction_drafts"][0].update({"previous_turn": 2, "previous_role": "B"})
+            lease_checkpoint.write_text(json.dumps(malformed))
+            with self.assertRaisesRegex(C.ConfirmationFailed, "not bound to a completed PENDING REPAIR turn"):
+                C._load_lease(cfg, finding)
+            lease_checkpoint.write_text(json.dumps(lease_doc))
+
+            self.assertEqual(cfg._finding_leases, {})
+            os.environ[resumelib.INVOCATION_ENV] = "invocation-2"
+            os.environ[resumelib.MANUAL_ENV] = "1"
+            resumed_cfg = C.ConfirmConfig(
+                name="T",
+                ws=ws,
+                adapter=adapter,
+                worktree=False,
+                max_parallel=1,
+                debate=True,
+                rounds=2,
+            )
+            self.assertEqual(C.run_parallel_confirmation(resumed_cfg), 0)
+
+        self.assertEqual(
+            (root / "calls").read_text().splitlines(),
+            [
+                "turn01_A.prompt.md",
+                "turn02_B.prompt.md",
+                "turn03_A.prompt.md",
+                "turn04_B.prompt.md",
+                "turn04_B.prompt.md",
+            ],
+        )
+        self.assertEqual((root / "b-count").read_text(), "xx")
+        self.assertEqual(len(set((root / "b-cwds").read_text().splitlines())), 1)
+        self.assertEqual((root / "b-resume-prompt").read_text(), PhaseLib._MANUAL_SESSION_RESUME_PROMPT)
+        self.assertEqual((root / "resume-check").read_text(), "passed")
+        self.assertEqual(
+            (ws.work_dir("T") / "confirmation" / "MC-1" / "repair-request.body.md").read_text(),
+            TestMergeRR.AGENT_BODY,
+        )
+        self.assertEqual(resumelib.active_entries(root), [])
+        self.assertFalse(lease_checkpoint.exists())
+        self.assertEqual(resumed_cfg._finding_leases, {})
+        self.assertEqual(resumed_cfg._policy_states, {})
 
     def test_repair_correction_keeps_later_turn_number_across_rate_replay(self) -> None:
         ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -29,6 +29,7 @@ from specula import confirmlib as C
 from specula import phaselib as PhaseLib
 from specula import pipelinelib as PL
 from specula import prompts as P
+from specula import resumelib
 from specula.phaselib import Workspace
 
 EVIDENCE = "The investigation inspected the real call path and captured concrete observed behavior."
@@ -688,6 +689,105 @@ class TestDriver(ConfirmCase):
         self.assertEqual((root / "resume-check").read_text(), "passed")
         self.assertEqual(cfg._finding_leases, {})
         self.assertEqual(cfg._policy_states, {})
+        self.assertFalse(leased_repo.exists())
+
+    def test_manual_resume_reloads_accepted_a_and_exact_interrupted_b(self) -> None:
+        ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
+        root = Path(self.tmp)
+        repo = _git_repo(root / "repo")
+        adapter = root / "resume-debate.sh"
+        adapter.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            "prompt= log= resume=\n"
+            'for arg do case "$arg" in\n'
+            "  --prompt-file=*) prompt=${arg#*=} ;;\n"
+            "  --log=*) log=${arg#*=} ;;\n"
+            "  --resume-state=*) resume=${arg#*=} ;;\n"
+            "esac; done\n"
+            'case "$(basename "$prompt")" in\n'
+            "  turn01_A.prompt.md)\n"
+            '    printf x >> "$CAPTURE/a-count"\n'
+            "    repo=$(sed -n 's/^- Source repo (build\\/run here): //p' \"$prompt\" | head -n 1)\n"
+            '    printf \'%s\\n\' "$repo" > "$CAPTURE/repo-path"\n'
+            '    printf retained > "$repo/lease-marker"\n'
+            '    printf \'%s\\n\' "$ADAPTER_SUCCESS_TEXT" > "$log"\n'
+            "    ;;\n"
+            "  turn02_B.prompt.md)\n"
+            '    printf x >> "$CAPTURE/b-count"\n'
+            '    attempt=$(wc -c < "$CAPTURE/b-count")\n'
+            '    pwd >> "$CAPTURE/b-cwds"\n'
+            '    repo=$(cat "$CAPTURE/repo-path")\n'
+            '    test -f "$repo/lease-marker"\n'
+            '    if [ "$attempt" -eq 1 ]; then\n'
+            "      printf retained > cwd-marker\n"
+            '      printf exact-b-session > "$resume"\n'
+            "      printf 'rate limited\\n' > \"$log\"\n"
+            "      exit 75\n"
+            "    fi\n"
+            '    test "$(cat "$resume")" = exact-b-session\n'
+            "    test -f cwd-marker\n"
+            '    cp "$prompt" "$CAPTURE/b-resume-prompt"\n'
+            '    printf passed > "$CAPTURE/resume-check"\n'
+            '    printf \'%s\\n\' "$ADAPTER_SUCCESS_TEXT" > "$log"\n'
+            "    ;;\n"
+            "  *) exit 97 ;;\n"
+            "esac\n"
+        )
+        adapter.chmod(0o755)
+        resumelib.initialize_run(root)
+        resumelib.save_configuration(root, {"agent": adapter.stem})
+        cfg = C.ConfirmConfig(
+            name="T",
+            ws=ws,
+            adapter=adapter,
+            repo_dir=str(repo),
+            worktree=True,
+            max_parallel=1,
+            debate=True,
+            rounds=1,
+        )
+        with mock.patch.dict(
+            os.environ,
+            {
+                "CAPTURE": str(root),
+                "ADAPTER_SUCCESS_TEXT": _response("ENV_LIMITED"),
+                resumelib.INVOCATION_ENV: "invocation-1",
+            },
+            clear=False,
+        ):
+            os.environ.pop(resumelib.MANUAL_ENV, None)
+            os.environ.pop(resumelib.FRESH_ENV, None)
+            self.assertEqual(C.run_parallel_confirmation(cfg), 75)
+            leased_repo = Path((root / "repo-path").read_text().strip())
+            lease_checkpoint = ws.work_dir("T") / "confirmation" / "MC-1" / ".resume-lease.json"
+            self.assertTrue(lease_checkpoint.is_file())
+            self.assertTrue((leased_repo / "lease-marker").is_file())
+            self.assertEqual(cfg._finding_leases, {})
+
+            os.environ[resumelib.INVOCATION_ENV] = "invocation-2"
+            os.environ[resumelib.MANUAL_ENV] = "1"
+            resumed_cfg = C.ConfirmConfig(
+                name="T",
+                ws=ws,
+                adapter=adapter,
+                repo_dir=str(repo),
+                worktree=True,
+                max_parallel=1,
+                debate=True,
+                rounds=1,
+            )
+            self.assertEqual(C.run_parallel_confirmation(resumed_cfg), 0)
+
+        self.assertEqual((root / "a-count").read_text(), "x")
+        self.assertEqual((root / "b-count").read_text(), "xx")
+        self.assertEqual(len(set((root / "b-cwds").read_text().splitlines())), 1)
+        self.assertEqual((root / "b-resume-prompt").read_text(), PhaseLib._MANUAL_SESSION_RESUME_PROMPT)
+        self.assertEqual((root / "resume-check").read_text(), "passed")
+        self.assertEqual(resumelib.active_entries(root), [])
+        self.assertFalse(lease_checkpoint.exists())
+        self.assertEqual(resumed_cfg._finding_leases, {})
+        self.assertEqual(resumed_cfg._policy_states, {})
         self.assertFalse(leased_repo.exists())
 
     def test_repair_correction_keeps_later_turn_number_across_rate_replay(self) -> None:

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -48,7 +48,7 @@ if str(SRC) not in sys.path:  # test the tree this file lives in, installed or n
 
 import specula.progress as progress_module  # noqa: E402
 import specula.quota as quota  # noqa: E402
-from specula import phaselib, snapshotlib  # noqa: E402
+from specula import phaselib, resumelib, snapshotlib  # noqa: E402
 from specula.adapters.utils.policy import POLICY_BLOCKED_RC  # noqa: E402
 from specula.adapters.utils.transient import TRANSIENT_FAILURE_RC  # noqa: E402
 from specula.progress import ProgressConfig, RunningAgent  # noqa: E402
@@ -196,6 +196,9 @@ class PhaseCase(unittest.TestCase):
             "CLAUDE_EFFORT",
             "SPECULA_SOURCE_SNAPSHOT",
             "GIT_CEILING_DIRECTORIES",
+            resumelib.INVOCATION_ENV,
+            resumelib.MANUAL_ENV,
+            resumelib.FRESH_ENV,
         ):
             self.set_env(var, str(self.run_dir) if var == "SPECULA_RUN_DIR" else None)
 
@@ -1082,6 +1085,111 @@ class TestHandoffGate(PhaseCase):
         self.assertEqual((self.work_dir() / "agent.log").read_text(), "continued in session-exact-123\n")
         self.assertIn("resuming the exact session (1/1)", out)
 
+    def test_manual_resume_uses_exact_session_latest_extra_and_attempt_archive(self) -> None:
+        count = self.tmp() / "count"
+        captures = self.tmp()
+        artifact = self.tmp() / "repo"
+        artifact.mkdir()
+        self.patch_attr(self, "artifact_flag", lambda: f"--artifact={artifact}")
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("CAPTURE_DIR", str(captures))
+        resumelib.initialize_run(self.run_dir)
+        resumelib.save_configuration(self.run_dir, {"agent": self.adapter.stem})
+        self.set_env(resumelib.INVOCATION_ENV, "invocation-1")
+        extra = self.work_dir() / ".prompt-extra.md"
+        extra.parent.mkdir(parents=True, exist_ok=True)
+        extra.write_text("Original priority\n")
+        self.write_adapter(
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            'for arg do case "$arg" in '
+            "--prompt-file=*) prompt=${arg#*=} ;; "
+            "--log=*) log=${arg#*=} ;; "
+            "--resume-state=*) resume=${arg#*=} ;; "
+            "esac; done\n"
+            'cp "$prompt" "$CAPTURE_DIR/prompt-$attempt.md"\n'
+            'if [ "$attempt" -eq 1 ]; then\n'
+            '  printf "session-manual-123\\n" > "$resume"\n'
+            '  printf "interrupted\\n" > "$log"\n'
+            "  exit 9\n"
+            "fi\n"
+            '[ "$(cat "$resume")" = "session-manual-123" ]\n'
+            'printf "continued\\n" > "$log"\n'
+            'printf "brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
+        )
+
+        first_rc, first_out = self.run_analysis(options=["--transient-resumes=0"])
+        self.assertEqual(first_rc, 9, first_out)
+        self.assertEqual(len(resumelib.active_entries(self.run_dir)), 1)
+
+        extra.write_text("Focus on trace fidelity\n")
+        self.set_env(resumelib.INVOCATION_ENV, "invocation-2")
+        self.set_env(resumelib.MANUAL_ENV, "1")
+        resumed_rc, resumed_out = self.run_analysis(options=["--transient-resumes=0"])
+
+        self.assertEqual(resumed_rc, 0, resumed_out)
+        self.assertEqual(count.read_text(), "xx")
+        original_prompt = (captures / "prompt-1.md").read_text()
+        resumed_prompt = (captures / "prompt-2.md").read_text()
+        self.assertIn("modeling-brief.md", original_prompt)
+        self.assertEqual(
+            resumed_prompt,
+            phaselib._MANUAL_SESSION_RESUME_PROMPT + "\n## Target-Specific Instructions\n\nFocus on trace fidelity\n",
+        )
+        self.assertNotIn("Original priority", resumed_prompt)
+        self.assertEqual((self.work_dir() / "agent.attempt-1.log").read_text(), "interrupted\n")
+        self.assertEqual((self.work_dir() / "agent.log").read_text(), "continued\n")
+        self.assertEqual(resumelib.active_entries(self.run_dir), [])
+
+    def test_manual_resume_skips_accepted_targets_then_runs_pending_targets(self) -> None:
+        artifact = self.tmp() / "repo"
+        artifact.mkdir()
+        captures = self.tmp()
+        self.patch_attr(self, "artifact_flag", lambda: f"--artifact={artifact}")
+        self.set_env("CAPTURE_DIR", str(captures))
+        resumelib.initialize_run(self.run_dir)
+        resumelib.save_configuration(self.run_dir, {"agent": self.adapter.stem})
+        self.set_env(resumelib.INVOCATION_ENV, "invocation-1")
+        self.write_adapter(
+            'name=$(basename "$(dirname "$SPECULA_WORK_DIR")")\n'
+            'printf x >> "$CAPTURE_DIR/$name-count"\n'
+            'attempt=$(wc -c < "$CAPTURE_DIR/$name-count")\n'
+            'for arg do case "$arg" in '
+            "--log=*) log=${arg#*=} ;; "
+            "--resume-state=*) resume=${arg#*=} ;; "
+            "esac; done\n"
+            'if [ "$name" = active ] && [ "$attempt" -eq 1 ]; then\n'
+            '  printf "active-session\\n" > "$resume"\n'
+            '  printf "rate limited\\n" > "$log"\n'
+            "  exit 75\n"
+            "fi\n"
+            'if [ "$name" = active ]; then test "$(cat "$resume")" = active-session; fi\n'
+            'printf "brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
+            'printf "done\\n" > "$log"\n'
+        )
+        targets = ["accepted|g|Go|r", "active|g|Go|r", "pending|g|Go|r"]
+
+        first_rc, first_out = self.run_analysis(targets, options=["--max-parallel=1"])
+        self.assertEqual(first_rc, quota.RATE_LIMIT_RC, first_out)
+        self.assertEqual((captures / "accepted-count").read_text(), "x")
+        self.assertEqual((captures / "active-count").read_text(), "x")
+        self.assertFalse((captures / "pending-count").exists())
+        self.assertEqual(
+            resumelib.completed_logicals(("phase", "code_analysis")),
+            {("phase", "code_analysis", "accepted")},
+        )
+
+        self.set_env(resumelib.INVOCATION_ENV, "invocation-2")
+        self.set_env(resumelib.MANUAL_ENV, "1")
+        resumed_rc, resumed_out = self.run_analysis(targets, options=["--max-parallel=1"])
+
+        self.assertEqual(resumed_rc, 0, resumed_out)
+        self.assertEqual((captures / "accepted-count").read_text(), "x")
+        self.assertEqual((captures / "active-count").read_text(), "xx")
+        self.assertEqual((captures / "pending-count").read_text(), "x")
+        self.assertEqual(resumelib.active_entries(self.run_dir), [])
+        self.assertEqual(resumelib.completed_entries(self.run_dir), [])
+
     def test_default_transient_resume_budget_stops_after_twenty_continuations(self) -> None:
         count = self.tmp() / "count"
         self.set_env("COUNT_FILE", str(count))
@@ -1840,6 +1948,94 @@ class TestRunAgentBlocking(PhaseCase):
         self.assertEqual((captures / "prompt-4.md").read_text(), phaselib._SESSION_RESUME_PROMPT)
         self.assertEqual((captures / "turn.attempt-3.log").read_text(), "attempt-3\n")
         self.assertEqual(log_file.read_text(), "attempt-4\n")
+
+    def test_manual_blocking_resume_restores_retry_cursor_and_archive_number(self) -> None:
+        adapter = self.tmp() / "adapter.sh"
+        count = self.tmp() / "count"
+        captures = self.tmp()
+        adapter.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            'for arg do case "$arg" in '
+            "--prompt-file=*) prompt=${arg#*=} ;; "
+            "--log=*) log=${arg#*=} ;; "
+            "--resume-state=*) resume=${arg#*=} ;; "
+            "esac; done\n"
+            'if [ ! -f "$resume" ]; then printf "manual-session\n" > "$resume"; fi\n'
+            'cp "$prompt" "$CAPTURE_DIR/prompt-$attempt.md"\n'
+            'printf "attempt-%s\n" "$attempt" > "$log"\n'
+            'case "$attempt" in\n'
+            "  1) exit 74 ;;\n"
+            "  2) exit 76 ;;\n"
+            "  3) exit 75 ;;\n"
+            "  4) exit 76 ;;\n"
+            "  *) exit 99 ;;\n"
+            "esac\n"
+        )
+        adapter.chmod(0o755)
+        run_dir = self.tmp()
+        resumelib.initialize_run(run_dir)
+        resumelib.save_configuration(run_dir, {"agent": adapter.stem})
+        self.set_env("SPECULA_RUN_DIR", str(run_dir))
+        self.set_env(resumelib.INVOCATION_ENV, "invocation-1")
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("CAPTURE_DIR", str(captures))
+        prompt_file = captures / "prompt.md"
+        log_file = captures / "turn.log"
+        logical = ("confirm", NAME, "finding", "MC-1", "1", "A")
+
+        with mock.patch("specula.phaselib.time.sleep"):
+            first_rc, _ = phaselib.run_agent_blocking(
+                adapter,
+                "original prompt",
+                prompt_file,
+                log_file,
+                phase_key="bug_confirmation",
+                work_dir=self.work_dir(),
+                claude_alias="profile",
+                policy_retries=1,
+                transient_resumes=1,
+                resume_logical=logical,
+                resume_phase="bug_confirmation",
+                resume_target=NAME,
+                resume_kind="finding-turn",
+                resume_finding_id="MC-1",
+            )
+        self.assertEqual(first_rc, quota.RATE_LIMIT_RC)
+
+        self.set_env(resumelib.INVOCATION_ENV, "invocation-2")
+        self.set_env(resumelib.MANUAL_ENV, "1")
+        second_rc, _ = phaselib.run_agent_blocking(
+            adapter,
+            "original prompt",
+            prompt_file,
+            log_file,
+            phase_key="bug_confirmation",
+            work_dir=self.work_dir(),
+            claude_alias="profile",
+            policy_retries=1,
+            transient_resumes=1,
+            resume_logical=logical,
+            resume_phase="bug_confirmation",
+            resume_target=NAME,
+            resume_kind="finding-turn",
+            resume_finding_id="MC-1",
+        )
+
+        self.assertEqual(second_rc, POLICY_BLOCKED_RC)
+        self.assertEqual(count.read_text(), "xxxx")
+        self.assertEqual((captures / "prompt-4.md").read_text(), phaselib._MANUAL_SESSION_RESUME_PROMPT)
+        for attempt in range(1, 4):
+            self.assertEqual(
+                (captures / f"turn.attempt-{attempt}.log").read_text(),
+                f"attempt-{attempt}\n",
+            )
+        entry = resumelib.active_entries(run_dir)[0]
+        self.assertEqual(entry["policy_attempt"], 1)
+        self.assertEqual(entry["transient_attempt"], 1)
+        self.assertEqual(entry["invocation_attempt"], 4)
 
     def test_turn_phase_scopes_stop_gate_sets_cwd_and_removes_stale_log(self) -> None:
         adapter = self.tmp() / "adapter.sh"
@@ -3249,6 +3445,39 @@ class TestReviewPhase(PhaseCase):
 
         self.assertEqual(rc, POLICY_BLOCKED_RC, out)
         self.assertEqual(count.read_text(), "xx")
+
+    def test_manual_review_resume_keeps_exhausted_policy_budget(self) -> None:
+        count = self.tmp() / "count"
+        self.install_adapter(
+            "fake",
+            'printf x >> "$COUNT_FILE"\n'
+            'attempt=$(wc -c < "$COUNT_FILE")\n'
+            'for arg do case "$arg" in --log=*) log=${arg#*=} ;; --resume-state=*) resume=${arg#*=} ;; esac; done\n'
+            'test -f "$resume" || printf "review-session\n" > "$resume"\n'
+            'printf "attempt-%s\n" "$attempt" > "$log"\n'
+            'case "$attempt" in 1) exit 76 ;; 2) exit 75 ;; 3) exit 76 ;; *) exit 99 ;; esac\n',
+        )
+        resumelib.initialize_run(self.run_dir)
+        resumelib.save_configuration(self.run_dir, {"agent": "fake"})
+        self.set_env(resumelib.INVOCATION_ENV, "invocation-1")
+        self.set_env("COUNT_FILE", str(count))
+        self.set_env("SPECULA_PROGRESS", "off")
+
+        first_rc, first_out = self.run_phase(
+            "review",
+            ["analysis", "--agent=fake", "--policy-retries=1", NAME],
+        )
+        self.assertEqual(first_rc, quota.RATE_LIMIT_RC, first_out)
+
+        self.set_env(resumelib.INVOCATION_ENV, "invocation-2")
+        self.set_env(resumelib.MANUAL_ENV, "1")
+        resumed_rc, resumed_out = self.run_phase(
+            "review",
+            ["analysis", "--agent=fake", "--policy-retries=1", NAME],
+        )
+
+        self.assertEqual(resumed_rc, POLICY_BLOCKED_RC, resumed_out)
+        self.assertEqual(count.read_text(), "xxx")
 
     def test_review_zero_policy_retries_disables_continuation(self) -> None:
         count = self.tmp() / "count"

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -1141,6 +1141,86 @@ class TestHandoffGate(PhaseCase):
         self.assertEqual((self.work_dir() / "agent.log").read_text(), "continued\n")
         self.assertEqual(resumelib.active_entries(self.run_dir), [])
 
+    def test_manual_resume_reaches_exact_session_for_each_single_agent_phase(self) -> None:
+        captures = self.tmp()
+        self.set_env("CAPTURE_DIR", str(captures))
+        self.write_adapter(
+            'count="$CAPTURE_DIR/$RESUME_CASE.count"\n'
+            "prompt= log= resume=\n"
+            'for arg do case "$arg" in '
+            "--prompt-file=*) prompt=${arg#*=} ;; "
+            "--log=*) log=${arg#*=} ;; "
+            "--resume-state=*) resume=${arg#*=} ;; "
+            "esac; done\n"
+            'printf x >> "$count"\n'
+            'attempt=$(wc -c < "$count")\n'
+            'if [ "$attempt" -eq 1 ]; then\n'
+            '  printf "%s-session\n" "$RESUME_CASE" > "$resume"\n'
+            '  printf "interrupted\n" > "$log"\n'
+            "  exit 9\n"
+            "fi\n"
+            'test "$(cat "$resume")" = "$RESUME_CASE-session"\n'
+            'case "$SPECULA_PHASE" in\n'
+            '  code_analysis) printf "brief\n" > "$SPECULA_WORK_DIR/modeling-brief.md" ;;\n'
+            "  spec_generation)\n"
+            '    mkdir -p "$SPECULA_WORK_DIR/spec"\n'
+            "    for file in base.tla MC.tla Trace.tla instrumentation-spec.md; do\n"
+            '      printf "output\n" > "$SPECULA_WORK_DIR/spec/$file"\n'
+            "    done\n"
+            "    ;;\n"
+            "  harness_generation)\n"
+            '    mkdir -p "$SPECULA_WORK_DIR/harness" "$SPECULA_WORK_DIR/traces"\n'
+            '    printf "#!/bin/sh\n" > "$SPECULA_WORK_DIR/harness/run.sh"\n'
+            '    printf "guide\n" > "$SPECULA_WORK_DIR/harness/INSTRUMENTATION.md"\n'
+            '    printf "{}\n" > "$SPECULA_WORK_DIR/traces/one.ndjson"\n'
+            "    ;;\n"
+            '  spec_validation) printf "bug report\n" > "$SPECULA_WORK_DIR/spec/bug-report.md" ;;\n'
+            '  bug_confirmation) printf "confirmed\n" > "$SPECULA_WORK_DIR/confirmed-bugs.md" ;;\n'
+            '  bug_classification) printf "severity\n" > "$SPECULA_WORK_DIR/bug-severity.md" ;;\n'
+            "esac\n"
+            'printf "continued\n" > "$log"\n'
+        )
+        cases: list[tuple[PhaseSpec, list[str], str, str]] = [
+            (spec, [], spec["prompt"], spec["key"]) for spec in PHASES
+        ]
+        cases.append((BY_KEY["spec_validation"], ["--repair"], ".spec-repair-prompt.md", "spec_validation_repair"))
+
+        for spec, extra_args, prompt_rel, case_name in cases:
+            with self.subTest(phase=case_name):
+                self.run_dir = self.tmp()
+                self.set_env("SPECULA_RUN_DIR", str(self.run_dir))
+                self.set_env("RESUME_CASE", case_name)
+                self.set_env(resumelib.INVOCATION_ENV, f"{case_name}-invocation-1")
+                self.set_env(resumelib.MANUAL_ENV, None)
+                self.seed(spec["inputs"])
+                if spec["key"] == "harness_generation":
+                    self.seed(["spec/MC.tla"])
+                elif spec["key"] == "spec_validation":
+                    self.seed(["modeling-brief.md"])
+                resumelib.initialize_run(self.run_dir)
+                resumelib.save_configuration(self.run_dir, {"agent": self.adapter.stem})
+                args = [f"--agent={self.adapter.stem}", *extra_args]
+                if spec["key"] == "bug_confirmation":
+                    args.append("--legacy-confirm")
+                if spec["artifact"]:
+                    args.append(self.artifact_flag())
+                args.append(NAME)
+
+                first_rc, first_out = self.run_phase(spec["key"], args)
+                self.assertEqual(first_rc, 9, first_out)
+                active = resumelib.active_entries(self.run_dir)
+                self.assertEqual([entry["phase"] for entry in active], [spec["key"]])
+
+                self.set_env(resumelib.INVOCATION_ENV, f"{case_name}-invocation-2")
+                self.set_env(resumelib.MANUAL_ENV, "1")
+                resumed_rc, resumed_out = self.run_phase(spec["key"], args)
+
+                self.assertEqual(resumed_rc, 0, resumed_out)
+                self.assertEqual((captures / f"{case_name}.count").read_text(), "xx")
+                self.assertEqual((self.work_dir() / prompt_rel).read_text(), phaselib._MANUAL_SESSION_RESUME_PROMPT)
+                self.assertEqual(resumelib.active_entries(self.run_dir), [])
+                self.assertEqual(resumelib.completed_entries(self.run_dir), [])
+
     def test_manual_resume_skips_accepted_targets_then_runs_pending_targets(self) -> None:
         artifact = self.tmp() / "repo"
         artifact.mkdir()
@@ -3247,6 +3327,67 @@ class TestReviewPhase(PhaseCase):
             )
 
         self.assertFalse(marker.exists())
+
+    def test_manual_resume_reaches_exact_session_for_each_review_phase(self) -> None:
+        captures = self.tmp()
+        self.set_env("CAPTURE_DIR", str(captures))
+        self.set_env("SPECULA_PROGRESS", "off")
+        self.install_adapter(
+            "fake",
+            "log= resume=\n"
+            'for arg do case "$arg" in '
+            "--log=*) log=${arg#*=} ;; "
+            "--resume-state=*) resume=${arg#*=} ;; "
+            "esac; done\n"
+            'stem=$(basename "$log" .log)\n'
+            'count="$CAPTURE_DIR/$stem.count"\n'
+            'printf x >> "$count"\n'
+            'attempt=$(wc -c < "$count")\n'
+            'if [ "$attempt" -eq 1 ]; then\n'
+            '  printf "%s-session\n" "$stem" > "$resume"\n'
+            '  printf "interrupted\n" > "$log"\n'
+            "  exit 9\n"
+            "fi\n"
+            'test "$(cat "$resume")" = "$stem-session"\n'
+            'case "$stem" in\n'
+            '  review-analysis) output="$SPECULA_WORK_DIR/review-analysis.md" ;;\n'
+            '  review-specgen) output="$SPECULA_WORK_DIR/spec/review-specgen.md" ;;\n'
+            '  review-validation) output="$SPECULA_WORK_DIR/spec/review-validation.md" ;;\n'
+            "esac\n"
+            'mkdir -p "$(dirname "$output")"\n'
+            'printf "review\n" > "$output"\n'
+            'printf "continued\n" > "$log"\n',
+        )
+        cases = (
+            ("analysis", ".review-analysis-prompt.md"),
+            ("specgen", "spec/.review-specgen-prompt.md"),
+            ("validation", "spec/.review-validation-prompt.md"),
+        )
+
+        for phase, prompt_rel in cases:
+            with self.subTest(phase=phase):
+                self.run_dir = self.tmp()
+                self.set_env("SPECULA_RUN_DIR", str(self.run_dir))
+                self.set_env(resumelib.INVOCATION_ENV, f"review-{phase}-invocation-1")
+                self.set_env(resumelib.MANUAL_ENV, None)
+                resumelib.initialize_run(self.run_dir)
+                resumelib.save_configuration(self.run_dir, {"agent": "fake"})
+                args = [phase, "--agent=fake", "--transient-resumes=0", NAME]
+
+                first_rc, first_out = self.run_phase("review", args)
+                self.assertEqual(first_rc, 9, first_out)
+                active = resumelib.active_entries(self.run_dir)
+                self.assertEqual([entry["phase"] for entry in active], [f"review:{phase}"])
+
+                self.set_env(resumelib.INVOCATION_ENV, f"review-{phase}-invocation-2")
+                self.set_env(resumelib.MANUAL_ENV, "1")
+                resumed_rc, resumed_out = self.run_phase("review", args)
+
+                self.assertEqual(resumed_rc, 0, resumed_out)
+                self.assertEqual((captures / f"review-{phase}.count").read_text(), "xx")
+                self.assertEqual((self.work_dir() / prompt_rel).read_text(), phaselib._MANUAL_SESSION_RESUME_PROMPT)
+                self.assertEqual(resumelib.active_entries(self.run_dir), [])
+                self.assertEqual(resumelib.completed_entries(self.run_dir), [])
 
     def test_review_streams_activity_through_shared_monitor(self) -> None:
         event = json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "reviewing"}})

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -32,6 +32,7 @@ from unittest import mock
 SRC = Path(__file__).resolve().parents[2] / "src"
 
 from specula import pipelinelib as pl
+from specula import resumelib
 from specula.phaselib import Workspace, _logical_cwd
 from specula.snapshotlib import SOURCE_MAP, SnapshotError
 
@@ -499,6 +500,42 @@ def write_agent_config(path: Path, phases: dict[str, str] | None = None) -> Path
 
 
 class TestParsing(TmpCwd):
+    def test_manual_resume_positions_pipeline_at_each_unfinished_phase(self) -> None:
+        skip_fields = (
+            "skip_analysis",
+            "skip_specgen",
+            "skip_harness",
+            "skip_validation",
+            "skip_confirmation",
+        )
+        expected = {
+            "code_analysis": (),
+            "review:analysis": ("skip_analysis",),
+            "spec_generation": ("skip_analysis",),
+            "review:specgen": ("skip_analysis", "skip_specgen"),
+            "harness_generation": ("skip_analysis", "skip_specgen"),
+            "spec_validation": ("skip_analysis", "skip_specgen", "skip_harness"),
+            "review:validation": ("skip_analysis", "skip_specgen", "skip_harness", "skip_validation"),
+            "bug_confirmation": ("skip_analysis", "skip_specgen", "skip_harness", "skip_validation"),
+            "bug_classification": skip_fields,
+        }
+
+        for phase, skipped in expected.items():
+            with self.subTest(phase=phase):
+                pipeline = pl.Pipeline()
+                pipeline._manual_resume_phase = phase
+                pipeline._position_at_manual_resume_phase()
+                self.assertEqual(
+                    {field for field in skip_fields if getattr(pipeline, field)},
+                    set(skipped),
+                )
+
+    def test_manual_resume_rejects_unknown_phase(self) -> None:
+        pipeline = pl.Pipeline()
+        pipeline._manual_resume_phase = "unknown"
+        with self.assertRaisesRegex(resumelib.ResumeError, "cannot position the pipeline"):
+            pipeline._position_at_manual_resume_phase()
+
     def test_keep_original_is_opt_in_and_requires_isolation(self) -> None:
         default = pl.Pipeline()
         self.assertIsNone(default.parse_args(["t|g|l|r"]))
@@ -2143,6 +2180,33 @@ class TestRepairLoop(RRDirCase):
         self.assertIn("Resuming pending repair requests before the ordinary Phase 3 pass", out)
         self.assertIn("Ordinary Phase 3 covered for every target by the resumed repair loop", out)
         self.assertIn("Initial Phase 4 completed by the resumed repair loop", out)
+
+    def test_manual_phase4_resume_precedes_existing_open_repairs(self) -> None:
+        make_rr(self.rr_dir, "RR-1", "OPEN")
+        events: list[str] = []
+
+        self.p.skip_analysis = True
+        self.p.skip_specgen = True
+        self.p.skip_harness = True
+        self.p.skip_validation = True
+        self.p.skip_classification = True
+        self.p._manual_resume_phase = "bug_confirmation"
+        self.p.validate_agent_adapter = lambda: None  # type: ignore[method-assign]
+        self.p.generate_summary = lambda: None  # type: ignore[method-assign]
+        self.p.wait_for_quota = lambda **kwargs: None  # type: ignore[method-assign]
+        self.p.run_phase4_confirmation = lambda: events.append("resume-phase4")  # type: ignore[method-assign]
+
+        def repair_after_resume(*_args: Any, **_kwargs: Any) -> set[str]:
+            self.assertEqual(events, ["resume-phase4"])
+            events.append("repair")
+            return {"footest"}
+
+        self.p.run_repair_loop = repair_after_resume  # type: ignore[method-assign]
+
+        rc, _out = quiet(self.p.main)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(events, ["resume-phase4", "repair"])
 
     def test_committed_repair_cannot_be_skipped_and_mutated_by_ordinary_phase3(self) -> None:
         for skip_confirmation, skip_repair in ((True, False), (False, True)):

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -536,6 +536,54 @@ class TestParsing(TmpCwd):
         with self.assertRaisesRegex(resumelib.ResumeError, "cannot position the pipeline"):
             pipeline._position_at_manual_resume_phase()
 
+    def test_pipeline_success_exit_rejects_leftover_active_conversation(self) -> None:
+        run = self.tmp / "run"
+        run.mkdir()
+        resumelib.initialize_run(run)
+        resumelib.save_configuration(run, {"agent": "fake"})
+        pipeline = make_pipeline(
+            ["foo|owner/repo|Go|ref"],
+            run_dir=run,
+            run_id="run",
+            skip_analysis=True,
+            skip_specgen=True,
+            skip_harness=True,
+            skip_validation=True,
+            skip_confirmation=True,
+            skip_classification=True,
+            skip_repair_loop=True,
+        )
+        pipeline.validate_agent_adapter = lambda: None  # type: ignore[method-assign]
+        pipeline.refresh_output_indexes = lambda: None  # type: ignore[method-assign]
+        pipeline.generate_summary = mock.Mock()  # type: ignore[method-assign]
+        work = run / "foo" / ".specula-output"
+        env = {
+            "SPECULA_RUN_DIR": str(run),
+            resumelib.INVOCATION_ENV: "invocation-1",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            resumelib.prepare_turn(
+                ("phase", "bug_classification", "foo"),
+                phase="bug_classification",
+                target="foo",
+                kind="phase",
+                adapter=Path("fake"),
+                model=None,
+                effort=None,
+                claude_alias="claude",
+                cwd=self.tmp,
+                resume_state=work / "bug-classification.resume.json",
+                prompt_file=work / ".bug-classification-prompt.md",
+                log_file=work / "bug-classification.log",
+            )
+            rc, out = quiet(pipeline.main)
+
+        self.assertEqual(rc, 1)
+        self.assertIn("cannot complete with unfinished conversation", out)
+        self.assertNotIn("Pipeline completed", out)
+        pipeline.generate_summary.assert_not_called()
+        self.assertEqual(len(resumelib.active_entries(run)), 1)
+
     def test_keep_original_is_opt_in_and_requires_isolation(self) -> None:
         default = pl.Pipeline()
         self.assertIsNone(default.parse_args(["t|g|l|r"]))

--- a/tests/unit/test_resumelib.py
+++ b/tests/unit/test_resumelib.py
@@ -1,0 +1,273 @@
+"""Contract tests for durable unfinished-conversation ownership."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from specula import resumelib
+
+
+@dataclass(frozen=True)
+class TurnFiles:
+    cwd: Path
+    resume_state: Path
+    prompt_file: Path
+    log_file: Path
+
+
+def _enable_resume(
+    run_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    invocation: str = "invocation-1",
+) -> None:
+    resumelib.initialize_run(run_dir)
+    resumelib.save_configuration(run_dir, {"agent": "codex"})
+    monkeypatch.setenv("SPECULA_RUN_DIR", str(run_dir))
+    monkeypatch.setenv(resumelib.INVOCATION_ENV, invocation)
+    monkeypatch.delenv(resumelib.MANUAL_ENV, raising=False)
+    monkeypatch.delenv(resumelib.FRESH_ENV, raising=False)
+
+
+def _turn_files(run_dir: Path) -> TurnFiles:
+    work_dir = run_dir / "target" / ".specula-output"
+    work_dir.mkdir(parents=True)
+    return TurnFiles(
+        cwd=run_dir / "source",
+        resume_state=work_dir / "phase.resume.json",
+        prompt_file=work_dir / "phase.prompt.md",
+        log_file=work_dir / "phase.log",
+    )
+
+
+def _prepare(
+    files: TurnFiles,
+    *,
+    logical: tuple[str, ...] = ("phase", "validation", "target"),
+    phase: str = "validation",
+    model: str | None = "model-a",
+) -> resumelib.ResumeClaim:
+    return resumelib.prepare_turn(
+        logical,
+        phase=phase,
+        target="target",
+        kind="phase",
+        adapter=Path("/adapters/codex.py"),
+        model=model,
+        effort="high",
+        claude_alias="claude",
+        cwd=files.cwd,
+        resume_state=files.resume_state,
+        prompt_file=files.prompt_file,
+        log_file=files.log_file,
+    )
+
+
+def _start_manual_resume(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(resumelib.INVOCATION_ENV, "invocation-2")
+    monkeypatch.setenv(resumelib.MANUAL_ENV, "1")
+
+
+def test_fresh_turn_registration(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+
+    claim = _prepare(files)
+
+    assert claim == resumelib.ResumeClaim(attempt=1, manual=False, resumable=False)
+    entries = resumelib.active_entries()
+    assert len(entries) == 1
+    assert entries[0]["logical"] == ["phase", "validation", "target"]
+    assert entries[0]["owner"] == "invocation-1"
+
+
+def test_same_invocation_automatically_claims_native_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    _prepare(files)
+    files.resume_state.write_text('{"session_id": "session-1"}\n')
+
+    claim = _prepare(files)
+
+    assert claim == resumelib.ResumeClaim(attempt=2, manual=False, resumable=True)
+
+
+def test_new_invocation_manually_claims_exact_native_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    _prepare(files)
+    files.resume_state.write_text('{"session_id": "session-1"}\n')
+    _start_manual_resume(monkeypatch)
+
+    claim = _prepare(files)
+
+    assert claim == resumelib.ResumeClaim(attempt=2, manual=True, resumable=True)
+    assert resumelib.active_entries()[0]["owner"] == "invocation-2"
+
+
+def test_manual_claim_restores_retry_cursor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    logical = ("phase", "validation", "target")
+    _prepare(files, logical=logical)
+    resumelib.update_turn(
+        logical,
+        rate_limit_attempt=3,
+        policy_attempt=2,
+        transient_attempt=1,
+        invocation_attempt=6,
+        retry_reason="rate_limit",
+    )
+    files.resume_state.write_text('{"session_id": "session-1"}\n')
+    _start_manual_resume(monkeypatch)
+
+    claim = _prepare(files, logical=logical)
+
+    assert claim.rate_limit_attempt == 3
+    assert claim.policy_attempt == 2
+    assert claim.transient_attempt == 1
+    assert claim.invocation_attempt == 6
+    assert claim.retry_reason == "rate_limit"
+
+
+def test_completed_turn_is_not_resumed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    logical = ("phase", "validation", "target")
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    _prepare(files, logical=logical)
+    files.resume_state.write_text('{"session_id": "completed-session"}\n')
+    resumelib.complete_turn(logical)
+    _start_manual_resume(monkeypatch)
+
+    claim = _prepare(files, logical=logical)
+
+    assert claim == resumelib.ResumeClaim(attempt=1, manual=False, resumable=False)
+    assert resumelib.active_entries()[0]["owner"] == "invocation-2"
+
+
+@pytest.mark.parametrize("state_kind", ["missing", "directory"])
+def test_manual_resume_fails_closed_for_unusable_native_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    state_kind: str,
+) -> None:
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    _prepare(files)
+    if state_kind == "directory":
+        files.resume_state.mkdir()
+    _start_manual_resume(monkeypatch)
+
+    with pytest.raises(resumelib.ResumeError, match="native session state|unsafe native session state"):
+        _prepare(files)
+
+    assert resumelib.active_entries()[0]["owner"] == "invocation-1"
+
+
+def test_manual_resume_fails_closed_for_binding_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    _prepare(files)
+    files.resume_state.write_text('{"session_id": "session-1"}\n')
+    _start_manual_resume(monkeypatch)
+
+    with pytest.raises(resumelib.ResumeError, match=r"recorded model='model-a'.*current value is 'model-b'"):
+        _prepare(files, model="model-b")
+
+    assert resumelib.active_entries()[0]["owner"] == "invocation-1"
+
+
+def test_manual_resume_preserves_phase_and_turn_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    _prepare(files)
+    _start_manual_resume(monkeypatch)
+
+    resumelib.ensure_phase("validation")
+    with pytest.raises(resumelib.ResumeError, match="unfinished conversation.*validation"):
+        resumelib.ensure_phase("model-checking")
+    with pytest.raises(resumelib.ResumeError, match="native session state path already belongs"):
+        _prepare(files, logical=("phase", "validation", "other-target"))
+
+
+@pytest.mark.parametrize("linked_component", ["root", "active", "completed"])
+def test_fresh_reset_rejects_resume_directory_symlinks_without_deleting_outside(
+    tmp_path: Path,
+    linked_component: str,
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.json"
+    victim.write_text('{"keep": true}\n')
+
+    if linked_component == "root":
+        resumelib.resume_dir(run_dir).symlink_to(outside, target_is_directory=True)
+    else:
+        resumelib.resume_dir(run_dir).mkdir()
+        linked_dir = resumelib.active_dir(run_dir) if linked_component == "active" else resumelib.completed_dir(run_dir)
+        linked_dir.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(resumelib.ResumeError, match="not a real directory"):
+        resumelib.initialize_run(run_dir, reset=True)
+
+    assert victim.read_text() == '{"keep": true}\n'
+
+
+def test_corrupt_active_record_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    _prepare(files)
+    record = next(resumelib.active_dir(tmp_path).glob("*.json"))
+    data = json.loads(record.read_text())
+    data["attempt"] = "two"
+    record.write_text(json.dumps(data))
+
+    with pytest.raises(resumelib.ResumeError, match="invalid active conversation attempt"):
+        resumelib.active_entries()
+
+
+@pytest.mark.parametrize("record_state", ["active", "completed"])
+def test_record_with_noncanonical_filename_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    record_state: str,
+) -> None:
+    logical = ("phase", "validation", "target")
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    _prepare(files, logical=logical)
+    if record_state == "completed":
+        resumelib.mark_completed(logical)
+        directory = resumelib.completed_dir(tmp_path)
+    else:
+        directory = resumelib.active_dir(tmp_path)
+    record = next(directory.glob("*.json"))
+    record.rename(directory / "wrong.json")
+
+    reader = resumelib.completed_entries if record_state == "completed" else resumelib.active_entries
+    with pytest.raises(resumelib.ResumeError, match="invalid .* filename"):
+        reader()

--- a/tests/unit/test_resumelib.py
+++ b/tests/unit/test_resumelib.py
@@ -155,7 +155,59 @@ def test_completed_turn_is_not_resumed(tmp_path: Path, monkeypatch: pytest.Monke
     claim = _prepare(files, logical=logical)
 
     assert claim == resumelib.ResumeClaim(attempt=1, manual=False, resumable=False)
+    assert not files.resume_state.exists()
     assert resumelib.active_entries()[0]["owner"] == "invocation-2"
+
+
+def test_new_turn_clears_stale_native_state_before_publishing_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    files.resume_state.write_text("OLD-COMPLETED-SESSION")
+
+    _prepare(files)
+
+    assert not files.resume_state.exists()
+    assert len(resumelib.active_entries()) == 1
+
+
+def test_new_turn_does_not_publish_checkpoint_when_stale_state_cannot_be_cleared(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    files.resume_state.mkdir()
+
+    with pytest.raises(resumelib.ResumeError, match="cannot clear stale native session state"):
+        _prepare(files)
+
+    assert resumelib.active_entries() == []
+
+
+def test_crash_after_native_state_cleanup_leaves_no_misbound_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    files.resume_state.write_text("OLD-COMPLETED-SESSION")
+    original_write = resumelib._atomic_write
+
+    def crash_before_active(path: Path, data: dict[str, object]) -> None:
+        if path.parent == resumelib.active_dir(tmp_path):
+            raise OSError("injected checkpoint publication crash")
+        original_write(path, data)
+
+    monkeypatch.setattr(resumelib, "_atomic_write", crash_before_active)
+
+    with pytest.raises(OSError, match="injected checkpoint publication crash"):
+        _prepare(files)
+
+    assert not files.resume_state.exists()
+    assert resumelib.active_entries() == []
 
 
 @pytest.mark.parametrize("state_kind", ["missing", "directory"])
@@ -166,9 +218,13 @@ def test_manual_resume_fails_closed_for_unusable_native_state(
 ) -> None:
     _enable_resume(tmp_path, monkeypatch)
     files = _turn_files(tmp_path)
+    if state_kind == "missing":
+        files.resume_state.write_text("OLD-COMPLETED-SESSION")
     _prepare(files)
     if state_kind == "directory":
         files.resume_state.mkdir()
+    else:
+        assert not files.resume_state.exists()
     _start_manual_resume(monkeypatch)
 
     with pytest.raises(resumelib.ResumeError, match="native session state|unsafe native session state"):
@@ -191,6 +247,98 @@ def test_manual_resume_fails_closed_for_binding_mismatch(
         _prepare(files, model="model-b")
 
     assert resumelib.active_entries()[0]["owner"] == "invocation-1"
+
+
+@pytest.mark.parametrize("mutation", ["update", "complete", "mark_completed"])
+def test_previous_owner_cannot_mutate_claimed_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+) -> None:
+    logical = ("phase", "validation", "target")
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    _prepare(files, logical=logical)
+    files.resume_state.write_text('{"session_id": "session-1"}\n')
+    _start_manual_resume(monkeypatch)
+    _prepare(files, logical=logical)
+    claimed = resumelib.active_entries()[0]
+
+    monkeypatch.setenv(resumelib.INVOCATION_ENV, "invocation-1")
+    with pytest.raises(resumelib.ResumeError, match="checkpoint ownership changed"):
+        if mutation == "update":
+            resumelib.update_turn(logical, invocation_attempt=9)
+        elif mutation == "complete":
+            resumelib.complete_turn(logical)
+        else:
+            resumelib.mark_completed(logical)
+
+    assert resumelib.active_entries()[0] == claimed
+    assert resumelib.completed_entries() == []
+
+
+def test_previous_owner_cannot_clear_new_completed_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logical = ("phase", "validation", "target")
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    _prepare(files, logical=logical)
+    files.resume_state.write_text('{"session_id": "session-1"}\n')
+    _start_manual_resume(monkeypatch)
+    _prepare(files, logical=logical)
+    resumelib.mark_completed(logical)
+    completed = resumelib.completed_entries()[0]
+
+    monkeypatch.setenv(resumelib.INVOCATION_ENV, "invocation-1")
+    monkeypatch.delenv(resumelib.MANUAL_ENV, raising=False)
+    with pytest.raises(resumelib.ResumeError, match="checkpoint ownership changed"):
+        resumelib.clear_completed()
+
+    assert resumelib.completed_entries()[0] == completed
+
+
+def test_manual_resume_reconciles_completed_write_before_unlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logical = ("phase", "validation", "target")
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    _prepare(files, logical=logical)
+    active_path = next(resumelib.active_dir(tmp_path).glob("*.json"))
+    entry = json.loads(active_path.read_text())
+    entry["updated_ns"] += 1
+    done_path = resumelib.completed_dir(tmp_path) / active_path.name
+    resumelib._atomic_write(done_path, entry)
+    _start_manual_resume(monkeypatch)
+
+    resumelib.reconcile_completed(logical)
+
+    assert resumelib.active_entries() == []
+    assert resumelib.completed_logicals() == {logical}
+
+
+def test_manual_resume_rejects_mismatched_completed_crash_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logical = ("phase", "validation", "target")
+    _enable_resume(tmp_path, monkeypatch)
+    files = _turn_files(tmp_path)
+    _prepare(files, logical=logical)
+    active_path = next(resumelib.active_dir(tmp_path).glob("*.json"))
+    entry = json.loads(active_path.read_text())
+    entry["attempt"] += 1
+    entry["updated_ns"] += 1
+    resumelib._atomic_write(resumelib.completed_dir(tmp_path) / active_path.name, entry)
+    _start_manual_resume(monkeypatch)
+
+    with pytest.raises(resumelib.ResumeError, match="does not match active conversation"):
+        resumelib.reconcile_completed(logical)
+
+    assert len(resumelib.active_entries()) == 1
 
 
 def test_manual_resume_preserves_phase_and_turn_order(

--- a/tests/unit/test_workspace_isolation.py
+++ b/tests/unit/test_workspace_isolation.py
@@ -25,6 +25,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from typing import Any
@@ -46,6 +47,7 @@ class EnvIsolatedCase(unittest.TestCase):
             resumelib.INVOCATION_ENV,
             resumelib.MANUAL_ENV,
             resumelib.FRESH_ENV,
+            resumelib.RUN_LOCK_FD_ENV,
             "SPECULA_TLC_SCOPE",
             "SPECULA_TLC_MEMORY_LIMIT",
             "SPECULA_TLC_WORKER_LIMIT",
@@ -591,6 +593,22 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
             self.assertEqual(resumed.resolve_run_dir(), 1)
         self.assertIn("no unfinished agent conversation", err.getvalue())
 
+    def test_attach_rejects_skip_for_interrupted_classification(self) -> None:
+        root = self.tmp()
+        first = self._pipeline(["--run-id=classification", "foo|o/r|Go|ref"], root)
+        self._seed_active_turn(first, phase="bug_classification")
+        assert first.run_dir is not None
+        before = resumelib.active_entries(first.run_dir)
+
+        resumed = pl.Pipeline()
+        self.assertIsNone(resumed.parse_args(["--run-id=classification", "--skip-classification"]))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(resumed.resolve_run_dir(acquire_lock=True), 1)
+
+        self.assertIn("cannot use --skip-classification", err.getvalue())
+        self.assertEqual(resumelib.active_entries(first.run_dir), before)
+
     def test_legacy_run_requires_fresh_context(self) -> None:
         root = self.tmp()
         run = root / "runs" / "legacy-resume"
@@ -631,8 +649,52 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
         with contextlib.redirect_stderr(err):
             self.assertEqual(contender.resolve_run_dir(acquire_lock=True), 1)
 
-        self.assertIn("already active", err.getvalue())
+        self.assertIn("wait for it to finish or terminate it manually", err.getvalue())
         self.assertEqual(resumelib.active_entries(running.run_dir), before)
+
+    def test_live_inherited_run_lock_blocks_attach_after_dispatcher_closes(self) -> None:
+        root = self.tmp()
+        running = self._pipeline(["--run-id=orphaned", "foo|o/r|Go|ref"], root)
+        self._seed_active_turn(running)
+        running._acquire_run_lock()
+        assert running._run_lock_fd is not None
+        marker = self.tmp() / "phase-started"
+        child = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import pathlib,sys,time; pathlib.Path(sys.argv[1]).write_text('ready'); time.sleep(60)",
+                str(marker),
+            ],
+            pass_fds=(running._run_lock_fd,),
+        )
+        self.addCleanup(child.kill)
+        deadline = time.monotonic() + 5
+        while not marker.is_file() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(marker.is_file())
+        assert running.run_dir is not None
+        before = resumelib.active_entries(running.run_dir)
+
+        # Model SIGKILL of the dispatcher: its fd closes without LOCK_UN while
+        # the inherited phase/agent lease remains live.
+        running._release_run_lock()
+        contender = pl.Pipeline()
+        self.assertIsNone(contender.parse_args(["--run-id=orphaned"]))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(contender.resolve_run_dir(acquire_lock=True), 1)
+
+        self.assertIn("live phase or agent", err.getvalue())
+        self.assertIn("terminate it manually", err.getvalue())
+        self.assertEqual(resumelib.active_entries(running.run_dir), before)
+
+        child.terminate()
+        child.wait(timeout=5)
+        resumed = pl.Pipeline()
+        self.assertIsNone(resumed.parse_args(["--run-id=orphaned"]))
+        self.assertIsNone(resumed.resolve_run_dir(acquire_lock=True))
+        self.addCleanup(resumed._release_run_lock)
 
     def test_run_lock_rejects_symlink(self) -> None:
         root = self.tmp()

--- a/tests/unit/test_workspace_isolation.py
+++ b/tests/unit/test_workspace_isolation.py
@@ -31,7 +31,7 @@ from typing import Any
 
 PKG = Path(__file__).resolve().parents[2] / "src" / "specula"
 
-from specula import phaselib
+from specula import phaselib, resumelib
 from specula import pipelinelib as pl
 
 RUN_ID_RE = re.compile(r"^\d{8}-\d{6}-[0-9a-f]{4}$")
@@ -43,6 +43,9 @@ class EnvIsolatedCase(unittest.TestCase):
     def setUp(self) -> None:
         names = (
             "SPECULA_RUN_DIR",
+            resumelib.INVOCATION_ENV,
+            resumelib.MANUAL_ENV,
+            resumelib.FRESH_ENV,
             "SPECULA_TLC_SCOPE",
             "SPECULA_TLC_MEMORY_LIMIT",
             "SPECULA_TLC_WORKER_LIMIT",
@@ -331,6 +334,30 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
         self.assertIsNone(p.resolve_run_dir())
         return p
 
+    def _seed_active_turn(
+        self,
+        pipeline: pl.Pipeline,
+        *,
+        phase: str = "code_analysis",
+        target: str = "foo",
+    ) -> None:
+        assert pipeline.run_dir is not None
+        work = pipeline.run_dir / target / ".specula-output"
+        resumelib.prepare_turn(
+            ("phase", phase, target),
+            phase=phase,
+            target=target,
+            kind="phase",
+            adapter=Path("codex"),
+            model="gpt-5.5",
+            effort="high",
+            claude_alias="work",
+            cwd=Path.cwd().resolve(),
+            resume_state=work / "agent.resume.json",
+            prompt_file=work / "agent-prompt.md",
+            log_file=work / "agent.log",
+        )
+
     def test_isolate_creates_run_and_meta(self) -> None:
         root = self.tmp()
         argv = ["--isolate", "--agent=claude-code", "foo|o/r|Go|ref"]
@@ -353,6 +380,293 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
         self.assertEqual(os.environ["SPECULA_RUN_DIR"], str(p.run_dir))
         self.assertEqual(os.environ["SPECULA_TLC_SCOPE"], str(p.run_dir.resolve()))
 
+    def test_new_run_writes_resume_configuration(self) -> None:
+        root = self.tmp()
+        p = self._pipeline(
+            [
+                "--run-id=resume-config",
+                "--agent=codex",
+                "--model=gpt-5.5",
+                "--effort=high",
+                "--claude-alias=work",
+                "foo|o/r|Go|ref",
+            ],
+            root,
+        )
+        assert p.run_dir is not None
+
+        stored = json.loads(resumelib.config_path(p.run_dir).read_text())
+        self.assertEqual(stored["version"], 1)
+        self.assertEqual(
+            stored["configuration"]["default"],
+            {"agent": "codex", "model": "gpt-5.5", "effort": "high"},
+        )
+        self.assertEqual(stored["configuration"]["claude_alias"], "work")
+        self.assertEqual(stored["configuration"]["targets"], ["foo|o/r|Go|ref"])
+
+    def test_attach_restores_omitted_agent_tuning_alias_and_targets(self) -> None:
+        root = self.tmp()
+        first = self._pipeline(
+            [
+                "--run-id=restore",
+                "--agent=codex",
+                "--model=gpt-5.5",
+                "--effort=high",
+                "--claude-alias=work",
+                "foo|o/r|Go|ref",
+                "bar|o/r|Rust|ref",
+            ],
+            root,
+        )
+        self._seed_active_turn(first)
+
+        resumed = pl.Pipeline()
+        self.assertIsNone(resumed.parse_args(["--run-id=restore"]))
+        self.assertIsNone(resumed.resolve_run_dir())
+
+        self.assertEqual(resumed.agent, "codex")
+        self.assertEqual(resumed.model, "gpt-5.5")
+        self.assertEqual(resumed.effort, "high")
+        self.assertEqual(resumed.claude_alias, "work")
+        self.assertEqual(resumed.targets, ["foo|o/r|Go|ref", "bar|o/r|Rust|ref"])
+        self.assertEqual(resumed._manual_resume_phase, "code_analysis")
+
+    def test_attach_restores_original_in_place_launcher_cwd(self) -> None:
+        original_cwd = Path.cwd()
+        self.addCleanup(os.chdir, original_cwd)
+        launch_cwd = self.tmp()
+        other_cwd = self.tmp()
+        root = self.tmp()
+        os.chdir(launch_cwd)
+        first = self._pipeline(["--run-id=restore-cwd", "foo|o/r|Go|ref"], root)
+        self._seed_active_turn(first)
+
+        os.chdir(other_cwd)
+        resumed = pl.Pipeline()
+        self.assertIsNone(resumed.parse_args(["--run-id=restore-cwd"]))
+        self.assertIsNone(resumed.resolve_run_dir())
+
+        self.assertEqual(resumed._manual_launch_cwd, launch_cwd.resolve())
+
+    def test_fresh_context_restores_omitted_run_config_and_allows_override(self) -> None:
+        root = self.tmp()
+        first = self._pipeline(
+            [
+                "--run-id=fresh-config",
+                "--agent=codex",
+                "--model=gpt-old",
+                "--effort=high",
+                "--claude-alias=work",
+                "foo|o/r|Go|ref",
+            ],
+            root,
+        )
+        self._seed_active_turn(first)
+
+        resumed = pl.Pipeline()
+        self.assertIsNone(resumed.parse_args(["--run-id=fresh-config", "--fresh-context", "--model=gpt-new"]))
+        self.assertIsNone(resumed.resolve_run_dir())
+
+        assert resumed.run_dir is not None
+        self.assertEqual(resumed.agent, "codex")
+        self.assertEqual(resumed.model, "gpt-new")
+        self.assertEqual(resumed.effort, "high")
+        self.assertEqual(resumed.claude_alias, "work")
+        self.assertEqual(resumed.targets, ["foo|o/r|Go|ref"])
+        self.assertEqual(resumelib.active_entries(resumed.run_dir), [])
+        self.assertEqual(os.environ[resumelib.FRESH_ENV], "1")
+        self.assertNotIn(resumelib.MANUAL_ENV, os.environ)
+
+    def test_fresh_agent_and_confirmation_mode_do_not_inherit_incompatible_tuning(self) -> None:
+        root = self.tmp()
+        first = self._pipeline(
+            [
+                "--run-id=fresh-mode",
+                "--agent=claude-code",
+                "--model=claude-old",
+                "--effort=max",
+                "--confirm-debate",
+                "foo|o/r|Go|ref",
+            ],
+            root,
+        )
+        self._seed_active_turn(first)
+
+        resumed = pl.Pipeline()
+        self.assertIsNone(
+            resumed.parse_args(["--run-id=fresh-mode", "--fresh-context", "--agent=codex", "--legacy-confirm"])
+        )
+        self.assertIsNone(resumed.resolve_run_dir())
+
+        self.assertEqual(resumed.agent, "codex")
+        self.assertIsNone(resumed.model)
+        self.assertIsNone(resumed.effort)
+        self.assertTrue(resumed.confirm_legacy)
+        self.assertFalse(resumed.confirm_debate)
+
+    def test_attach_restores_confirmation_mode_and_limits(self) -> None:
+        for mode_flag, attr in (
+            ("--legacy-confirm", "confirm_legacy"),
+            ("--confirm-debate", "confirm_debate"),
+        ):
+            with self.subTest(mode=mode_flag):
+                root = self.tmp()
+                first = self._pipeline(
+                    [
+                        "--run-id=mode",
+                        mode_flag,
+                        "--max-parallel=3",
+                        "--max-turns=9",
+                        "foo|o/r|Go|ref",
+                    ],
+                    root,
+                )
+                self._seed_active_turn(first, phase="bug_confirmation")
+
+                resumed = pl.Pipeline()
+                self.assertIsNone(resumed.parse_args(["--run-id=mode"]))
+                self.assertIsNone(resumed.resolve_run_dir())
+                self.assertTrue(getattr(resumed, attr))
+                self.assertEqual(resumed.max_parallel, "3")
+                self.assertEqual(resumed.max_turns, "9")
+
+    def test_attach_rejects_changed_targets_and_confirmation_mode(self) -> None:
+        root = self.tmp()
+        first = self._pipeline(["--run-id=shape", "foo|o/r|Go|ref"], root)
+        self._seed_active_turn(first)
+
+        for args in (
+            ["--run-id=shape", "other|o/r|Go|ref"],
+            ["--run-id=shape", "--legacy-confirm"],
+            ["--run-id=shape", "--confirm-debate"],
+            ["--run-id=shape", "--max-parallel=2"],
+            ["--run-id=shape", "--max-turns=8"],
+        ):
+            with self.subTest(args=args):
+                resumed = pl.Pipeline()
+                self.assertIsNone(resumed.parse_args(args))
+                err = io.StringIO()
+                with contextlib.redirect_stderr(err):
+                    self.assertEqual(resumed.resolve_run_dir(), 1)
+                self.assertIn("--fresh-context", err.getvalue())
+
+    def test_attach_rejects_incompatible_agent_overrides(self) -> None:
+        root = self.tmp()
+        first = self._pipeline(
+            [
+                "--run-id=override",
+                "--agent=codex",
+                "--model=gpt-5.5",
+                "--effort=high",
+                "--claude-alias=work",
+                "foo|o/r|Go|ref",
+            ],
+            root,
+        )
+        self._seed_active_turn(first)
+
+        overrides = (
+            "--agent=claude-code",
+            "--model=gpt-5.4",
+            "--effort=medium",
+            "--claude-alias=other",
+        )
+        for override in overrides:
+            with self.subTest(override=override):
+                resumed = pl.Pipeline()
+                self.assertIsNone(resumed.parse_args(["--run-id=override", override]))
+                err = io.StringIO()
+                with contextlib.redirect_stderr(err):
+                    self.assertEqual(resumed.resolve_run_dir(), 1)
+                self.assertIn("--fresh-context", err.getvalue())
+
+    def test_attach_without_unfinished_conversation_fails(self) -> None:
+        root = self.tmp()
+        self._pipeline(["--run-id=complete", "foo|o/r|Go|ref"], root)
+
+        resumed = pl.Pipeline()
+        self.assertIsNone(resumed.parse_args(["--run-id=complete"]))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(resumed.resolve_run_dir(), 1)
+        self.assertIn("no unfinished agent conversation", err.getvalue())
+
+    def test_legacy_run_requires_fresh_context(self) -> None:
+        root = self.tmp()
+        run = root / "runs" / "legacy-resume"
+        run.mkdir(parents=True)
+        (run / "run.json").write_text('{"run_id": "legacy-resume"}\n')
+        self.patch_root(pl, root)
+
+        resumed = pl.Pipeline()
+        self.assertIsNone(resumed.parse_args(["--run-id=legacy-resume", "foo|o/r|Go|ref"]))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(resumed.resolve_run_dir(), 1)
+        self.assertIn("resume config", err.getvalue())
+
+        fresh = pl.Pipeline()
+        self.assertIsNone(fresh.parse_args(["--run-id=legacy-resume", "--fresh-context", "foo|o/r|Go|ref"]))
+        self.assertIsNone(fresh.resolve_run_dir())
+        self.assertTrue(resumelib.config_path(run).is_file())
+
+    def test_fresh_context_requires_run_id(self) -> None:
+        p = pl.Pipeline()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(p.parse_args(["--fresh-context", "foo|o/r|Go|ref"]), 1)
+        self.assertIn("--fresh-context requires --run-id", err.getvalue())
+
+    def test_concurrent_fresh_attach_cannot_clear_active_checkpoint(self) -> None:
+        root = self.tmp()
+        running = self._pipeline(["--run-id=locked", "foo|o/r|Go|ref"], root)
+        self._seed_active_turn(running)
+        running._acquire_run_lock()
+        self.addCleanup(running._release_run_lock)
+        before = resumelib.active_entries(running.run_dir)
+
+        contender = pl.Pipeline()
+        self.assertIsNone(contender.parse_args(["--run-id=locked", "--fresh-context", "foo|o/r|Go|ref"]))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(contender.resolve_run_dir(acquire_lock=True), 1)
+
+        self.assertIn("already active", err.getvalue())
+        self.assertEqual(resumelib.active_entries(running.run_dir), before)
+
+    def test_run_lock_rejects_symlink(self) -> None:
+        root = self.tmp()
+        p = self._pipeline(["--run-id=unsafe-lock", "foo|o/r|Go|ref"], root)
+        assert p.run_dir is not None
+        outside = self.tmp() / "outside-lock"
+        outside.write_text("keep\n")
+        lock = resumelib.resume_dir(p.run_dir) / "run.lock"
+        lock.symlink_to(outside)
+
+        with self.assertRaisesRegex(resumelib.ResumeError, "safe run lock"):
+            p._acquire_run_lock()
+        self.assertEqual(outside.read_text(), "keep\n")
+
+    def test_attach_rejects_symlinked_run_directory_without_clearing_target(self) -> None:
+        root = self.tmp()
+        runs = root / "runs"
+        runs.mkdir()
+        outside = self.tmp()
+        resumelib.initialize_run(outside)
+        victim = resumelib.active_dir(outside) / "victim.json"
+        victim.write_text('{"keep": true}\n')
+        (runs / "unsafe-run").symlink_to(outside, target_is_directory=True)
+        self.patch_root(pl, root)
+
+        p = pl.Pipeline()
+        self.assertIsNone(p.parse_args(["--run-id=unsafe-run", "--fresh-context", "foo|o/r|Go|ref"]))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(p.resolve_run_dir(acquire_lock=True), 1)
+
+        self.assertIn("run directory is not a real directory", err.getvalue())
+        self.assertEqual(victim.read_text(), '{"keep": true}\n')
+
     def test_snapshot_mode_and_private_source_survive_resume_without_flag(self) -> None:
         root = self.tmp()
         original = self.tmp()
@@ -369,12 +683,38 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
         os.environ.pop("SPECULA_TLC_SCOPE", None)
         os.environ.pop("SPECULA_SOURCE_SNAPSHOT", None)
 
-        resumed = self._pipeline(["--run-id=private", "foo|o/r|Go|ref"], root)
+        resumed = self._pipeline(["--run-id=private", "--fresh-context", "foo|o/r|Go|ref"], root)
         resumed.prepare_source_snapshots(["foo"])
 
         self.assertTrue(resumed.keep_original)
         self.assertEqual((private / "agent.txt").read_text(), "keep\n")
         self.assertEqual(phaselib.Workspace(["foo"]).find_repo_dir("foo"), str(private))
+
+    def test_snapshot_manual_resume_does_not_require_original_artifact(self) -> None:
+        root = self.tmp()
+        original = self.tmp()
+        (original / "source.txt").write_text("original\n")
+        first = self._pipeline(
+            ["--run-id=private-resume", "--keep-original", f"--artifact={original}", "foo|o/r|Go|ref"],
+            root,
+        )
+        first.prepare_source_snapshots(["foo"])
+        self._seed_active_turn(first)
+        (original / "source.txt").unlink()
+        original.rmdir()
+        os.environ.pop("SPECULA_RUN_DIR", None)
+        os.environ.pop("SPECULA_TLC_SCOPE", None)
+        os.environ.pop("SPECULA_SOURCE_SNAPSHOT", None)
+
+        self.patch_root(pl, root)
+        resumed = pl.Pipeline()
+        self.assertIsNone(resumed.parse_args(["--run-id=private-resume"]))
+        self.assertIsNone(resumed.resolve_run_dir())
+
+        assert resumed.run_dir is not None
+        self.assertTrue(resumed.keep_original)
+        self.assertEqual(resumed.targets, ["foo|o/r|Go|ref"])
+        self.assertTrue((resumed.run_dir / "foo" / "source" / "source.txt").is_file())
 
     def test_meta_records_cli_tuning_over_environment(self) -> None:
         root = self.tmp()
@@ -490,7 +830,7 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
         (run / "foo" / ".specula-output").mkdir(parents=True)
         (run / "foo" / ".specula-output" / "keep.txt").write_text("keep")
         (run / "run.json").write_text('{"run_id": "myrun", "original": true}\n')
-        p = self._pipeline(["--run-id=myrun", "foo|o/r|Go|ref"], root)
+        p = self._pipeline(["--run-id=myrun", "--fresh-context", "foo|o/r|Go|ref"], root)
         self.assertEqual(p.run_dir, run)
         self.assertEqual((run / "foo" / ".specula-output" / "keep.txt").read_text(), "keep")
         # attach never rewrites the original record
@@ -506,7 +846,7 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
         os.environ.pop("SPECULA_RUN_DIR", None)
         os.environ.pop("SPECULA_TLC_SCOPE", None)
 
-        resumed = self._pipeline(["--run-id=myrun", "foo|o/r|Go|ref"], root)
+        resumed = self._pipeline(["--run-id=myrun", "--fresh-context", "foo|o/r|Go|ref"], root)
         self.assertEqual(resumed.tlc_memory_limit, "64G")
         self.assertEqual(resumed.tlc_worker_limit, "12")
 
@@ -517,7 +857,13 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
         (run / "run.json").write_text('{"run_id": "legacy", "original": true}\n')
 
         configured = self._pipeline(
-            ["--run-id=legacy", "--tlc-memory-limit=48G", "--tlc-worker-limit=10", "foo|o/r|Go|ref"],
+            [
+                "--run-id=legacy",
+                "--fresh-context",
+                "--tlc-memory-limit=48G",
+                "--tlc-worker-limit=10",
+                "foo|o/r|Go|ref",
+            ],
             root,
         )
         self.assertEqual(configured.tlc_memory_limit, "48G")
@@ -527,7 +873,7 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
         os.environ.pop("SPECULA_RUN_DIR", None)
         os.environ.pop("SPECULA_TLC_SCOPE", None)
 
-        resumed = self._pipeline(["--run-id=legacy", "foo|o/r|Go|ref"], root)
+        resumed = self._pipeline(["--run-id=legacy", "--fresh-context", "foo|o/r|Go|ref"], root)
         self.assertEqual(resumed.tlc_memory_limit, "48G")
         self.assertEqual(resumed.tlc_worker_limit, "10")
         self.assertTrue(json.loads((run / "run.json").read_text())["original"])
@@ -539,7 +885,7 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
         (run / "run.json").write_text('{"tlc_memory_limit": 64, "tlc_worker_limit": null}\n')
         self.patch_root(pl, root)
         p = pl.Pipeline()
-        self.assertIsNone(p.parse_args(["--run-id=legacy", "foo|o/r|Go|ref"]))
+        self.assertIsNone(p.parse_args(["--run-id=legacy", "--fresh-context", "foo|o/r|Go|ref"]))
 
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
@@ -560,7 +906,15 @@ class TestRunMetaAndAttach(EnvIsolatedCase):
         os.environ.pop("SPECULA_TLC_SCOPE", None)
         resumed = pl.Pipeline()
         self.assertIsNone(
-            resumed.parse_args(["--run-id=myrun", "--tlc-memory-limit=32G", "--tlc-worker-limit=8", "foo|o/r|Go|ref"])
+            resumed.parse_args(
+                [
+                    "--run-id=myrun",
+                    "--fresh-context",
+                    "--tlc-memory-limit=32G",
+                    "--tlc-worker-limit=8",
+                    "foo|o/r|Go|ref",
+                ]
+            )
         )
         err = io.StringIO()
         with contextlib.redirect_stderr(err):


### PR DESCRIPTION
## Summary

- resume the exact unfinished Claude Code, Codex, Copilot CLI, OpenCode, or Pi conversation with `specula run --run-id`
- return to the interrupted phase, reject live old phase/agent owners, and fail closed on mismatched session state
- preserve Phase 4 per-turn decisions so an interrupted debate resumes the exact frontier
- use `--fresh-context` to explicitly abandon previous agent context

Refs #123