### PR TITLE
Clarify target guidance across phase skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ specula run mysys \
 The `mysys-guidance.md` is optional but highly recommended.
 It is a configuration file that guides Specula to focus on target modules and scenarios,
 	with consistent modeling scope across runs.
-We provide a [template](./docs/modeling-guidance-template.md). 
+We provide a [template](./docs/modeling-guidance-template.md) and a
+[completed example](./docs/modeling-guidance-example.md).
 
 Outputs are stored in `runs/<run-id>`. 
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -370,6 +370,10 @@ specula run [options] "name|owner/repository|language|reference"
 
 `--dry-run` still creates the isolated run metadata, log, and summary files. The confirmation repair loop is enabled by default. `--max-repair-rounds=N` caps rounds across the whole loop, not attempts per request; when the cap is reached, remaining open requests are deferred. For the individual `specula confirm` command, the corresponding debate flags are `--debate` and `--rounds=N` (range `1` through `5`).
 
+When an interactive `specula run` has no `--guidance`, Specula asks before
+continuing. Non-interactive and batch runs print a warning and continue without
+waiting for input, so unattended jobs are not blocked.
+
 Use command-specific help for the authoritative option list:
 
 ```bash

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -122,7 +122,9 @@ Quote the target descriptor because `|` has special meaning in the shell. Its fi
 For more consistent scope across repeated runs and to focus resources on your
 highest-priority modules and scenarios, we recommend starting from the
 [modeling guidance template](./modeling-guidance-template.md) and passing your
-edited file to a single-target run:
+edited file to a single-target run. See the
+[completed SONiC linkmgrd example](./modeling-guidance-example.md) for a
+concrete configuration:
 
 ```bash
 specula run \

--- a/docs/modeling-guidance-example.md
+++ b/docs/modeling-guidance-example.md
@@ -1,0 +1,43 @@
+# Example: SONiC linkmgrd Modeling Guidance
+
+## Required
+
+### Goal
+
+- Assess correctness risks across Dual-ToR link and failover state management in `sonic-net/sonic-linkmgrd`.
+
+### Scope
+
+- In scope: both active-standby and active-active per-port control paths, from configuration, database, route, link, probe, and mux inputs through local and peer forwarding-state decisions and acknowledgements.
+- Boundaries/exclusions: read code outside linkmgrd only to establish caller and component contracts. Exclude packet encoding, Redis/SAI internals, physical mux implementation, and performance unless needed to establish a linkmgrd safety or recovery precondition.
+
+### Priority Questions
+
+1. Can a delayed, duplicated, reordered, or missing input or timeout leave a decision that no longer matches the current mode, health, route, or observed hardware state?
+   Expected behavior: decisions apply to the current context and converge when current observations persist.
+2. Can an accepted event be lost, applied twice, or reflected inconsistently across LinkProber, MuxState, LinkState, and LinkManager?
+   Expected behavior: component and composite states remain mutually consistent and required follow-up is not silently skipped.
+3. Across active-standby and active-active operation, can fault and recovery sequences cause a traffic blackhole, contradictory forwarding decisions, oscillation, or permanent failure to recover?
+   Expected behavior: each mode preserves its documented forwarding rules and recovers after the relevant health conditions recover.
+4. Can mode, configuration, default-route, startup, or warm-restart changes race with pending work so that pre-change work mutates post-change state or reconciliation finishes prematurely?
+   Expected behavior: lifecycle and configuration boundaries do not admit stale work, and retained state is reconciled before normal operation.
+5. Can events, timers, or state for one mux port affect another port's decisions or progress?
+   Expected behavior: per-port behavior remains isolated while shared service lifecycle operations remain consistent.
+
+### Must-cover Interactions
+
+- Database and configuration notifications in `src/DbInterface.cpp` ↔ dispatch through `src/MuxManager.cpp` and `src/MuxPort.cpp`.
+- Link-prober events in `src/link_prober/LinkProberStateMachineBase.cpp` ↔ active-standby and active-active LinkManager transitions.
+- Mux and physical-link state machines ↔ composite LinkManager state and emitted forwarding commands.
+- LinkManager timers and callbacks ↔ responses and later state or configuration changes in both operating modes.
+- Default-route and warm-restart handling in `doc/default_route.md`, `src/DbInterface.cpp`, and `src/MuxManager.cpp` ↔ ongoing per-port transitions.
+
+### Assumptions
+
+- Treat the checked-out implementation and its actual call graph as ground truth; use `doc/default_route.md` only for its stated intended behavior.
+
+## Optional
+
+### Suggested Starting Points
+
+- `src/DbInterface.cpp`, `src/MuxManager.cpp`, `src/MuxPort.cpp`, `src/link_manager/`, `src/link_prober/`, `src/mux_state/`, and `src/link_state/`.

--- a/docs/modeling-guidance-template.md
+++ b/docs/modeling-guidance-template.md
@@ -1,29 +1,52 @@
 # Target-Specific Modeling Guidance
 
-## Objective
+Complete the Required sections and remove unused Optional sections. Describe
+WHAT should be verified, not HOW to model it. Priority questions are a coverage
+floor: Specula should verify each one against the code and may also explore
+adjacent code-derived risks. Expected behavior is a contract to test, not an
+implementation fact to assume.
 
-- [Describe the behavior, risk, or subsystem this run should prioritize.]
+## Required
 
-## Required Scope
+### Goal
 
-- `[path/to/file:line or symbol]`: [Explain why this code must be analyzed.]
-- [List the other modules or entry points that belong in scope.]
+- [What decision or confidence should this run support?]
 
-## Required Coverage
+### Scope
 
-- [Describe an important interaction or call path that must be followed.]
-- [Identify the normal, failure, recovery, concurrency, or ordering behavior that must be considered.]
+- In scope: [Subsystems, operations, or interfaces.]
+- Boundaries/exclusions: [Explicit trust boundaries or exclusions, if any; otherwise `None`.]
 
-## Scenario Hypotheses
+### Priority Questions
 
-- Can [event or interleaving] cause [undesired outcome]?
-- What happens when [failure or recovery event] occurs while [operation] is in progress?
-- Does [component or code path] preserve [expected behavior] across [state transition]?
+List genuine priorities in order (typically 3–5). Never invent questions only
+to reach that range.
 
-## Known Incidents and References
+1. When [event or condition], can [observable undesired outcome]?
+   Expected behavior: [The intended user-visible or system contract.]
+2. When [event or condition], can [observable undesired outcome]?
+   Expected behavior: [The intended contract.]
 
-- [Issue, pull request, incident, paper, or design document]: [Briefly explain why it matters.]
+### Must-cover Interactions
 
-## Out of Scope
+- [Module/component A] ↔ [Module/component B]:
+  [Operation, lifecycle, or state transition that must be followed.]
+- Consider: [Relevant failure, recovery, concurrency, or ordering conditions.]
 
-- [Subsystem or behavior]: [Explain why it should be excluded.]
+### Assumptions
+
+- [Only non-obvious caller, environment, or fault assumptions; write `None` if none.]
+
+## Optional
+
+### Known Incidents and References
+
+- [Issue, incident, paper, or design document]: [Why it matters.]
+
+### Suggested Starting Points
+
+- `[path/to/file:line or symbol]`: [Why it may be relevant.]
+
+### Additional Exploration
+
+- [Adjacent risks worth exploring after the priority questions; omit to leave exploration open.]

--- a/skills/code_analysis/guide.md
+++ b/skills/code_analysis/guide.md
@@ -84,6 +84,8 @@ Every finding MUST be verified: re-read exact code lines, check for compensating
 
 **Goal**: Synthesize findings into an actionable document for Spec Generation — select top Scenarios, propose spec extensions, state what NOT to model and why, classify remaining findings by verification method.
 
+When target-specific guidance is provided, treat its priorities and scope as required investigative intent. Make their handling visible in the Modeling Brief through the relevant Scenarios, findings, exclusions, or unresolved questions, without imposing a separate format. Guidance determines what must be investigated, not what the evidence must conclude, and it remains a coverage floor rather than a ceiling on code-driven exploration. Respect explicit boundaries, while reading adjacent code when needed to establish in-scope behavior.
+
 **Read `references/modeling-brief-format.md`** for the format specification.
 **See `examples/hashicorp-raft-modeling-brief.md`** for a complete example.
 

--- a/skills/spec_generation/guide.md
+++ b/skills/spec_generation/guide.md
@@ -77,6 +77,8 @@ Counter-bound fault-injection actions (timeout, crash, message loss, etc.). Do N
 
 This is a self-check, not a grading rubric. Glance over brief §2 / §5 / §6.1 while finalizing Phase 2, identify any obvious gaps, and either close them or note honestly why something is out of scope. The audit is **brief-driven, not taxonomy-driven** — if the brief did not raise it, you do not have to cover it. Fill the audit by reading actual cfg files, not from memory of what you intended.
 
+When target-specific guidance is provided, preserve its intent while translating the Modeling Brief into the spec. Make it clear in `brief-coverage.md` how the user's priorities are represented or why another verification route is more appropriate, using whatever form and level of detail fit the target. Do not distort implementation evidence or modeling decisions merely to echo the guidance.
+
 See `references/brief-coverage-checklist.md` for table sketches and a worked failure example.
 
 ---

--- a/skills/writing-modeling-guidance/guide.md
+++ b/skills/writing-modeling-guidance/guide.md
@@ -23,9 +23,11 @@ If none apply, explain that guidance is optional and Specula can determine the m
 
 1. **State WHAT to verify, not HOW to model it.** Specification generation decides modeling abstractions.
 2. **Phrase hypotheses as questions.** Ask whether an event can cause an outcome instead of declaring a formal invariant.
-3. **Cite real `file:line` locations or symbols whenever possible.**
+3. **Use real `file:line` locations or symbols when the user supplies them or asks for help locating relevant code.** Source anchors are optional and must not replace user intent.
 4. **Keep it concise.** Aim for roughly 20–60 lines.
 5. **Do not repeat what source analysis can discover.** Prioritize user intent, incidents, risks, and exclusions.
+6. **Do not invent or silently complete user intent.** Ask a focused question when a missing priority, expected behavior, or assumption would materially change what gets verified. Resolving a user-selected question to code locations is useful; adding a new priority or contract is not.
+7. **Treat expected behavior as a contract to test.** Do not assume it is implemented correctly or encode it into a model guard or assumption so that violations become unreachable.
 
 ## Keep / Remove
 
@@ -41,19 +43,28 @@ Self-test before writing: would the guidance still make sense if Specula switche
 
 ## Recommended structure
 
-Start from `docs/modeling-guidance-template.md` and include only sections the target needs:
+Start from `docs/modeling-guidance-template.md`. Complete every Required section and include only relevant Optional sections:
 
-1. Objective.
-2. Required scope and key entry points.
-3. Required interactions and failure, recovery, concurrency, or ordering coverage.
-4. Scenario hypotheses.
-5. Known incidents and references.
-6. Out-of-scope behavior.
+Required sections:
+
+1. Goal: the decision or confidence the run should support.
+2. Scope and boundary.
+3. Prioritized questions, each pairing a trigger or condition with an observable outcome and the intended contract. Three to five is typical, but never invent filler to reach that range.
+4. Module or component interactions that must be followed.
+5. Non-obvious caller, environment, or fault assumptions; write `None` when there are none.
+
+Optional sections:
+
+1. Known incidents and references.
+2. Suggested source locations or symbols.
+3. Additional exploration after the priority questions.
+
+Priority questions are a coverage floor, not an exploration ceiling. Agents should address every priority question without treating it as a known bug, then remain free to investigate adjacent risks derived from the code.
 
 ## Procedure
 
 1. Confirm the target system, the user's priorities, and any hypotheses or exclusions.
-2. Read enough source to cite real paths, lines, or symbols. Research relevant incidents when requested or needed.
+2. If the user supplies source locations or requests help finding them, verify enough source to cite real paths, lines, or symbols. Research incidents when requested or needed to ground user-provided context; do not mine either as a substitute for missing intent.
 3. Draft concise guidance using the template and hard rules.
 4. Show the draft to the user before writing it, including any sections intentionally omitted.
 5. Write the approved text to a user-chosen path and show the corresponding `specula run --guidance=/absolute/path/to/file ...` command.
@@ -63,6 +74,8 @@ Start from `docs/modeling-guidance-template.md` and include only sections the ta
 - Formal variable, operator, invariant, or action definitions.
 - State-space bounds selected by the guidance author.
 - Hypotheses presented as established bugs without evidence.
+- Expected behavior encoded as an action guard or assumption instead of a property that may be violated.
+- AI-generated priorities, contracts, or assumptions presented as if the user supplied them.
 - README summaries or generic correctness advice.
 - Long protocol background that source analysis can recover.
 

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -653,6 +653,37 @@ class Pipeline:
             return False
         return True
 
+    def should_confirm_without_guidance_before_resolve(self) -> bool:
+        """Return whether the CLI should prompt before run state can change.
+
+        Existing explicit runs may already have guidance in their immutable
+        resume configuration. Read only that field here; full validation and
+        restoration remain resolve_run_dir's responsibility.
+        """
+        if self.guidance_path is not None:
+            return False
+        if not self._run_id_given:
+            return True
+        if not _valid_run_id(self.run_id):
+            return False  # resolve_run_dir reports the invalid ID
+
+        run_dir = SPECULA_ROOT / "runs" / self.run_id
+        try:
+            run_info = run_dir.lstat()
+        except FileNotFoundError:
+            return True
+        except OSError:
+            return False  # resolve_run_dir reports the inspection failure
+        if not stat.S_ISDIR(run_info.st_mode):
+            return False  # resolve_run_dir reports the unsafe run path
+        try:
+            stored = resumelib.load_configuration(run_dir)
+        except resumelib.ResumeError:
+            # A legacy run without checkpoints can proceed only through
+            # --fresh-context, so confirm before that reset can discard state.
+            return self.fresh_context
+        return stored.get("guidance") is None
+
     # ── workspace isolation (step 4; runs before the tee so pipeline.log can
     #    land in the run root) ──
     def _resolve_snapshot_sources(self, fallback_artifact: str = "") -> dict[str, Path]:
@@ -3594,14 +3625,11 @@ def main(argv: list[str]) -> int:
         # --help / unknown option exit before the tee starts, like the bash
         # top-level parse: no .specula-output/, no pipeline.log.
         return rc
-    if not p._run_id_given and not p.confirm_without_guidance():
+    if p.should_confirm_without_guidance_before_resolve() and not p.confirm_without_guidance():
         return 1
     rc = p.resolve_run_dir(acquire_lock=True)
     if rc is not None:
         return rc  # invalid --run-id: pre-tee exit, like the option errors
-    if p._run_id_given and not p.confirm_without_guidance():
-        p._release_run_lock()
-        return 1
 
     if p.run_dir:
         # isolated: the log is a run-scoped artifact, it lives at the run root

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -627,6 +627,32 @@ class Pipeline:
                 return 1
         return None
 
+    def confirm_without_guidance(self) -> bool:
+        """Confirm an interactive run that has no target-specific guidance.
+
+        Never read stdin when the prompt could be hidden or unattended. Batch
+        workers redirect their output, so they take this non-interactive path
+        even when the scheduler itself was started from a terminal.
+        """
+        if self.guidance_path is not None:
+            return True
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
+            print(
+                "WARNING: no --guidance file provided; continuing without "
+                "target-specific guidance in non-interactive mode.",
+                file=sys.stderr,
+            )
+            return True
+        try:
+            answer = input("No --guidance file was provided. Continue without target-specific guidance? [y/N] ")
+        except (EOFError, KeyboardInterrupt):
+            print()
+            answer = ""
+        if answer.strip().lower() not in {"y", "yes"}:
+            print("Aborted. Pass --guidance=PATH to provide target-specific guidance.")
+            return False
+        return True
+
     # ── workspace isolation (step 4; runs before the tee so pipeline.log can
     #    land in the run root) ──
     def _resolve_snapshot_sources(self, fallback_artifact: str = "") -> dict[str, Path]:
@@ -3568,9 +3594,14 @@ def main(argv: list[str]) -> int:
         # --help / unknown option exit before the tee starts, like the bash
         # top-level parse: no .specula-output/, no pipeline.log.
         return rc
+    if not p._run_id_given and not p.confirm_without_guidance():
+        return 1
     rc = p.resolve_run_dir(acquire_lock=True)
     if rc is not None:
         return rc  # invalid --run-id: pre-tee exit, like the option errors
+    if p._run_id_given and not p.confirm_without_guidance():
+        p._release_run_lock()
+        return 1
 
     if p.run_dir:
         # isolated: the log is a run-scoped artifact, it lives at the run root

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -1103,6 +1103,63 @@ class TestParsing(TmpCwd):
                     self.assertEqual(pl.Pipeline().parse_args(argv), 1)
                 self.assertIn(message, err.getvalue())
 
+    def test_interactive_run_confirms_omitted_guidance(self) -> None:
+        class TTYBuffer(io.StringIO):
+            def isatty(self) -> bool:
+                return True
+
+        p = pl.Pipeline()
+        self.assertIsNone(p.parse_args(["t|g|l|r"]))
+
+        for answer, expected in (("yes", True), ("n", False), ("", False)):
+            with self.subTest(answer=answer):
+                stdin = TTYBuffer()
+                stdout = TTYBuffer()
+                with (
+                    mock.patch.object(sys, "stdin", stdin),
+                    contextlib.redirect_stdout(stdout),
+                    mock.patch("builtins.input", return_value=answer) as prompt,
+                ):
+                    self.assertEqual(p.confirm_without_guidance(), expected)
+                prompt.assert_called_once_with(
+                    "No --guidance file was provided. Continue without target-specific guidance? [y/N] "
+                )
+                if not expected:
+                    self.assertIn("Aborted.", stdout.getvalue())
+
+    def test_noninteractive_run_never_prompts_for_omitted_guidance(self) -> None:
+        class TTYBuffer(io.StringIO):
+            def isatty(self) -> bool:
+                return True
+
+        p = pl.Pipeline()
+        self.assertIsNone(p.parse_args(["t|g|l|r"]))
+
+        for stdin, stdout in ((io.StringIO(), TTYBuffer()), (TTYBuffer(), io.StringIO())):
+            with self.subTest(stdin_tty=stdin.isatty(), stdout_tty=stdout.isatty()):
+                err = io.StringIO()
+                with (
+                    mock.patch.object(sys, "stdin", stdin),
+                    contextlib.redirect_stdout(stdout),
+                    contextlib.redirect_stderr(err),
+                    mock.patch("builtins.input") as prompt,
+                ):
+                    self.assertTrue(p.confirm_without_guidance())
+
+                prompt.assert_not_called()
+                self.assertIn("continuing without target-specific guidance", err.getvalue())
+
+    def test_configured_guidance_skips_confirmation(self) -> None:
+        guidance = self.tmp / "guidance.md"
+        guidance.write_text("scope\n")
+        p = pl.Pipeline()
+        self.assertIsNone(p.parse_args([f"--guidance={guidance}", "t|g|l|r"]))
+
+        with mock.patch("builtins.input") as prompt:
+            self.assertTrue(p.confirm_without_guidance())
+
+        prompt.assert_not_called()
+
     def test_guidance_is_read_once_and_staged_for_all_phases(self) -> None:
         guidance = self.tmp / "guidance.md"
         guidance.write_text("first version\n")

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -1160,6 +1160,37 @@ class TestParsing(TmpCwd):
 
         prompt.assert_not_called()
 
+    def test_guidance_confirmation_preflight_distinguishes_new_and_saved_runs(self) -> None:
+        runs = self.tmp / "runs"
+        guided = runs / "guided"
+        unguided = runs / "unguided"
+        legacy = runs / "legacy"
+        guided.mkdir(parents=True)
+        unguided.mkdir()
+        legacy.mkdir()
+        resumelib.initialize_run(guided)
+        resumelib.initialize_run(unguided)
+        resumelib.initialize_run(legacy)
+        resumelib.save_configuration(guided, {"guidance": "/tmp/guidance.md"})
+        resumelib.save_configuration(unguided, {"guidance": None})
+
+        cases = (
+            ("new", False, True),
+            ("guided", False, False),
+            ("unguided", False, True),
+            ("legacy", False, False),
+            ("legacy", True, True),
+        )
+        with mock.patch.object(pl, "SPECULA_ROOT", self.tmp):
+            for run_id, fresh_context, expected in cases:
+                with self.subTest(run_id=run_id):
+                    p = pl.Pipeline()
+                    args = [f"--run-id={run_id}", "t|g|l|r"]
+                    if fresh_context:
+                        args.insert(1, "--fresh-context")
+                    self.assertIsNone(p.parse_args(args))
+                    self.assertEqual(p.should_confirm_without_guidance_before_resolve(), expected)
+
     def test_guidance_is_read_once_and_staged_for_all_phases(self) -> None:
         guidance = self.tmp / "guidance.md"
         guidance.write_text("first version\n")
@@ -3436,6 +3467,34 @@ class TestMainTeeTeardown(TmpCwd):
             f"sys.exit(pl.main({args!r}))\n"
         )
         return subprocess.run([sys.executable, str(d)], cwd=self.tmp, capture_output=True, text=True)
+
+    def test_declining_guidance_does_not_create_explicit_run(self) -> None:
+        root = self.tmp / "root"
+        run = root / "runs" / "declined"
+        r = self._run_entry(
+            f"pl.SPECULA_ROOT = pl.Path({str(root)!r})\npl.Pipeline.confirm_without_guidance = lambda self: False",
+            ["--run-id=declined", "t|g|l|r"],
+        )
+
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertFalse(run.exists())
+        self.assertFalse((root / "runs" / "latest").exists())
+
+    def test_declining_guidance_does_not_reset_existing_fresh_context(self) -> None:
+        root = self.tmp / "root"
+        run = root / "runs" / "existing"
+        run.mkdir(parents=True)
+        resumelib.initialize_run(run)
+        resumelib.save_configuration(run, {"guidance": None})
+        active = resumelib.active_dir(run) / "keep.json"
+        active.write_text("{}\n")
+        r = self._run_entry(
+            f"pl.SPECULA_ROOT = pl.Path({str(root)!r})\npl.Pipeline.confirm_without_guidance = lambda self: False",
+            ["--run-id=existing", "--fresh-context", "t|g|l|r"],
+        )
+
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertTrue(active.is_file())
 
     def test_unexpected_exception_traceback_reaches_log(self) -> None:
         # bash set -e left the failing command's stderr in pipeline.log; an


### PR DESCRIPTION
## Summary

- refine the target-guidance template around required goal, scope, priority questions, interactions, and assumptions
- tell Code Analysis to treat user guidance as required investigative intent and make its handling visible in the existing Modeling Brief
- tell Spec Generation to preserve that intent and explain its representation or alternate verification route in the existing brief-coverage audit
- add a completed SONiC linkmgrd example, linked from the README and Usage Guide, as requested in Issue #128

## Design boundary

The existing analysis and modeling workflows remain primary. This change adds no candidate ledger, IDs, status enum, fixed table, count requirement, parser, runtime gate, or new pipeline artifact. User guidance determines what must be investigated, code evidence determines the conclusion, and Spec Generation retains control of the modeling approach. Guidance is a coverage floor, not an exploration ceiling.

The completed example contains only target-specific intent. Experiment-only reporting and reconciliation instructions were deliberately excluded.

## Validation

- skill validation passed for code-analysis, spec-generation, and writing-modeling-guidance
- full test suite: 1286 passed, 582 subtests passed
- independent forward test kept the supplied timeout/completion priority visible while freely discovering a separate cancel/resubmit risk and choosing its own scenarios and abstraction
- documentation links and whitespace checks passed

## Scope

Four guidance/phase-skill files, one completed example, and two documentation links. No Specula runtime or test changes.