### PR TITLE
Prepare Specula v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-08-13
+
+### Added
+
+- Added exact-session resume for unfinished agent conversations across supported adapters. `specula run --run-id` returns to the interrupted work, while `--fresh-context` explicitly starts with a new agent context.
+- Added per-target `.specula-output/summary.md` reports with run status, findings, evidence limits, report links, timing, token usage, estimated cost, and configured resource limits.
+- Added optional `--guidance=PATH` input for target-specific modeling priorities, with a reusable template and completed example carried through code analysis and specification generation.
+
+### Changed
+
+- Made `--keep-original` snapshots honor project ignore rules and produce reviewable Git patches without embedding binary or trace payloads.
+- Kept resumed and incomplete summaries target-local and excluded stale or invalid findings from final results.
+
 ## [1.0.0] - 2026-08-01
 
 ### Added
@@ -82,7 +95,8 @@ See the [v0.2.0 release notes](https://github.com/specula-org/Specula/releases/t
 - Added initial support for Claude Code, Codex, and Copilot CLI.
 - Added the trace-debugger MCP tooling and curated methodology for validating model fidelity before interpreting model-checking results.
 
-[Unreleased]: https://github.com/specula-org/Specula/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/specula-org/Specula/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/specula-org/Specula/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/specula-org/Specula/compare/v0.3.0...v1.0.0
 [0.3.0]: https://github.com/specula-org/Specula/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/specula-org/Specula/compare/v0.1.0...v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "specula"
-version = "1.0.0"
+version = "1.1.0"
 description = "Specula: a framework for finding deep bugs in system code using TLA+."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/infra/setup_codex_plugin.py
+++ b/scripts/infra/setup_codex_plugin.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 
 PLUGIN_NAME = "specula-codex"
-PLUGIN_VERSION = "1.0.0"
+PLUGIN_VERSION = "1.1.0"
 MARKETPLACE_NAME = "specula"
 LEGACY_MCP_NAMES = ("tracedebugger", "spec_analyzer", "inv_checking_tool")
 

--- a/src/specula/cli.py
+++ b/src/specula/cli.py
@@ -20,7 +20,7 @@ import sys
 from pathlib import Path
 
 PROG = "specula"
-VERSION = "1.0.0"
+VERSION = "1.1.0"
 
 SPECULA_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = SPECULA_ROOT / "scripts"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -83,7 +83,7 @@ class TestHelp(CaptureExec):
 
     def test_version(self) -> None:
         rc, out, err = self._main(["--version"])
-        self.assertEqual((rc, out, err), (0, "specula 1.0.0\n", ""))
+        self.assertEqual((rc, out, err), (0, "specula 1.1.0\n", ""))
         self.assertEqual(self.execs, [])
 
 
@@ -150,4 +150,4 @@ class TestShim(unittest.TestCase):
             capture_output=True,
             text=True,
         )
-        self.assertEqual((r.returncode, r.stdout, r.stderr), (0, "specula 1.0.0\n", ""))
+        self.assertEqual((r.returncode, r.stdout, r.stderr), (0, "specula 1.1.0\n", ""))

--- a/tests/unit/test_setup_codex_plugin.py
+++ b/tests/unit/test_setup_codex_plugin.py
@@ -189,7 +189,7 @@ class TestCodexPluginSkillContract(unittest.TestCase):
                 lock_version,
                 cast(str, manifest["version"]),
             },
-            {"1.0.0"},
+            {"1.1.0"},
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1103,7 +1103,7 @@ wheels = [
 
 [[package]]
 name = "specula"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- synchronize the project package, CLI, Codex plugin, lockfile, and version assertions to 1.1.0
- add a curated 1.1.0 changelog covering session resume, per-target result and resource summaries, target-specific modeling guidance, and reviewable keep-original patches
- advance the case-studies submodule to include the latest reviewed case-study archive
