### PR TITLE
Add bring-your-own-model workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `specula run --byom=PATH` for continuing Phase 2 onward from user-provided model, instrumentation, harness, or trace artifacts, with a final modification report for each target.
+
 ## [1.1.0] - 2026-08-13
 
 ### Added

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -151,6 +151,27 @@ specula run \
 
 Supported adapters are `claude-code` (default), `codex`, `copilot-cli`, `opencode`, and `pi`. Model names and effort values are interpreted by the selected agent. OpenCode and Pi model names use `provider/model` syntax.
 
+## Bring Your Own Model (BYOM)
+
+Use `--byom` when you already have a TLA+ model or other verification assets:
+
+```bash
+specula run \
+  --byom=/absolute/path/to/model-or-assets \
+  --artifact=/absolute/path/to/source \
+  "name|owner/repository|language|reference"
+```
+
+The path may name one model file or a directory containing any combination of models, configs, TraceSpec files, instrumentation, harnesses, traces, and replay instructions. For a multi-target run, every target receives the same BYOM root and selects its own assets from the target name and your instructions.
+
+Clearly describe in your prompt what the BYOM path provides and how those artifacts should be used. The existing `--guidance` option remains available for single-target runs only.
+
+BYOM skips the full code-analysis phase. Its Phase 2 and Phase 2.5 agents inspect the supplied assets, perform a focused Scenario supplement, reuse usable work, and fill only missing or incompatible specification, instrumentation, harness, and trace responsibilities. Existing traces are used without rerunning the harness by default; the agent may run or adjust the harness when validation requires it. The standard validation, confirmation, repair, and classification workflow then continues unchanged.
+
+Specula does not modify the original BYOM path. Later phases may modify the adopted workspace copies under their normal validation and repair rules. At the end of each target run, `byom-modification-report.md` summarizes which supplied assets were reused or modified, what Specula added, and why. The report is an agent-produced comparison, not a mechanically complete patch.
+
+BYOM requires the default isolated layout and conflicts with `--no-isolate` and every `--skip-*` option. Other `specula run` options retain their normal behavior. A resumed run reuses its stored absolute BYOM path; use `--fresh-context` to select a different path.
+
 ### Hybrid agent configuration
 
 Use an agent configuration file to select different agents or models for different pipeline phases:
@@ -347,6 +368,7 @@ specula run [options] "name|owner/repository|language|reference"
 | `--model=NAME` | Override the configured model |
 | `--effort=LEVEL` | Override reasoning effort |
 | `--artifact=PATH` | Set the target source checkout |
+| `--byom=PATH` | Start from a user-provided model file or verification-assets directory and run Phase 2 onward |
 | `--guidance=PATH` | Read optional modeling guidance for a single-target run |
 | `--keep-original` | Run against a full private source copy and write `changes.patch` |
 | `--tlc-memory-limit=SIZE` | Set the run-wide aggregate TLC heap + direct-memory budget; default is 80% of effective available memory at the first TLC start |
@@ -369,6 +391,8 @@ specula run [options] "name|owner/repository|language|reference"
 | `--no-isolate` | Use the legacy output layout described above |
 
 `--dry-run` still creates the isolated run metadata, log, and summary files. The confirmation repair loop is enabled by default. `--max-repair-rounds=N` caps rounds across the whole loop, not attempts per request; when the cap is reached, remaining open requests are deferred. For the individual `specula confirm` command, the corresponding debate flags are `--debate` and `--rounds=N` (range `1` through `5`).
+
+`--byom` is supported only by `specula run`. It conflicts with `--no-isolate`, `--skip-analysis`, `--skip-specgen`, `--skip-harness`, `--skip-validate`, `--skip-confirmation`, `--skip-classification`, and `--skip-repair-loop`.
 
 When an interactive `specula run` has no `--guidance`, Specula asks before
 continuing. Non-interactive and batch runs print a warning and continue without

--- a/scripts/tlc/validate.sh
+++ b/scripts/tlc/validate.sh
@@ -62,14 +62,16 @@ function validate {
 
     set -o pipefail
     if [ "${log_to_file}" = "true" ]; then
-        env JSON="${trace}" java -XX:+UseParallelGC -cp ${tooldir}/tla2tools.jar:${tooldir}/CommunityModules-deps.jar tlc2.TLC -config "${config}" "${spec}" -lncheck final -metadir "${statedir}" -fpmem 0.9 2>&1 | tee "${log}" | sed -nuE "s/<<\"Progress %:\", ([0-9]+)>>$/${id} \1/p"
+        env JSON="${trace}" java -XX:+UseParallelGC -cp ${tooldir}/tla2tools.jar:${tooldir}/CommunityModules-deps.jar tlc2.TLC -config "${config}" "${spec}" -lncheck final -metadir "${statedir}" -fpmem 0.9 2>&1 | tee "${log}" | sed -nuE "s/<<\"Progress %:\", ([0-9]{1,2})>>$/${id} \1/p"
         local tlc_status=${PIPESTATUS[0]}
     else
-        env JSON="${trace}" java -XX:+UseParallelGC -cp ${tooldir}/tla2tools.jar:${tooldir}/CommunityModules-deps.jar tlc2.TLC -config "${config}" "${spec}" -lncheck final -metadir "${statedir}" -fpmem 0.9 2>&1 | sed -nuE "s/<<\"Progress %:\", ([0-9]+)>>$/${id} \1/p"
+        env JSON="${trace}" java -XX:+UseParallelGC -cp ${tooldir}/tla2tools.jar:${tooldir}/CommunityModules-deps.jar tlc2.TLC -config "${config}" "${spec}" -lncheck final -metadir "${statedir}" -fpmem 0.9 2>&1 | sed -nuE "s/<<\"Progress %:\", ([0-9]{1,2})>>$/${id} \1/p"
         local tlc_status=${PIPESTATUS[0]}
     fi
 
-    if [ "${tlc_status}" -ne 0 ]; then
+    if [ "${tlc_status}" -eq 0 ]; then
+        echo "${id} 100"
+    else
         echo "${id} -1"
     fi
 }

--- a/skills/byom/SKILL.md
+++ b/skills/byom/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: byom
+description: "Bring-your-own-model workflow for Specula. Use when a pipeline run starts from a user-provided TLA+ model or a partial set of model, TraceSpec, instrumentation, harness, and trace artifacts instead of generating every verification artifact from scratch."
+---
+
+Read `guide.md` for the full workflow methodology.

--- a/skills/byom/guide.md
+++ b/skills/byom/guide.md
@@ -1,0 +1,49 @@
+# Bring Your Own Model Workflow
+
+Continue the normal Specula workflow from user-provided verification artifacts. Treat the supplied path and the target-specific instructions as flexible inputs: they may contain one model file, a directory of partial artifacts, or assets for several targets.
+
+## Shared Rules
+
+1. Inspect the supplied path and the target-specific instructions. Identify only the assets that belong to the current target; if ownership is ambiguous, stop and explain what the user must clarify.
+2. Never modify the original supplied path. Copy adopted artifacts into the target's `.specula-output/` workspace and make later changes only there.
+3. Reuse every supplied artifact that already performs the required job. Verify that it is usable, but do not recreate it merely to match Specula's usual implementation style.
+4. During the initial inventory and Scenario analysis, do not make semantic changes to supplied artifacts. Add missing artifacts or adapters around them. Once the normal validation and repair workflows begin, they may revise workspace copies as usual.
+5. Do not require a manifest or fixed input layout. Infer relationships from the artifacts, target source, and user instructions. Record uncertainty instead of guessing.
+
+## Phase 2: Adopt and Complete the Specification
+
+1. Inventory supplied models, invariants, configs, trace-validation wrappers, instrumentation mappings, harnesses, traces, and replay instructions.
+2. Read the installed **code-analysis** skill and use only its relevant Scenario-discovery guidance for a focused pass. Analyze only behaviors and interactions related to the supplied model. Do not repeat the full Phase 1 analysis or silently expand the model's scope.
+3. Write a concise `modeling-brief.md` that records the supplied scope and the focused Scenario supplement. Record out-of-model Scenarios as coverage gaps rather than changing the supplied model during this phase.
+4. Copy usable specification artifacts into `spec/`. Read and follow the installed **spec-generation** skill only for missing Phase 2 responsibilities, including any required MC/Trace wrappers, configs, coverage audit, or instrumentation mapping. Preserve supplied implementations when they already satisfy those responsibilities.
+5. Finish with the ordinary Phase 2 output contract so the standard harness phase can consume the workspace.
+
+## Phase 2.5: Adopt and Complete the Harness
+
+1. Inspect supplied instrumentation, harness code, run commands, and traces before creating anything.
+2. Read and follow the installed **harness-generation** skill only for missing or unusable Phase 2.5 responsibilities. Prefer adapting supplied tooling over replacing it.
+3. If usable traces are already present, adopt them and proceed without rerunning the harness by default. Run the harness when needed to diagnose a problem, refresh missing evidence, or make the traces consumable.
+4. Fix instrumentation, harness, and trace-adaptation problems in the workspace when the normal harness workflow calls for it. Never change files at the original supplied path.
+5. Finish with the ordinary Phase 2.5 output contract so the standard validation workflow can start.
+
+## Phase Ownership
+
+This skill changes how the current pipeline phase reuses supplied artifacts. It does not authorize the current agent to execute any additional pipeline phase.
+
+1. Complete only the phase assigned by the launcher prompt.
+2. References to other skills borrow the methodology needed for the current phase; they do not authorize performing the referenced skill's phase.
+3. Stop after satisfying the current phase's output contract. The pipeline launches each later phase separately.
+4. Use the existing **validation-workflow**, **bug-confirmation**, repair loop, and **bug-classification** without changing their methodology when the launcher assigns those phases. They may modify the adopted workspace copies under their normal rules.
+
+## Final Modification Report
+
+Only when the launcher explicitly assigns the final reporting responsibility, compare the original supplied path with the final target workspace and write `.specula-output/byom-modification-report.md` after confirmation, repair, and classification finish.
+
+Keep the report short and include:
+
+- supplied assets reused without modification;
+- supplied assets modified in the workspace and why;
+- verification assets added by Specula and why;
+- relationships that could not be determined reliably.
+
+State explicitly when nothing supplied was modified. This is an agent-produced comparison report, not a mechanically complete patch. Do not modify any verification artifact while preparing it.

--- a/skills/workflow-overview.md
+++ b/skills/workflow-overview.md
@@ -213,6 +213,7 @@ Pauses when API usage exceeds threshold, waits for reset, resumes automatically.
 
 | Skill | Phase | Location |
 |-------|-------|----------|
+| `byom` | 2–4 | `skills/byom/` |
 | `code_analysis` | 1 | `skills/code_analysis/` |
 | `spec_generation` | 2 | `skills/spec_generation/` |
 | `harness-generation` | 2.5 | `skills/harness-generation/` |

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -636,8 +636,14 @@ class ConfirmConfig:
                 if pending is not None:
                     pending.set()
 
-    def release_finding_lease(self, finding_id: str, *, force: bool = False) -> None:
-        """Idempotently release one terminal finding's runtime-only lease."""
+    def release_finding_lease(
+        self,
+        finding_id: str,
+        *,
+        force: bool = False,
+        retain_worktree: bool = False,
+    ) -> None:
+        """Release runtime-only state, optionally retaining the evidence worktree."""
         with self._finding_leases_lock:
             lease = self._finding_leases.pop(finding_id, None)
         if lease is None:
@@ -652,14 +658,15 @@ class ConfirmConfig:
             lease.turn_cwds.clear()
             lease.repair_turns.clear()
             lease.no_correction_drafts.clear()
-            try:
-                lease.cleanup()
-            except BaseException as exc:
-                message = f"  WARNING: {finding_id}: retry-lease cleanup failed ({exc})"
+            if not retain_worktree:
                 try:
-                    _log(message)
-                except OSError:
-                    print(message, flush=True)
+                    lease.cleanup()
+                except BaseException as exc:
+                    message = f"  WARNING: {finding_id}: retry-lease cleanup failed ({exc})"
+                    try:
+                        _log(message)
+                    except OSError:
+                        print(message, flush=True)
             _remove_lease_state(lease)
 
     def clear_retry_runtime(self) -> None:
@@ -1920,7 +1927,10 @@ def run_finding_safe(
             o.body = _merge_repair_evidence(prior, repair_evidence, o.body, cfg.repair_round)
         _save_verdict(o, cfg)
         resumelib.complete_prefix(("confirm", cfg.name, "finding", f.id))
-        cfg.release_finding_lease(f.id, force=True)
+        # Reproduction scripts may depend on files or builds in this exact
+        # isolated checkout. Keep it as part of the terminal evidence bundle;
+        # a later rerun safely replaces it through the stale-worktree path.
+        cfg.release_finding_lease(f.id, force=True, retain_worktree=True)
         cfg.clear_policy_states(("finding", f.id))
         return o
     except Exception as exc:  # RateLimited / ConfirmationFailed / anything unexpected

--- a/src/specula/output_index.py
+++ b/src/specula/output_index.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from urllib.parse import quote_from_bytes
 
 INDEX_FILENAME = "index.md"
+BYOM_REPORT_FILENAME = "byom-modification-report.md"
 PIPELINE_LOG_ENV = "SPECULA_PIPELINE_LOG"
 _NOT_AVAILABLE = "Not available"
 
@@ -192,6 +193,13 @@ def render_target_index(name: str, work_dir: Path, *, pipeline_log: Path | None 
             "— Confirmation results and supporting evidence"
         ),
         (f"- {_document('Severity report', work_dir / 'bug-severity.md', work_dir)} — Impact assessment"),
+    ]
+
+    byom_report = work_dir / BYOM_REPORT_FILENAME
+    if _is_file_under(work_dir, byom_report):
+        lines.append(f"- {_document('BYOM modification report', byom_report, work_dir)} — Changes to supplied assets")
+
+    lines += [
         "",
         "> Availability means that a document exists. It does not imply review approval",
         "> or confirmation of every finding.",

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -42,7 +42,7 @@ import specula.progress as progress
 from specula import quota, resumelib
 from specula.adapters.utils.policy import POLICY_BLOCKED_RC
 from specula.adapters.utils.transient import TRANSIENT_FAILURE_RC
-from specula.output_index import PIPELINE_LOG_ENV, is_safe_target_name, write_target_index
+from specula.output_index import BYOM_REPORT_FILENAME, PIPELINE_LOG_ENV, is_safe_target_name, write_target_index
 from specula.prompts import render
 from specula.resource_summary import (
     RESOURCE_INVOCATION_ENV,
@@ -81,8 +81,14 @@ MAX_DEBATE_ROUNDS = 5
 DEFAULT_POLICY_RETRIES = 20
 DEFAULT_TRANSIENT_RESUMES = 20
 TRANSIENT_RESUME_BACKOFF_MAX_SECONDS = 60.0
+BYOM_PATH_ENV = "SPECULA_BYOM_PATH"
 
 _RESOURCE_RECORDER: ResourceInvocationRecorder | None = None
+
+
+def _byom_path() -> Path | None:
+    raw = os.environ.get(BYOM_PATH_ENV)
+    return Path(raw) if raw else None
 
 
 def _resource_start_target(name: str, work_dir: Path) -> None:
@@ -2050,10 +2056,16 @@ Prerequisites:
 
     def check(self, ws: Workspace, names: list[str]) -> bool:
         ok = True
+        byom_path = _byom_path()
         for name in names:
             brief = ws.work_dir(name) / "modeling-brief.md"
             repo_dir = ws.find_repo_dir(name)
-            if brief.is_file():
+            if byom_path is not None and (byom_path.is_file() or byom_path.is_dir()):
+                line = f"  {name:<20} BYOM input OK"
+            elif byom_path is not None:
+                line = f"  {name:<20} BYOM input MISSING"
+                ok = False
+            elif brief.is_file():
                 lines = _wc_l(brief)
                 line = f"  {name:<20} modeling-brief.md ({lines} lines)"
             else:
@@ -2080,6 +2092,19 @@ Prerequisites:
         spec_dir = wd / "spec"
         brief = wd / "modeling-brief.md"
         repo_dir = ws.find_repo_dir(name)
+        byom_path = _byom_path()
+        if byom_path is not None:
+            prompt = f"""# BYOM Phase 2 Task: {name}
+
+Use the installed Specula skill {prompt_skill_ids("byom")}. Read it in full and complete its Phase 2 responsibilities for this target.
+
+- **User-provided artifacts**: {byom_path}
+- **Source code**: {repo_dir}
+- **Target workspace**: {wd}
+
+Combine those artifacts with the target-specific instructions below. Reuse supplied work, perform the focused Scenario supplement, and leave the ordinary Phase 2 outputs ready for the harness phase.
+"""
+            return self._with_extra(ws, name, prompt)
         prompt = f"""# TLA+ Spec Generation Task
 
 You are generating a TLA+ specification for: **{name}**
@@ -2185,6 +2210,7 @@ Prerequisites:
 
     def check(self, ws: Workspace, names: list[str]) -> bool:
         ok = True
+        byom_path = _byom_path()
         for name in names:
             spec_dir = ws.work_dir(name) / "spec"
             repo_dir = ws.find_repo_dir(name)
@@ -2199,6 +2225,12 @@ Prerequisites:
             else:
                 line += "  instr MISSING"
                 ok = False
+            if byom_path is not None:
+                if (ws.work_dir(name) / "modeling-brief.md").is_file():
+                    line += "  brief OK"
+                else:
+                    line += "  brief MISSING"
+                    ok = False
             line += "  repo OK" if repo_dir else "  repo MISSING"
             if not repo_dir:
                 ok = False
@@ -2219,6 +2251,20 @@ Prerequisites:
         wd = ws.work_dir(name)
         spec_dir = wd / "spec"
         repo_dir = ws.find_repo_dir(name)
+        byom_path = _byom_path()
+        if byom_path is not None:
+            prompt = f"""# BYOM Phase 2.5 Task: {name}
+
+Use the installed Specula skill {prompt_skill_ids("byom")}. Read it in full and complete its Phase 2.5 responsibilities for this target.
+
+- **User-provided artifacts**: {byom_path}
+- **Source code**: {repo_dir}
+- **Specification workspace**: {spec_dir}
+- **Target workspace**: {wd}
+
+Combine those artifacts with the target-specific instructions below. Reuse supplied instrumentation, harnesses, and traces; fill only what is missing or unusable; then leave the ordinary Phase 2.5 outputs ready for validation.
+"""
+            return self._with_extra(ws, name, prompt)
         prompt = f"""# Trace Harness Generation Task: {name}
 
 You are generating a trace harness for **{name}** — instrumenting the real source code to produce NDJSON traces for TLA+ trace validation.
@@ -2342,7 +2388,7 @@ Prerequisites:
         # NOTE: bash bug_classification generate_prompt does NOT inject .prompt-extra.
         name = self.target_name(target)
         wd = ws.work_dir(name)
-        return f"""# Final Bug Reporting Task: {name}
+        prompt = f"""# Final Bug Reporting Task: {name}
 
 You are completing the Phase 4 final reports for **{name}**.
 
@@ -2361,9 +2407,27 @@ Use the installed Specula skill {prompt_skill_ids("bug-classification")}. Read i
 
 Do everything the skill specifies. Do not add, relax, or override any step here.
 """
+        byom_path = _byom_path()
+        if byom_path is None:
+            return prompt
+        prompt += f"""
+## BYOM Modification Report
+
+After completing and validating the normal Phase 4b outputs, use the installed Specula skill {prompt_skill_ids("byom")} and complete its final modification-report responsibility.
+
+- **Original user-provided artifacts**: {byom_path}
+- **Final target workspace**: {wd}
+- **Required report**: {wd}/{BYOM_REPORT_FILENAME}
+
+Compare the supplied artifacts with the final workspace, explain what was reused, modified, or added and why, and state any uncertain correspondence. Do not modify verification artifacts while writing this report.
+"""
+        return prompt + self._read_prompt_extra(ws, name)
 
     def prepare_fresh_outputs(self, ws: Workspace, name: str) -> None:
-        for filename in ("bug-severity.md", ".summary-findings.md"):
+        filenames = ["bug-severity.md", ".summary-findings.md"]
+        if _byom_path() is not None:
+            filenames.append(BYOM_REPORT_FILENAME)
+        for filename in filenames:
             path = ws.work_dir(name) / filename
             try:
                 path.unlink()
@@ -2441,6 +2505,23 @@ Do everything the skill specifies. Do not add, relax, or override any step here.
                     f"  WARNING: {name}: .summary-findings.md {fragment_issue}; "
                     "summary.md will omit the findings fragment"
                 )
+            if _byom_path() is not None:
+                byom_report = ws.work_dir(name) / BYOM_REPORT_FILENAME
+                try:
+                    byom_report_info = byom_report.lstat()
+                except OSError:
+                    issues.append(f"{BYOM_REPORT_FILENAME} missing")
+                else:
+                    if not stat.S_ISREG(byom_report_info.st_mode):
+                        issues.append(f"{BYOM_REPORT_FILENAME} is not a regular file")
+                    else:
+                        try:
+                            byom_report_text = byom_report.read_text()
+                        except (OSError, UnicodeError):
+                            issues.append(f"{BYOM_REPORT_FILENAME} unreadable")
+                        else:
+                            if not byom_report_text.strip():
+                                issues.append(f"{BYOM_REPORT_FILENAME} empty")
             if issues:
                 print(f"  {name}: Phase 4b output invalid ({'; '.join(issues)})")
                 failures.append((name, 1))

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -52,6 +52,7 @@ from specula.output_index import (
     write_target_index,
 )
 from specula.phaselib import (
+    BYOM_PATH_ENV,
     DEFAULT_POLICY_RETRIES,
     DEFAULT_TRANSIENT_RESUMES,
     Workspace,
@@ -152,6 +153,7 @@ Options:
   --model=NAME           Model forwarded to every agent adapter
   --effort=LEVEL         Reasoning effort forwarded to every agent adapter
   --artifact=PATH        Path to system artifact/source code
+  --byom=PATH            Use user-provided model artifacts and run Phase 2 onward
   --guidance=PATH        Target-specific modeling guidance (single-target runs only)
   --keep-original        Work in a full private copy and write a reviewable changes.patch
   --tlc-memory-limit=SIZE
@@ -184,6 +186,15 @@ Output navigation (default isolated layout):
 """
 
 DIVIDER = "════════════════════════════════════════════════════════════"
+BYOM_CONFLICTING_FLAGS = (
+    "--skip-analysis",
+    "--skip-specgen",
+    "--skip-harness",
+    "--skip-validate",
+    "--skip-confirmation",
+    "--skip-classification",
+    "--skip-repair-loop",
+)
 
 
 def log(msg: str) -> None:
@@ -363,6 +374,8 @@ class Pipeline:
         self._effort_given = False
         self.artifact = ""
         self._artifact_given = False
+        self.byom_path: Path | None = None
+        self._byom_given = False
         self.guidance_path: Path | None = None
         self.guidance_text: str | None = None
         self._guidance_given = False
@@ -503,6 +516,20 @@ class Pipeline:
             elif arg.startswith("--artifact="):
                 self.artifact = arg.split("=", 1)[1]
                 self._artifact_given = True
+            elif arg.startswith("--byom="):
+                if self._byom_given:
+                    print("ERROR: --byom may be specified only once", file=sys.stderr)
+                    return 1
+                raw_path = arg.split("=", 1)[1]
+                if not raw_path:
+                    print("ERROR: --byom requires a path", file=sys.stderr)
+                    return 1
+                self._byom_given = True
+                try:
+                    self.byom_path = self._normalize_byom_path(raw_path)
+                except (OSError, RuntimeError, ValueError) as exc:
+                    print(f"ERROR: invalid --byom path '{raw_path}': {exc}", file=sys.stderr)
+                    return 1
             elif arg.startswith("--guidance="):
                 if self._guidance_given:
                     print("ERROR: --guidance may be specified only once", file=sys.stderr)
@@ -557,6 +584,12 @@ class Pipeline:
         if not self.targets:
             self.targets.append(_logical_cwd().name)  # bash `basename "$PWD"` (logical)
         self._targets_given = targets_given
+        byom_error = self._byom_option_error()
+        if byom_error is not None:
+            print(f"ERROR: {byom_error}", file=sys.stderr)
+            return 1
+        if self.byom_path is not None:
+            self.skip_analysis = True
         if self.guidance_path is not None and len(self.targets) != 1:
             print("ERROR: --guidance supports exactly one target per run", file=sys.stderr)
             return 1
@@ -625,6 +658,28 @@ class Pipeline:
             if conv is float and not math.isfinite(parsed):
                 print(f"ERROR: {label} must be a finite number, got '{val}'", file=sys.stderr)
                 return 1
+        return None
+
+    @staticmethod
+    def _normalize_byom_path(raw_path: str) -> Path:
+        expanded = Path(raw_path).expanduser()
+        if not expanded.is_absolute():
+            expanded = _logical_cwd() / expanded
+        path = expanded.resolve(strict=True)
+        if not (path.is_file() or path.is_dir()):
+            raise ValueError("expected an existing file or directory")
+        if not os.access(path, os.R_OK):
+            raise ValueError("path is not readable")
+        return path
+
+    def _byom_option_error(self) -> str | None:
+        if self.byom_path is None:
+            return None
+        conflicts = [flag for flag in BYOM_CONFLICTING_FLAGS if flag in self.argv]
+        if conflicts:
+            return f"--byom conflicts with {', '.join(conflicts)}; BYOM runs every phase after analysis"
+        if not self.isolate:
+            return "--byom requires isolated mode; remove --no-isolate (isolation is the default)"
         return None
 
     def confirm_without_guidance(self) -> bool:
@@ -787,6 +842,7 @@ class Pipeline:
             "skip_reviews": self.skip_reviews,
             "targets": list(self.targets),
             "artifact": self.artifact,
+            "byom": str(self.byom_path) if self.byom_path is not None else None,
             "guidance": str(self.guidance_path) if self.guidance_path is not None else None,
         }
 
@@ -969,6 +1025,27 @@ class Pipeline:
             self.guidance_path = Path(stored_guidance)
         if self.guidance_path is not None and len(self.targets) != 1:
             raise resumelib.ResumeError("stored guidance requires exactly one target")
+
+        stored_byom = raw.get("byom")
+        if stored_byom is not None and (not isinstance(stored_byom, str) or not Path(stored_byom).is_absolute()):
+            raise resumelib.ResumeError("invalid stored BYOM path")
+        if self._byom_given:
+            if not allow_overrides and (
+                stored_byom is None or self.byom_path is None or self.byom_path != Path(stored_byom)
+            ):
+                raise resumelib.ResumeError(
+                    "--byom differs from this run; pass --fresh-context to use another input path"
+                )
+        elif stored_byom is not None:
+            try:
+                self.byom_path = self._normalize_byom_path(stored_byom)
+            except (OSError, RuntimeError, ValueError) as exc:
+                raise resumelib.ResumeError(f"this run's BYOM input is unavailable: {stored_byom} ({exc})") from exc
+        byom_error = self._byom_option_error()
+        if byom_error is not None:
+            raise resumelib.ResumeError(byom_error)
+        if self.byom_path is not None:
+            self.skip_analysis = True
 
         stored_artifact = raw.get("artifact")
         if not isinstance(stored_artifact, str):
@@ -1270,6 +1347,10 @@ class Pipeline:
                 print(f"ERROR: {exc}", file=sys.stderr)
                 return fail()
         os.environ["SPECULA_RUN_DIR"] = str(self.run_dir)  # phase subprocesses inherit
+        if self.byom_path is not None:
+            os.environ[BYOM_PATH_ENV] = str(self.byom_path)
+        else:
+            os.environ.pop(BYOM_PATH_ENV, None)
         if self.keep_original:
             os.environ[SNAPSHOT_MODE_ENV] = "1"
         else:
@@ -1417,6 +1498,7 @@ class Pipeline:
             "claude_alias": self.claude_alias,
             "artifact": self.artifact,
             "artifact_git_sha": artifact_sha,
+            "byom": str(self.byom_path) if self.byom_path is not None else None,
             "guidance": str(self.guidance_path) if self.guidance_path is not None else None,
             "tlc_memory_limit": self.tlc_memory_limit or os.environ.get(MEMORY_LIMIT_ENV) or "auto",
             "tlc_worker_limit": self.tlc_worker_limit or os.environ.get(WORKER_LIMIT_ENV) or None,
@@ -3425,6 +3507,8 @@ class Pipeline:
         print(f"TLC workers:  {worker_limit}")
         if self.guidance_path is not None:
             print(f"Guidance:     {self.guidance_path}")
+        if self.byom_path is not None:
+            print(f"BYOM input:   {self.byom_path}")
         if self.run_dir:
             print(f"Run:          {self.run_id}  ({self.run_dir})")
         print()

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -3352,7 +3352,9 @@ class Pipeline:
             out += [f"### {name}", ""]
 
             brief = work_dir / "modeling-brief.md"
-            if brief.is_file():
+            if self.byom_path is not None:
+                out.append("- **Phase 1 (Analysis)**: SKIPPED (BYOM)")
+            elif brief.is_file():
                 out.append(f"- **Phase 1 (Analysis)**: OK (modeling-brief: {_wc_l(brief)} lines)")
             else:
                 out.append("- **Phase 1 (Analysis)**: MISSING")

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -285,6 +285,9 @@ class CliE2E(unittest.TestCase):
         run = self.sole_run_dir(root)
         target = run / "footest" / ".specula-output"
         self.assertTrue((target / "byom-modification-report.md").is_file())
+        summary = (run / "pipeline-summary.md").read_text()
+        self.assertIn("- **Phase 1 (Analysis)**: SKIPPED (BYOM)", summary)
+        self.assertNotIn("- **Phase 1 (Analysis)**: OK", summary)
         self.assertIn(
             "[BYOM modification report](byom-modification-report.md)",
             (target / "index.md").read_text(),

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -54,6 +54,7 @@ _VOLATILE = (
     "SPECULA_STOP_GATE",
     "SPECULA_MODEL",
     "SPECULA_EFFORT",
+    "SPECULA_BYOM_PATH",
     "CLAUDE_CONFIG_DIR",
     "CLAUDE_ALIAS",
     "CLAUDE_EFFORT",
@@ -164,6 +165,138 @@ class CliE2E(unittest.TestCase):
         self.assertIn("Specula", out)
         self.assertIn("[DRY RUN] bash scripts/launch/launch_code_analysis.sh", out)
         self.assertIn("Pipeline completed", out)
+
+    def test_byom_dry_run_skips_analysis_and_keeps_multi_target_pipeline(self) -> None:
+        root = self.specroot(case_dirs=("alpha", "beta"))
+        work = self.workdir()
+        supplied = work / "provided"
+        supplied.mkdir()
+        proc = self.run_cli(
+            root,
+            [
+                "run",
+                "--dry-run",
+                f"--byom={supplied}",
+                "alpha|o/a|Go|ref",
+                "beta|o/b|Rust|ref",
+            ],
+            cwd=work,
+        )
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("Skipping Phase 1 (--skip-analysis)", proc.stdout)
+        self.assertNotIn("launch_code_analysis.sh", proc.stdout)
+        for launcher in (
+            "launch_spec_generation.sh",
+            "launch_harness_generation.sh",
+            "launch_spec_validation.sh",
+            "launch_bug_confirmation.sh",
+            "launch_bug_classification.sh",
+        ):
+            self.assertIn(launcher, proc.stdout)
+        meta = json.loads((self.sole_run_dir(root) / "run.json").read_text())
+        self.assertEqual(meta["byom"], str(supplied))
+        self.assertEqual(meta["resume_configuration"]["byom"], str(supplied))
+
+    def test_byom_rejects_skips_and_legacy_layout(self) -> None:
+        root = self.specroot()
+        work = self.workdir()
+        supplied = work / "Model.tla"
+        supplied.write_text("---- MODULE Model ----\n====\n")
+        for flag in (*ALL_PHASE_SKIPS, "--no-isolate"):
+            with self.subTest(flag=flag):
+                proc = self.run_cli(root, ["run", f"--byom={supplied}", flag, "footest"], cwd=work)
+                self.assertNotEqual(proc.returncode, 0)
+                self.assertIn("--byom", proc.stderr)
+
+    def test_byom_is_not_a_public_individual_phase_option(self) -> None:
+        root = self.specroot()
+        work = self.workdir()
+        supplied = work / "Model.tla"
+        supplied.write_text("---- MODULE Model ----\n====\n")
+
+        proc = self.run_cli(root, ["specgen", f"--byom={supplied}", "footest"], cwd=work)
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("Unknown option: --byom", proc.stdout)
+
+    def test_byom_fake_adapter_completes_phase2_through_final_report(self) -> None:
+        root = self.specroot()
+        work = self.workdir()
+        artifact = work / "artifact"
+        artifact.mkdir()
+        supplied = work / "Model.tla"
+        supplied.write_text("---- MODULE Model ----\n====\n")
+        adapter = root / "scripts" / "launch" / "adapters" / "fake.sh"
+        adapter.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            'printf "%s\\n" "$SPECULA_PHASE" >> "$0.phases"\n'
+            'test "$SPECULA_BYOM_PATH" = "' + str(supplied) + '"\n'
+            'case "$SPECULA_PHASE" in\n'
+            "  spec_generation)\n"
+            '    mkdir -p "$SPECULA_WORK_DIR/spec"\n'
+            '    printf "# BYOM brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
+            "    for file in base.tla MC.tla Trace.tla instrumentation-spec.md; do\n"
+            '      printf "seeded\\n" > "$SPECULA_WORK_DIR/spec/$file"\n'
+            "    done\n"
+            "    ;;\n"
+            "  harness_generation)\n"
+            '    mkdir -p "$SPECULA_WORK_DIR/harness" "$SPECULA_WORK_DIR/traces"\n'
+            '    printf "#!/bin/sh\\n" > "$SPECULA_WORK_DIR/harness/run.sh"\n'
+            '    printf \'{"event":"seed"}\\n\' > "$SPECULA_WORK_DIR/traces/seed.ndjson"\n'
+            "    ;;\n"
+            "  spec_validation)\n"
+            '    printf "# Bug report\\n\\nNo violations found.\\n" > "$SPECULA_WORK_DIR/spec/bug-report.md"\n'
+            '    printf \'{"schema_version":"2","system":"footest","generated_by":"validation-workflow","findings":[]}\\n\' '
+            '> "$SPECULA_WORK_DIR/spec/findings.json"\n'
+            '    printf "# Validation changelog\\n" > "$SPECULA_WORK_DIR/spec/changelog.md"\n'
+            "    ;;\n"
+            "  bug_confirmation_turn)\n"
+            '    printf \'{"generated_by":"consolidate","findings":[]}\\n\' '
+            '> "$SPECULA_WORK_DIR/spec/candidates.json"\n'
+            "    ;;\n"
+            "  bug_classification)\n"
+            '    printf "# Severity Classification\\n\\n## Summary\\n\\n## Per-entry classification\\n" '
+            '> "$SPECULA_WORK_DIR/bug-severity.md"\n'
+            '    printf "No impact-bearing findings were recorded.\\n\\n## Findings\\n\\n- Other dispositions: 0.\\n\\n## Validation limits\\n\\nNo finding-specific validation limits were recorded.\\n" '
+            '> "$SPECULA_WORK_DIR/.summary-findings.md"\n'
+            '    printf "# BYOM Modification Report\\n\\nThe supplied model was reused.\\n" '
+            '> "$SPECULA_WORK_DIR/byom-modification-report.md"\n'
+            "    ;;\n"
+            "  *) exit 97 ;;\n"
+            "esac\n"
+        )
+        adapter.chmod(0o755)
+
+        proc = self.run_cli(
+            root,
+            [
+                "run",
+                "--agent=fake",
+                f"--artifact={artifact}",
+                f"--byom={supplied}",
+                "footest|owner/repo|Go|reference",
+            ],
+            cwd=work,
+        )
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        run = self.sole_run_dir(root)
+        target = run / "footest" / ".specula-output"
+        self.assertTrue((target / "byom-modification-report.md").is_file())
+        self.assertIn(
+            "[BYOM modification report](byom-modification-report.md)",
+            (target / "index.md").read_text(),
+        )
+        phases = Path(f"{adapter}.phases").read_text().splitlines()
+        self.assertNotIn("code_analysis", phases)
+        self.assertIn("spec_generation", phases)
+        self.assertIn("harness_generation", phases)
+        self.assertIn("spec_validation", phases)
+        self.assertIn("bug_confirmation_turn", phases)
+        self.assertIn("bug_classification", phases)
+        self.assertEqual(supplied.read_text(), "---- MODULE Model ----\n====\n")
 
     def test_run_id_resumes_interrupted_validation_without_phase_skip_flags(self) -> None:
         root = self.specroot()

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -690,7 +690,8 @@ class TestDriver(ConfirmCase):
         self.assertEqual((root / "resume-check").read_text(), "passed")
         self.assertEqual(cfg._finding_leases, {})
         self.assertEqual(cfg._policy_states, {})
-        self.assertFalse(leased_repo.exists())
+        self.assertTrue(leased_repo.is_dir())
+        self.assertTrue((leased_repo / "lease-marker").is_file())
 
     def test_manual_resume_reloads_accepted_a_and_exact_interrupted_b(self) -> None:
         ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
@@ -789,7 +790,8 @@ class TestDriver(ConfirmCase):
         self.assertFalse(lease_checkpoint.exists())
         self.assertEqual(resumed_cfg._finding_leases, {})
         self.assertEqual(resumed_cfg._policy_states, {})
-        self.assertFalse(leased_repo.exists())
+        self.assertTrue(leased_repo.is_dir())
+        self.assertTrue((leased_repo / "lease-marker").is_file())
 
     def test_manual_resume_keeps_no_correction_decision_and_exact_interrupted_b(self) -> None:
         ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])

--- a/tests/unit/test_output_index.py
+++ b/tests/unit/test_output_index.py
@@ -98,6 +98,7 @@ class TestTargetIndex(OutputIndexCase):
             "spec/bug-report.md",
             "confirmed-bugs.md",
             "bug-severity.md",
+            "byom-modification-report.md",
         ):
             self.write(work_dir, relative)
         for hidden_from_humans in (
@@ -121,6 +122,7 @@ class TestTargetIndex(OutputIndexCase):
             - [Summary](summary.md) — Results, validation limits, run details, and resource usage
             - [Confirmation report](confirmed-bugs.md) — Confirmation results and supporting evidence
             - [Severity report](bug-severity.md) — Impact assessment
+            - [BYOM modification report](byom-modification-report.md) — Changes to supplied assets
 
             > Availability means that a document exists. It does not imply review approval
             > or confirmation of every finding.

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -51,6 +51,7 @@ import specula.quota as quota  # noqa: E402
 from specula import phaselib, resource_summary, resumelib, snapshotlib  # noqa: E402
 from specula.adapters.utils.policy import POLICY_BLOCKED_RC  # noqa: E402
 from specula.adapters.utils.transient import TRANSIENT_FAILURE_RC  # noqa: E402
+from specula.output_index import BYOM_REPORT_FILENAME  # noqa: E402
 from specula.progress import ProgressConfig, RunningAgent  # noqa: E402
 from specula.skill_refs import CODEX_PLUGIN_NAME, prompt_skill_ids  # noqa: E402
 
@@ -192,6 +193,7 @@ class PhaseCase(unittest.TestCase):
             "SPECULA_CLAUDE_ALIAS",
             "SPECULA_MODEL",
             "SPECULA_EFFORT",
+            phaselib.BYOM_PATH_ENV,
             "CLAUDE_ALIAS",
             "CLAUDE_EFFORT",
             "SPECULA_SOURCE_SNAPSHOT",
@@ -356,6 +358,17 @@ class TestPreconditionGate(PhaseCase):
         self.assertEqual(rc, 1, out)
         self.assertIn(BY_KEY["code_analysis"]["fail"], out)
         self.assertIn("cannot update output index", err.getvalue())
+
+    def test_byom_spec_generation_does_not_require_phase1_output(self) -> None:
+        supplied = self.tmp() / "Model.tla"
+        supplied.write_text("---- MODULE Model ----\n====\n")
+        self.set_env(phaselib.BYOM_PATH_ENV, str(supplied))
+
+        rc, out = self.run_phase("spec_generation", ["--check", self.artifact_flag(), NAME])
+
+        self.assertEqual(rc, 0, out)
+        self.assertIn("BYOM input OK", out)
+        self.assertNotIn("MISSING modeling-brief.md", out)
 
 
 class TestCheckOnly(PhaseCase):
@@ -553,6 +566,31 @@ class TestDryRunCommand(PhaseCase):
         self.assertIn("OPEN | IN_REPAIR | CONSUMED | DEFERRED", repair_format)
         self.assertIn("| `OPEN` → `DEFERRED` | pipeline orchestrator |", repair_format)
         self.assertIn("Terminal states: `CONSUMED`", repair_format)
+
+    def test_byom_wraps_phase2_phase2_5_and_final_reporting_prompts(self) -> None:
+        supplied = self.tmp() / "provided"
+        supplied.mkdir()
+        self.set_env(phaselib.BYOM_PATH_ENV, str(supplied))
+        self.seed(["modeling-brief.md"])
+        (self.work_dir() / ".prompt-extra.md").write_text("Use the supplied replay command.\n")
+
+        for key, expected in (
+            ("spec_generation", "Phase 2 responsibilities"),
+            ("harness_generation", "Phase 2.5 responsibilities"),
+            ("bug_classification", "BYOM Modification Report"),
+        ):
+            with self.subTest(key=key):
+                rc, out = self.dry_run(BY_KEY[key])
+                self.assertEqual(rc, 0, out)
+                body = (self.work_dir() / BY_KEY[key]["prompt"]).read_text()
+                self.assertIn("**byom**", body)
+                self.assertIn(str(supplied), body)
+                self.assertIn(expected, body)
+                self.assertIn("Use the supplied replay command.", body)
+
+        classification = (self.work_dir() / ".bug-classification-prompt.md").read_text()
+        self.assertIn("**bug-classification**", classification)
+        self.assertIn("byom-modification-report.md", classification)
 
     def test_ordinary_phase_default_max_parallel_stays_one(self) -> None:
         rc, out = self.dry_run(BY_KEY["code_analysis"])
@@ -1652,6 +1690,38 @@ class TestBugClassificationOutputs(PhaseCase):
 
         self.assertEqual(rc, 0, out)
         self.assertIn("summary=yes", out)
+
+    def test_byom_requires_modification_report(self) -> None:
+        supplied = self.tmp() / "provided"
+        supplied.mkdir()
+        self.set_env(phaselib.BYOM_PATH_ENV, str(supplied))
+        (self.work_dir() / BYOM_REPORT_FILENAME).write_text("stale\n")
+        self.write_adapter(
+            self.write_output("bug-severity.md", self.SEVERITY)
+            + self.write_output(".summary-findings.md", self.FINDINGS)
+        )
+
+        rc, out = self.run_classification()
+
+        self.assertEqual(rc, 1, out)
+        self.assertIn("byom-modification-report.md missing", out)
+        self.assertFalse((self.work_dir() / BYOM_REPORT_FILENAME).exists())
+        self.assertFalse((self.work_dir() / "summary.md").exists())
+
+    def test_byom_accepts_nonempty_modification_report(self) -> None:
+        supplied = self.tmp() / "provided"
+        supplied.mkdir()
+        self.set_env(phaselib.BYOM_PATH_ENV, str(supplied))
+        self.write_adapter(
+            self.write_output("bug-severity.md", self.SEVERITY)
+            + self.write_output(".summary-findings.md", self.FINDINGS)
+            + self.write_output(BYOM_REPORT_FILENAME, "No supplied assets were modified.\n")
+        )
+
+        rc, out = self.run_classification()
+
+        self.assertEqual(rc, 0, out)
+        self.assertTrue((self.work_dir() / BYOM_REPORT_FILENAME).is_file())
 
     def test_standalone_success_rebuilds_summary_after_invalidating_old_findings(self) -> None:
         self.seed_complete_summary()

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -1009,6 +1009,85 @@ class TestParsing(TmpCwd):
         self.assertEqual(p.tlc_worker_limit, "24")
         self.assertEqual(p.targets, ["t|g|l|r"])
 
+    def test_byom_accepts_file_or_directory_and_multiple_targets(self) -> None:
+        model = self.tmp / "Model.tla"
+        model.write_text("---- MODULE Model ----\n====\n")
+        bundle = self.tmp / "bundle"
+        bundle.mkdir()
+
+        for supplied in (model, bundle):
+            with self.subTest(supplied=supplied):
+                p = pl.Pipeline()
+                self.assertIsNone(
+                    p.parse_args(
+                        [
+                            f"--byom={supplied.relative_to(self.tmp)}",
+                            "alpha|o/a|Go|ref",
+                            "beta|o/b|Rust|ref",
+                        ]
+                    )
+                )
+                self.assertEqual(p.byom_path, supplied)
+                self.assertTrue(p.skip_analysis)
+                self.assertFalse(p.skip_specgen)
+                self.assertFalse(p.skip_harness)
+
+    def test_byom_rejects_missing_duplicate_and_empty_paths(self) -> None:
+        model = self.tmp / "Model.tla"
+        model.write_text("---- MODULE Model ----\n====\n")
+        cases = (
+            (["--byom=", "t"], "requires a path"),
+            ([f"--byom={self.tmp / 'missing'}", "t"], "invalid --byom path"),
+            ([f"--byom={model}", f"--byom={model}", "t"], "only once"),
+        )
+        for argv, message in cases:
+            with self.subTest(argv=argv):
+                err = io.StringIO()
+                with contextlib.redirect_stderr(err):
+                    self.assertEqual(pl.Pipeline().parse_args(argv), 1)
+                self.assertIn(message, err.getvalue())
+
+    def test_byom_rejects_phase_skips_and_legacy_layout(self) -> None:
+        model = self.tmp / "Model.tla"
+        model.write_text("---- MODULE Model ----\n====\n")
+        for flag in (*pl.BYOM_CONFLICTING_FLAGS, "--no-isolate"):
+            with self.subTest(flag=flag):
+                err = io.StringIO()
+                with contextlib.redirect_stderr(err):
+                    self.assertEqual(pl.Pipeline().parse_args([f"--byom={model}", flag, "t"]), 1)
+                self.assertIn("--byom", err.getvalue())
+                if flag == "--no-isolate":
+                    self.assertIn("remove --no-isolate", err.getvalue())
+                else:
+                    self.assertIn(flag, err.getvalue())
+
+    def test_byom_resume_restores_or_explicitly_replaces_path(self) -> None:
+        first_path = self.tmp / "first.tla"
+        first_path.write_text("first\n")
+        second_path = self.tmp / "second.tla"
+        second_path.write_text("second\n")
+        initial = pl.Pipeline()
+        self.assertIsNone(initial.parse_args([f"--byom={first_path}", "t|g|l|r"]))
+        stored = initial._resume_configuration_document()
+
+        resumed = pl.Pipeline()
+        self.assertIsNone(resumed.parse_args([]))
+        resumed._restore_resume_configuration(stored)
+        self.assertEqual(resumed.byom_path, first_path)
+        self.assertTrue(resumed.skip_analysis)
+
+        changed = pl.Pipeline()
+        self.assertIsNone(changed.parse_args([f"--byom={second_path}", "t|g|l|r"]))
+        with self.assertRaisesRegex(resumelib.ResumeError, "--byom differs"):
+            changed._restore_resume_configuration(stored)
+        changed._restore_resume_configuration(stored, allow_overrides=True)
+        self.assertEqual(changed.byom_path, second_path)
+
+        conflicting = pl.Pipeline()
+        self.assertIsNone(conflicting.parse_args(["--skip-harness"]))
+        with self.assertRaisesRegex(resumelib.ResumeError, "--byom conflicts with --skip-harness"):
+            conflicting._restore_resume_configuration(stored)
+
     def test_invalid_tlc_resource_limits_are_rejected_at_parse(self) -> None:
         for flag in (
             "--tlc-memory-limit=lots",
@@ -1430,6 +1509,7 @@ class TestParsing(TmpCwd):
         self.assertIn("--policy-retries=N", out)
         self.assertIn("--transient-resumes=N", out)
         self.assertIn("--guidance=PATH", out)
+        self.assertIn("--byom=PATH", out)
         self.assertIn("--skip-validate", out)
         self.assertNotIn("--skip-validation", out)
         self.assertIn("default: 20", out)

--- a/tests/unit/test_skill_install.py
+++ b/tests/unit/test_skill_install.py
@@ -84,6 +84,7 @@ class TestInstallSkills(SkillInstallCase):
             [
                 "bug-classification",
                 "bug-confirmation",
+                "byom",
                 "code-analysis",
                 "harness-generation",
                 "spec-generation",
@@ -97,6 +98,23 @@ class TestInstallSkills(SkillInstallCase):
         self.assertTrue(result.complete)
         for skill in skills:
             self.assertEqual((self.target / skill.name).resolve(), skill.path.resolve())
+
+    def test_byom_uses_the_repository_skill_layout(self) -> None:
+        skill = REPO_ROOT / "skills" / "byom"
+        guide = (skill / "guide.md").read_text()
+
+        self.assertEqual(
+            (skill / "SKILL.md").read_text().splitlines()[-1],
+            "Read `guide.md` for the full workflow methodology.",
+        )
+        self.assertTrue((skill / "guide.md").is_file())
+        self.assertFalse((skill / "agents" / "openai.yaml").exists())
+        self.assertIn("Complete only the phase assigned by the launcher prompt.", guide)
+        self.assertIn("The pipeline launches each later phase separately.", guide)
+        self.assertIn(
+            "they do not authorize performing the referenced skill's phase.",
+            guide,
+        )
 
     def test_first_install_uses_registered_names(self) -> None:
         code = self.skill("code_analysis", "code-analysis")

--- a/tests/unit/test_validate_script.py
+++ b/tests/unit/test_validate_script.py
@@ -1,0 +1,90 @@
+"""Regression tests for the parallel TLC trace validator."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATE = REPO_ROOT / "scripts" / "tlc" / "validate.sh"
+
+
+class TestValidateScript(unittest.TestCase):
+    def setUp(self) -> None:
+        self._temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self._temporary.cleanup)
+        self.root = Path(self._temporary.name)
+        self.bin = self.root / "bin"
+        self.tools = self.root / "tools"
+        self.bin.mkdir()
+        self.tools.mkdir()
+        for jar in ("tla2tools.jar", "CommunityModules-deps.jar"):
+            (self.tools / jar).touch()
+        java = self.bin / "java"
+        java.write_text(
+            "#!/bin/sh\n"
+            "case $FAKE_JAVA_MODE in\n"
+            "  success-no-progress) exit 0 ;;\n"
+            "  fail-no-progress) exit 7 ;;\n"
+            "  fail-after-100) printf '%s\\n' '<<\"Progress %:\", 100>>'; exit 7 ;;\n"
+            "  progress-success)\n"
+            "    printf '%s\\n' '<<\"Progress %:\", 25>>' '<<\"Progress %:\", 100>>'\n"
+            "    exit 0\n"
+            "    ;;\n"
+            "  *) exit 99 ;;\n"
+            "esac\n"
+        )
+        java.chmod(0o755)
+
+    def run_validator(self, mode: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["FAKE_JAVA_MODE"] = mode
+        env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
+        env["TOOLDIR"] = str(self.tools)
+        return subprocess.run(
+            [
+                "bash",
+                str(VALIDATE),
+                "-p",
+                "1",
+                "-s",
+                "Trace.tla",
+                "-c",
+                "Trace.cfg",
+                "trace.ndjson",
+            ],
+            cwd=self.root,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
+    def test_tlc_exit_status_is_authoritative_without_progress_marker(self) -> None:
+        success = self.run_validator("success-no-progress")
+        failure = self.run_validator("fail-no-progress")
+
+        self.assertEqual(success.returncode, 0, success.stdout + success.stderr)
+        self.assertIn("1 of 1 trace(s) passed", success.stdout)
+        self.assertEqual(failure.returncode, 1, failure.stdout + failure.stderr)
+        self.assertIn("0 of 1 trace(s) passed", failure.stdout)
+
+    def test_progress_100_cannot_mask_a_later_tlc_failure(self) -> None:
+        result = self.run_validator("fail-after-100")
+
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("0 of 1 trace(s) passed", result.stdout)
+
+    def test_incremental_progress_still_finishes_on_successful_exit(self) -> None:
+        result = self.run_validator("progress-success")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("1 of 1 trace(s) passed", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `specula run --byom=PATH` for file, directory, and multi-target BYOM inputs
- use a lightweight BYOM skill to reuse or complete Phase 2 and Phase 2.5 artifacts while leaving validation, confirmation, and repair behavior unchanged
- require a final per-target modification report and expose it in the target results index
- preserve normal runs and reject BYOM combinations with `--skip-*` or `--no-isolate`

Addresses #137.