### PR TITLE
Add incremental modeling workflow skill

### DIFF
--- a/skills/incremental-modeling/SKILL.md
+++ b/skills/incremental-modeling/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: incremental-modeling
+description: "Incrementally evolve and verify an existing Specula TLA+ suite for a new source revision. Use when an Agent has a prior Specula run plus old and new source, and must decide whether the model changes, update the reference/MC/Trace suite, generate Update.tla, reuse and rebase the prior trace harness for update-focused validation, model-check changed/unchanged interactions, and hand real counterexamples to bug reproduction."
+---
+
+Read `guide.md` for the full incremental workflow and its current stage boundaries.

--- a/skills/incremental-modeling/guide.md
+++ b/skills/incremental-modeling/guide.md
@@ -23,7 +23,7 @@ Read and apply the relevant parts of the existing skills rather than restating t
 - For evidence, Scenario construction, exclusions, category-specific reasoning, and modeling granularity, read and apply the installed Specula **code-analysis** skill. Follow its category routing when the update changes or stresses distributed/concurrent boundaries.
 - For code-faithful base/MC/Trace/instrumentation edits, source annotations, action splitting, and cfg coverage, read and apply the installed Specula **spec-generation** skill. Read its referenced generation documents for every artifact type touched by the update.
 - For reusing or modifying the prior harness and collecting fresh traces, read and apply only the relevant parts of the installed Specula **harness-generation** skill.
-- For running and debugging trace validation, follow the installed Specula **tla-trace-workflow** skill rather than duplicating its debugger methodology here.
+- For running and debugging trace validation, follow the installed Specula **tla-trace-workflow** skill. Use [Validation 3's category-specific completion evidence](references/validation/03-trace-validation-loop.md#completion-evidence) in place of generic template requirements that assume every trace needs a temporal completion property.
 - For full trace/MC convergence, follow the installed Specula **validation-workflow** skill with the incremental ordering and gates defined here.
 - For counterexample confirmation and reproduction, follow the installed Specula **bug-confirmation** skill.
 

--- a/skills/incremental-modeling/guide.md
+++ b/skills/incremental-modeling/guide.md
@@ -1,0 +1,101 @@
+# Incremental Modeling Workflow
+
+Treat the prior Specula run as semantic evidence and the new source as the implementation to verify. Keep one complete current reference suite, reuse proven CI assets, and focus new validation effort on the update and its interactions with unchanged behavior.
+
+The workflow has four parts under `references/`: `generation/`, `validation/`, `model-checking/`, and `reproduction/`. Execute them in that order.
+
+## Inputs
+
+Require:
+
+- the old and new source revisions, or an exact diff plus both source trees;
+- the prior validated `.specula-output/`, including its modeling brief, analysis report, specs, instrumentation mapping, traces, validation history, findings, and reproductions when present;
+- a separate working copy for the new artifacts. Never overwrite the prior run.
+
+If the prior spec has not completed trace/model convergence, say so in the analysis and treat its conclusions as provisional.
+
+## Reuse the Existing Specula Methods
+
+Read and apply the relevant parts of the existing skills rather than restating them here:
+
+- For evidence, Scenario construction, exclusions, category-specific reasoning, and modeling granularity, read and apply the installed Specula **code-analysis** skill. Follow its category routing when the update changes or stresses distributed/concurrent boundaries.
+- For code-faithful base/MC/Trace/instrumentation edits, source annotations, action splitting, and cfg coverage, read and apply the installed Specula **spec-generation** skill. Read its referenced generation documents for every artifact type touched by the update.
+- For reusing or modifying the prior harness and collecting fresh traces, read and apply only the relevant parts of the installed Specula **harness-generation** skill.
+- For running and debugging trace validation, follow the installed Specula **tla-trace-workflow** skill rather than duplicating its debugger methodology here.
+- For full trace/MC convergence, follow the installed Specula **validation-workflow** skill with the incremental ordering and gates defined here.
+- For counterexample confirmation and reproduction, follow the installed Specula **bug-confirmation** skill.
+
+Do not rerun full-project archaeology by default. Reuse the old run and investigate history/issues only where the update introduces uncertainty, changes a known mechanism, or invalidates prior evidence.
+
+## Decision Gate: Does the Model Need to Change?
+
+Run Chapter 1 before making any semantic spec edit. It must end with exactly one disposition:
+
+- `NO_MODEL_CHANGE`: the source update changes neither behavior nor correctness requirements at the existing modeling scope and granularity. Record the evidence and exclusion rationale, keep semantic spec artifacts unchanged, skip Chapters 2–4, run the no-change branch of Chapter 5, and stop generation.
+- `MODEL_CHANGE_REQUIRED`: the update changes modeled behavior, assumptions/setup, atomicity, or correctness requirements. Continue through Chapters 2–5.
+
+Do not create `Update.tla` merely to document a no-change decision. Do not proceed with reference edits while the disposition is still unresolved.
+
+## Part 1: Generation
+
+First execute the decision chapter:
+
+1. `references/generation/01-update-reconnaissance.md` — perform the short analysis needed to choose scope and modeling granularity.
+
+Then branch:
+
+- For `NO_MODEL_CHANGE`, skip generation chapters and execute only the no-change completion checks in `references/generation/05-completeness-review.md`.
+- For `MODEL_CHANGE_REQUIRED`, execute the remaining chapters in order:
+
+2. `references/generation/02-reference-model-generation.md` — draft the complete new reference suite.
+3. `references/generation/03-update-focused-analysis.md` — use the explicit draft to derive deeper invariants, Scenarios, and interactions; revise the reference as needed.
+4. `references/generation/04-update-model-generation.md` — generate `Update.tla` and focused/open checking configs without duplicating reference behavior.
+5. `references/generation/05-completeness-review.md` — reread the source diff and close every affected spec surface.
+
+When defining `EnvUpdate` or discharge obligations, also read `references/generation/modular-verification.md`.
+
+Use one continuous reasoning process: analyze briefly, draft the reference update, analyze the now-explicit update interactions, revise the reference, generate `Update.tla`, and perform the completion pass. Do not turn these chapters into separate lossy handoffs or require a JSON change contract.
+
+Do not state either disposition, even as a placeholder, before the Chapter 1 decision gate is complete.
+
+## Semantic Ownership
+
+- `base.tla`, `MC.tla`, and `Trace.tla` own the complete new-version behavior.
+- `Update.tla` references the updated MC/reference Actions, selects interacting context, and defines update-specific properties and focused/open specs.
+- Do not copy a changed Action body into `Update.tla`. Fix the reference Action and alias/wrap its MC form.
+- Put assumptions, setup, variables, helpers, `Init`, `Next`, and action semantics directly in the reference suite.
+- Keep unchanged properties in the reference. Put new or revised update properties in `Update.tla`; ensure stale replaced properties are not still enabled by old cfgs.
+
+## Required Outputs
+
+For `MODEL_CHANGE_REQUIRED`, produce:
+
+- updated `modeling-brief.md` and `analysis-report.md` with evidence-backed update Scenarios;
+- complete updated `spec/base.tla`, `base.cfg`, `MC.tla`, MC/hunt cfgs, `Trace.tla`, `Trace.cfg`, `instrumentation-spec.md`, and `brief-coverage.md`;
+- `spec/Update.tla` plus the update-specific cfgs needed for full-property, concrete-focused, open-focused, and discharge checking;
+- three-way source comments connecting changed code, changed reference locations, and the corresponding `Update.tla` focus.
+
+For `NO_MODEL_CHANGE`, leave all semantic spec artifacts unchanged and record the evidence and modeling-scope rationale in the existing analysis/brief. Do not generate an empty `Update.tla`.
+
+## Part 2: Validation
+
+Run the validation chapters in order:
+
+1. `references/validation/01-reuse-prior-harness.md` — rebase the prior CI harness onto the new source with the smallest evidence-backed changes.
+2. `references/validation/02-update-focused-scenarios.md` — rerun prior scenarios and add focused traces for affected Actions and high-risk interactions.
+3. `references/validation/03-trace-validation-loop.md` — validate and debug fresh new-version traces, revisiting generation when evidence changes the model.
+4. `references/validation/04-validation-completeness.md` — verify harness provenance, update coverage, trace quality, and regression closure.
+
+`NO_MODEL_CHANGE` still enters validation: run the reused harness against the new implementation and validate fresh traces against the unchanged semantic spec. A fresh trace that exposes a new projected behavior reopens the generation decision.
+
+## Part 3: Model Checking
+
+Read `references/model-checking/01-update-focused-checking.md`. It delegates ordinary convergence, TLC operation, and counterexample classification to the installed Specula skills, while defining the incremental full/focused/open/discharge order and validation back-edge.
+
+## Part 4: Reproduction
+
+When Part 3 produces an actual counterexample, enter through `references/reproduction/01-confirm-counterexample.md`. That file adds only incremental provenance and old/new control guidance; the installed Specula **bug-confirmation** skill owns investigation, reproduction, verdicts, and repair requests.
+
+## Current Stop Boundary
+
+Generation may run syntax and static configuration preflights only. Validation may build the reused harness, collect traces, and run trace validation. Model checking begins only after the validation gate, and reproduction begins only with an actual counterexample.

--- a/skills/incremental-modeling/guide.md
+++ b/skills/incremental-modeling/guide.md
@@ -87,7 +87,7 @@ Run the validation chapters in order:
 
 1. `references/validation/01-reuse-prior-harness.md` — rebase the prior CI harness onto the new source with the smallest evidence-backed changes.
 2. `references/validation/02-update-focused-scenarios.md` — rerun prior scenarios and add focused traces for affected Actions and high-risk interactions.
-3. `references/validation/03-trace-validation-loop.md` — validate and debug fresh new-version traces, revisiting generation when evidence changes the model.
+3. `references/validation/03-trace-validation-loop.md` — debug with local feedback and related repair batches, revisiting generation when evidence changes the model.
 4. `references/validation/04-validation-completeness.md` — verify harness provenance, update coverage, trace quality, and regression closure.
 
 `NO_MODEL_CHANGE` still enters validation: run the reused harness against the new implementation and validate fresh traces against the current reference. A mismatch may expose either a missed source change or an existing model defect; distinguish them using both revisions. Semantic repairs require renewed validation and applicable model checking even when the source disposition remains `NO_MODEL_CHANGE`.
@@ -104,4 +104,4 @@ When Part 3 produces an actual counterexample, enter through `references/reprodu
 
 ## Current Stop Boundary
 
-Generation may run syntax and static configuration preflights only. Validation may build the reused harness, collect traces, and run trace validation. Model checking begins only after the validation gate, and reproduction begins only with an actual counterexample.
+Generation may run syntax and static configuration preflights only. Validation may build the reused harness, collect/replay traces, and run bounded local semantic diagnostics as described in Validation 3. Model-checking campaigns begin only after the initial validation gate; subsequent repairs use the local-feedback loop and final regression gate. Reproduction begins only with an actual counterexample.

--- a/skills/incremental-modeling/guide.md
+++ b/skills/incremental-modeling/guide.md
@@ -9,10 +9,12 @@ The workflow has four parts under `references/`: `generation/`, `validation/`, `
 Require:
 
 - the old and new source revisions, or an exact diff plus both source trees;
-- the prior validated `.specula-output/`, including its modeling brief, analysis report, specs, instrumentation mapping, traces, validation history, findings, and reproductions when present;
+- the prior `.specula-output/`, including its modeling brief, analysis report, specs, instrumentation mapping, traces, validation history, findings, and reproductions when present;
 - a separate working copy for the new artifacts. Never overwrite the prior run.
 
 If the prior spec has not completed trace/model convergence, say so in the analysis and treat its conclusions as provisional.
+
+Preserve correct system semantics rather than the old model's text. Prior validation provides evidence within its coverage; it does not make every old abstraction correct. Recheck the assumptions and state meanings on which the update depends, and actively repair implementation-backed inconsistencies within the modeling scope. Prioritize repairs needed for the update and its interactions; record independent issues for separate work. Chapter 2 defines the repair criteria.
 
 ## Reuse the Existing Specula Methods
 
@@ -31,10 +33,12 @@ Do not rerun full-project archaeology by default. Reuse the old run and investig
 
 Run Chapter 1 before making any semantic spec edit. It must end with exactly one disposition:
 
-- `NO_MODEL_CHANGE`: the source update changes neither behavior nor correctness requirements at the existing modeling scope and granularity. Record the evidence and exclusion rationale, keep semantic spec artifacts unchanged, skip Chapters 2–4, run the no-change branch of Chapter 5, and stop generation.
+- `NO_MODEL_CHANGE`: the source update changes neither behavior nor correctness requirements at the modeling scope and granularity. Record the evidence and exclusion rationale. When no model repair is needed, skip Chapters 2–4 and run the no-change completion checks in Chapter 5.
 - `MODEL_CHANGE_REQUIRED`: the update changes modeled behavior, assumptions/setup, atomicity, or correctness requirements. Continue through Chapters 2–5.
 
 Do not create `Update.tla` merely to document a no-change decision. Do not proceed with reference edits while the disposition is still unresolved.
+
+The disposition describes the source delta, not whether spec files changed. An existing model defect may require repair even with `NO_MODEL_CHANGE`; record that repair separately in the analysis and changelog without relabeling the source delta. Follow the affected generation and validation chapters for the repair. Reopen the disposition only if new evidence changes the assessment of the source delta.
 
 ## Part 1: Generation
 
@@ -44,7 +48,7 @@ First execute the decision chapter:
 
 Then branch:
 
-- For `NO_MODEL_CHANGE`, skip generation chapters and execute only the no-change completion checks in `references/generation/05-completeness-review.md`.
+- For `NO_MODEL_CHANGE` without a repair, execute only the no-change completion checks in `references/generation/05-completeness-review.md`. For a repair, apply Chapters 2, 3, and 5 and update existing checking views as needed; repair-only work can use ordinary MC configs without creating `Update.tla`.
 - For `MODEL_CHANGE_REQUIRED`, execute the remaining chapters in order:
 
 2. `references/generation/02-reference-model-generation.md` — draft the complete new reference suite.
@@ -75,7 +79,7 @@ For `MODEL_CHANGE_REQUIRED`, produce:
 - `spec/Update.tla` plus the update-specific cfgs needed for full-property, concrete-focused, open-focused, and discharge checking;
 - three-way source comments connecting changed code, changed reference locations, and the corresponding `Update.tla` focus.
 
-For `NO_MODEL_CHANGE`, leave all semantic spec artifacts unchanged and record the evidence and modeling-scope rationale in the existing analysis/brief. Do not generate an empty `Update.tla`.
+For `NO_MODEL_CHANGE`, record the evidence and modeling-scope rationale in the existing analysis/brief. Preserve semantic artifacts unless an implementation-backed repair is needed; document and validate any repair through the same loop. Do not generate an empty `Update.tla`.
 
 ## Part 2: Validation
 
@@ -86,7 +90,9 @@ Run the validation chapters in order:
 3. `references/validation/03-trace-validation-loop.md` — validate and debug fresh new-version traces, revisiting generation when evidence changes the model.
 4. `references/validation/04-validation-completeness.md` — verify harness provenance, update coverage, trace quality, and regression closure.
 
-`NO_MODEL_CHANGE` still enters validation: run the reused harness against the new implementation and validate fresh traces against the unchanged semantic spec. A fresh trace that exposes a new projected behavior reopens the generation decision.
+`NO_MODEL_CHANGE` still enters validation: run the reused harness against the new implementation and validate fresh traces against the current reference. A mismatch may expose either a missed source change or an existing model defect; distinguish them using both revisions. Semantic repairs require renewed validation and applicable model checking even when the source disposition remains `NO_MODEL_CHANGE`.
+
+For repair-only work, apply the validation coverage requirements to the repaired Actions and their interactions identified in the analysis, whether or not `Update.tla` is used.
 
 ## Part 3: Model Checking
 

--- a/skills/incremental-modeling/references/generation/01-update-reconnaissance.md
+++ b/skills/incremental-modeling/references/generation/01-update-reconnaissance.md
@@ -15,13 +15,15 @@ Do not infer protocol importance from diff size. A one-line guard can be model-c
 
 Before editing TLA+, determine:
 
-- the intended implementation behavior before and after the update;
+- the implementation behavior before and after the update;
 - whether that behavior is inside the old modeling scope and at the old abstraction granularity;
 - the state, messages, assumptions, setup, atomicity boundaries, and externally visible consequences directly changed;
 - prior Scenarios/findings whose mechanism, reachability, mask, or consequence may have changed;
 - likely reference surfaces to revisit, without treating the first matches as a complete list.
 
 Project every changed behavioral branch onto the existing model vocabulary. Excluding an internal mechanism, phase, state, or discriminator excludes its representation, not its effects on variables, messages, Actions, or properties already present in the reference. When a hidden discriminator selects different visible effects, preserve the concrete effects' nondeterministic union unless distinguishing the hidden state is necessary for correctness.
+
+Check that the reused abstraction still expresses the relevant implementation behavior. An unchanged code path can become important to a new interaction, and an old simplification can already be wrong. Treat the existing vocabulary as a starting point: when evidence requires a different representation or action boundary within the modeling scope, explain the reason and revise it through Chapter 2.
 
 For `NO_MODEL_CHANGE`, show that the old and new projected post-state sets are equal for every changed behavioral branch. A difference in any existing modeled state, message, enablement condition, atomicity boundary, or promised property requires `MODEL_CHANGE_REQUIRED`, even when the concrete cause is otherwise excluded.
 
@@ -32,7 +34,7 @@ Choose one disposition:
 
 Do not emit either label as an interim placeholder. Choose once the projection and call-path checks are complete.
 
-For `NO_MODEL_CHANGE`, verify the conclusion against the old scope and all changed call paths. Record why every projected result is unchanged; do not edit semantic spec content.
+For `NO_MODEL_CHANGE`, verify the conclusion against the scope and all changed call paths. Record why every projected result is unchanged. Separately record any discovered defect in the old model; its repair does not make the source delta model-relevant. Follow the repair route in [the workflow guide](../../guide.md).
 
 ## 3. Prepare the First Reference Draft
 

--- a/skills/incremental-modeling/references/generation/01-update-reconnaissance.md
+++ b/skills/incremental-modeling/references/generation/01-update-reconnaissance.md
@@ -1,0 +1,47 @@
+# Chapter 1: Update Reconnaissance
+
+Use the existing `code-analysis` methodology selectively. The old run already contains system reconnaissance, history, scope, and Scenarios; this pass determines what the new revision invalidates or introduces before editing TLA+.
+
+## 1. Establish Exact Inputs
+
+- Identify the old and new source revisions exactly.
+- Read the complete diff, then read every changed function in both revisions with its callers, callees, tests, and downstream consumers.
+- Read the old `modeling-brief.md`, `analysis-report.md`, base/MC/Trace specs, validation changelog, findings, confirmed dispositions, reproductions, and repair history relevant to the changed mechanism.
+- Preserve the old system category unless the update changes the concurrency or communication architecture. If it does, reapply the category routing from the installed Specula **code-analysis** skill.
+
+Do not infer protocol importance from diff size. A one-line guard can be model-critical; a large refactor can be outside the current abstraction.
+
+## 2. Decide Scope and Granularity
+
+Before editing TLA+, determine:
+
+- the intended implementation behavior before and after the update;
+- whether that behavior is inside the old modeling scope and at the old abstraction granularity;
+- the state, messages, assumptions, setup, atomicity boundaries, and externally visible consequences directly changed;
+- prior Scenarios/findings whose mechanism, reachability, mask, or consequence may have changed;
+- likely reference surfaces to revisit, without treating the first matches as a complete list.
+
+Project every changed behavioral branch onto the existing model vocabulary. Excluding an internal mechanism, phase, state, or discriminator excludes its representation, not its effects on variables, messages, Actions, or properties already present in the reference. When a hidden discriminator selects different visible effects, preserve the concrete effects' nondeterministic union unless distinguishing the hidden state is necessary for correctness.
+
+For `NO_MODEL_CHANGE`, show that the old and new projected post-state sets are equal for every changed behavioral branch. A difference in any existing modeled state, message, enablement condition, atomicity boundary, or promised property requires `MODEL_CHANGE_REQUIRED`, even when the concrete cause is otherwise excluded.
+
+Choose one disposition:
+
+- `NO_MODEL_CHANGE`: neither modeled behavior nor modeled correctness requirements change;
+- `MODEL_CHANGE_REQUIRED`: update the complete reference suite and generate `Update.tla`.
+
+Do not emit either label as an interim placeholder. Choose once the projection and call-path checks are complete.
+
+For `NO_MODEL_CHANGE`, verify the conclusion against the old scope and all changed call paths. Record why every projected result is unchanged; do not edit semantic spec content.
+
+## 3. Prepare the First Reference Draft
+
+For `MODEL_CHANGE_REQUIRED`, update the existing analysis artifacts just enough to guide the first model draft:
+
+- state the changed mechanism and evidence;
+- identify the intended model granularity;
+- identify obvious declarations/Actions/setup that must change;
+- list old Scenarios whose assumptions need rechecking;
+- preserve explicit exclusions.
+
+Do not attempt to finish all invariants and interaction Scenarios before modeling. Chapter 2 makes the changed state and action boundaries explicit; Chapter 3 then performs the deeper update-focused analysis.

--- a/skills/incremental-modeling/references/generation/02-reference-model-generation.md
+++ b/skills/incremental-modeling/references/generation/02-reference-model-generation.md
@@ -23,7 +23,7 @@ Work in this order, revisiting earlier steps whenever later reasoning reveals a 
 2. `Init` and setup/recovery initialization;
 3. changed helpers and all semantic callers;
 4. changed Actions and every parallel/special/general code path implementing the same mechanism;
-5. unaffected Actions that must initialize, preserve, or consume new/changed state;
+5. old Actions that initialize, preserve, or consume changed state, or whose applicability and effects need reconsideration in new/refined states;
 6. `Next`, reachability, fairness, and common properties;
 7. MC wrappers, counters, constraints, standard cfg, and Scenario hunt cfgs;
 8. Trace event wrappers, `ValidatePostState`, silent transitions, and instrumentation mapping;

--- a/skills/incremental-modeling/references/generation/02-reference-model-generation.md
+++ b/skills/incremental-modeling/references/generation/02-reference-model-generation.md
@@ -1,0 +1,71 @@
+# Chapter 2: Generate the Complete New Reference Suite
+
+Read and follow the installed Specula **spec-generation** skill for all touched artifacts. This chapter changes the input condition: start from the prior validated suite and revise it into the complete semantic model of the new source revision.
+
+## 1. Keep One Behavioral Source of Truth
+
+Put every change that determines how the new implementation behaves into the reference suite:
+
+- constants, variable declarations, message/record shape, and state representation;
+- module assumptions, setup, environment constraints, and fault semantics;
+- helpers/operators and every affected caller;
+- `Init`, `Next`, action guards/effects, atomicity, persistence, and recovery;
+- MC wrappers/counters/constraints/configs;
+- Trace wrappers, post-state checks, silent actions, and instrumentation fields.
+
+Do not defer difficult semantics to `Update.tla`. `Update.tla` is a checking lens over this completed model.
+
+## 2. Update in Dependency Order
+
+Work in this order, revisiting earlier steps whenever later reasoning reveals a gap:
+
+1. declarations, type/structural predicates, constants, assumptions, and variable groups;
+2. `Init` and setup/recovery initialization;
+3. changed helpers and all semantic callers;
+4. changed Actions and every parallel/special/general code path implementing the same mechanism;
+5. unaffected Actions that must initialize, preserve, or consume new/changed state;
+6. `Next`, reachability, fairness, and common properties;
+7. MC wrappers, counters, constraints, standard cfg, and Scenario hunt cfgs;
+8. Trace event wrappers, `ValidatePostState`, silent transitions, and instrumentation mapping;
+9. brief coverage audit and source annotations.
+
+Use the existing source-faithfulness rules: model the implementation rather than the intended paper algorithm; preserve real atomicity boundaries; split actions where code paths or interleaving windows diverge.
+
+Completeness is not permission to change unaffected semantics. Preserve every unchanged Action boundary, message lifecycle, guard, side effect, and special/general path unless the source update or evidence requires a change. Follow affected values through callers and consumers, but do not import behavior that existed before the update merely because the new analysis noticed it.
+
+## 3. Property Placement
+
+- Keep unchanged reference properties and continue checking them.
+- Remove stale cfg enablement for a property whose old definition no longer represents the new version.
+- Put new or revised update-specific properties in `Update.tla` during Chapter 4.
+- Keep general structural/type properties needed to validate the complete reference in the reference suite.
+
+Never weaken a still-promised property merely because the new model violates it. Record the violation candidate for later validation; at generation time, make the model faithful and the property evidence-based.
+
+## 4. Preserve Three-Way Traceability
+
+At each changed reference location, add a concise comment after the corresponding `Update.tla` name is known:
+
+```tla
+\* UPDATE-MAP
+\* code: src/path/file.ext:<line-range-or-symbol>
+\* update: Update!<focus-operator>
+```
+
+Retain the normal Specula `file:line` source annotations inside changed logic blocks. The mapping comment supplements them; it does not replace source-faithful annotations.
+
+For assumptions, setup, variables, or helpers that are not redefined in `Update.tla`, point to the `Update.tla` section that explains their effect on Affected Actions, Interaction Actions, or update properties.
+
+## 5. Generation Preflight
+
+Before Chapter 3:
+
+- validate the syntax of every changed TLA+ module;
+- inspect actual cfg names and enabled properties rather than relying on intent;
+- ensure every declared variable is initialized and constrained by every applicable Action;
+- ensure new/replaced Actions are reachable from the selected `Next` relation;
+- ensure Trace/instrumentation field names and trigger points agree.
+
+If `instrumentation-spec.md` declares an update identity or post-state field mandatory, the corresponding Trace wrapper must require and validate it. Do not make a required field optional merely because the old harness has not yet been rebased; Part 2 updates the harness.
+
+Use SANY, variable-assignment checks, and static cfg/operator resolution. Do not launch BFS, simulation, trace replay, or even shallow TLC exploration as a generation preflight. Part 2 and Part 3 own executable validation.

--- a/skills/incremental-modeling/references/generation/02-reference-model-generation.md
+++ b/skills/incremental-modeling/references/generation/02-reference-model-generation.md
@@ -1,6 +1,6 @@
 # Chapter 2: Generate the Complete New Reference Suite
 
-Read and follow the installed Specula **spec-generation** skill for all touched artifacts. This chapter changes the input condition: start from the prior validated suite and revise it into the complete semantic model of the new source revision.
+Read and follow the installed Specula **spec-generation** skill for all touched artifacts. Start from the prior suite and revise it into the complete semantic model of the new source revision, correcting implementation-backed inconsistencies in the relevant old abstraction as needed.
 
 ## 1. Keep One Behavioral Source of Truth
 
@@ -31,7 +31,9 @@ Work in this order, revisiting earlier steps whenever later reasoning reveals a 
 
 Use the existing source-faithfulness rules: model the implementation rather than the intended paper algorithm; preserve real atomicity boundaries; split actions where code paths or interleaving windows diverge.
 
-Completeness is not permission to change unaffected semantics. Preserve every unchanged Action boundary, message lifecycle, guard, side effect, and special/general path unless the source update or evidence requires a change. Follow affected values through callers and consumers, but do not import behavior that existed before the update merely because the new analysis noticed it.
+Preserve old behavior whose abstraction remains valid. Every semantic edit needs evidence from the source change, its interactions, an existing model/implementation mismatch, or a justified property correction. Do not preserve a known modeling defect solely because the corresponding code is unchanged. Prioritize defects affecting the update or its verification; record independent defects for separate work.
+
+Reuse the meaning of an abstraction, not just its assignments or guards. Check that the relevant action preconditions and state meanings remain consistent through production, consumption, and recovery. An unchanged concrete field need not mean an unchanged abstract value. Adjust variables or action boundaries when necessary to preserve that meaning, then update all dependent reference, MC, Trace, and Update definitions. Choose a semantically sufficient repair; changed line count and reuse of the original representation are not correctness criteria. Keep intentional abstractions explicit and appropriate to the properties being checked.
 
 ## 3. Property Placement
 

--- a/skills/incremental-modeling/references/generation/03-update-focused-analysis.md
+++ b/skills/incremental-modeling/references/generation/03-update-focused-analysis.md
@@ -1,0 +1,59 @@
+# Chapter 3: Update-Focused Deep Analysis
+
+Perform this analysis after Chapter 2 has produced a code-faithful first draft of the new reference suite. Use the explicit changed state, Actions, assumptions, and atomicity boundaries to find interactions and properties that were not obvious from the source diff alone.
+
+## 1. Trace the Changed Behavior Through the Old System
+
+Ask:
+
+- Which unchanged Actions establish each changed Action's preconditions?
+- Which unchanged Actions read, overwrite, persist, send, retry, cancel, or recover the changed result?
+- What happens with in-flight old messages, requests, or tasks across the changed path?
+- Which faults or interleavings cross a changed atomicity boundary?
+- Did the code update the same mechanism at every special/general call site and branch?
+- Which old assumptions, masks, and environment constraints still hold?
+
+Use the Category A/B analysis patterns from the installed Specula **code-analysis** skill for the changed mechanism. Do not apply an unrelated generic fault checklist.
+
+## 2. Derive Update Scenarios
+
+Group Scenarios by mechanism and interaction, not by changed file. Prioritize paths of these forms when supported by the code:
+
+```text
+old producer -> changed Action -> old consumer
+old context -> changed Action -> crash/recovery
+old Action -> changed Action -> old Action
+changed Action -> changed Action
+changed Action -> retry/timeout/configuration change
+```
+
+Each Scenario must identify real code paths, the model Actions needed to exercise them, the uncertainty to resolve, and a plausible correctness consequence.
+
+## 3. Derive Properties
+
+Classify properties as:
+
+- preserved old properties whose justification must be rechecked;
+- revised properties such as `Inv_new` when the system's guarantee changed;
+- newly introduced safety/liveness properties;
+- interaction properties that observe the changed behavior through an old consumer;
+- structural properties needed to keep focused checking meaningful.
+
+Do not weaken a still-promised property merely because the draft violates it. The later validation phase decides whether a violation is a model issue, property issue, or implementation bug.
+
+## 4. Reuse Finding Lineage
+
+For relevant prior findings, re-read the evidence rather than only the status label:
+
+- `REPRODUCED`: can the mechanism regress or move to a sibling path?
+- `MASKED`: did the update weaken/remove the mask?
+- `ENV_LIMITED`: did the trigger become executable here?
+- `FALSE POSITIVE` or repaired: did the reachability/property premise change?
+
+Use closed historical bugs as mechanism evidence, not as a goal to rediscover unchanged.
+
+## 5. Revise the Reference and Analysis
+
+Update the reference suite whenever this analysis reveals missing state, callers, atomicity, Trace fields, MC wrappers, or setup. Update the modeling brief/report with the final evidence-backed Scenarios, modeling recommendations, exclusions, and proposed properties.
+
+Repeat Chapters 2 and 3 until the reference expresses the analyzed behavior cleanly enough to generate `Update.tla` without duplicating semantics.

--- a/skills/incremental-modeling/references/generation/03-update-focused-analysis.md
+++ b/skills/incremental-modeling/references/generation/03-update-focused-analysis.md
@@ -31,6 +31,8 @@ Each Scenario must identify real code paths, the model Actions needed to exercis
 
 Derive expectations from implementation behavior and system guarantees, then use them to challenge the draft. Include relevant boundaries where a behavior must be rejected, delayed, or become ineffective, as well as paths where it should occur. Recheck reused assumptions when a Scenario depends on them; a path admitted by the model is not by itself evidence of implementation reachability.
 
+Use [Chapter 5's two-way behavioral review](05-completeness-review.md#2-close-the-reference-semantics) to look for missing implementation paths and unsupported model paths. Turn consequential uncertainties into Scenarios for later trace validation or model checking, with expected outcomes justified from the source rather than the draft's assignments. A successful trace replay shows that observed behavior is admitted; it does not rule out extra model behavior. Check that the selected properties can expose wrong interactions, rather than relying only on properties that restate the draft's assumptions.
+
 ## 3. Derive Properties
 
 Classify properties as:

--- a/skills/incremental-modeling/references/generation/03-update-focused-analysis.md
+++ b/skills/incremental-modeling/references/generation/03-update-focused-analysis.md
@@ -29,12 +29,14 @@ changed Action -> retry/timeout/configuration change
 
 Each Scenario must identify real code paths, the model Actions needed to exercise them, the uncertainty to resolve, and a plausible correctness consequence.
 
+Derive expectations from implementation behavior and system guarantees, then use them to challenge the draft. Include relevant boundaries where a behavior must be rejected, delayed, or become ineffective, as well as paths where it should occur. Recheck reused assumptions when a Scenario depends on them; a path admitted by the model is not by itself evidence of implementation reachability.
+
 ## 3. Derive Properties
 
 Classify properties as:
 
 - preserved old properties whose justification must be rechecked;
-- revised properties such as `Inv_new` when the system's guarantee changed;
+- revised properties such as `Inv_new` when the system's guarantee changed or evidence shows the old formulation was incorrect;
 - newly introduced safety/liveness properties;
 - interaction properties that observe the changed behavior through an old consumer;
 - structural properties needed to keep focused checking meaningful.

--- a/skills/incremental-modeling/references/generation/04-update-model-generation.md
+++ b/skills/incremental-modeling/references/generation/04-update-model-generation.md
@@ -1,0 +1,84 @@
+# Chapter 4: Generate `Update.tla`
+
+Build one update-focused model-checking view over the completed reference/MC suite. Do not duplicate changed implementation semantics.
+
+## 1. Module Role
+
+Prefer:
+
+```tla
+---- MODULE Update ----
+EXTENDS MC
+```
+
+Use the exact module names and MC variable groups in the target suite. If the existing MC module cannot be extended cleanly, make the smallest target-specific adjustment while keeping reference behavior single-owned.
+
+## 2. Affected Actions
+
+Alias or wrap the MC forms of every directly changed reference Action:
+
+```tla
+AffectedActions ==
+    \/ \E i \in Server : MCHandleVote(i)
+    \/ \E i \in Server : MCApplyConfigChange(i)
+```
+
+Use MC wrappers when they own counters or framing state. Do not call a base Action directly and leave MC variables unconstrained. Do not copy the Action body into `Update.tla`.
+
+## 3. Interaction Actions
+
+Add concrete unchanged Actions that are important to the update Scenario because they:
+
+- establish an affected Action's precondition;
+- read, overwrite, persist, send, retry, cancel, or recover its result;
+- cross a changed atomicity/fault boundary;
+- expose a consumer-visible consequence.
+
+Prefer concrete Actions for high-risk interactions that deserve deep schedule exploration.
+
+## 4. Update-Visible State and Environment
+
+Identify the variables necessary to state the update properties and interaction boundary. When relevant reference Actions are omitted from the concrete focused model, read `modular-verification.md` and define an evidence-based `EnvUpdate` summarizing their tolerated effects:
+
+```tla
+OpenUpdateNext ==
+    \/ AffectedActions
+    \/ InteractionActions
+    \/ EnvUpdate
+```
+
+Define discharge obligations showing that omitted real context Actions satisfy `EnvUpdate`, with correct frame conditions. Do not use an unconstrained environment to make the local property vacuous.
+
+## 5. Update-Specific Properties
+
+Define:
+
+- revised correctness properties such as `Inv_new`;
+- properties introduced by the update;
+- properties about changed/unchanged Action interaction;
+- targeted structural or temporal properties justified by update Scenarios.
+
+Every property must cite its Scenario and source/reference evidence. Later validation must check it against full `MCNext`; an open focused property additionally requires discharge checking.
+
+## 6. Focused Specs and Configs
+
+Provide separate entry points/configs for:
+
+- update properties over full `MCNext`;
+- concrete focused `AffectedActions \/ InteractionActions`;
+- open focused behavior including `EnvUpdate` when used;
+- discharge obligations for omitted context Actions;
+- Scenario-specific BFS and simulation settings to be used in later validation.
+
+At generation time, ensure each cfg names existing spec/property operators and that every update property is enabled somewhere. Do not run the later exhaustive/simulation campaign in this chapter.
+
+## 7. Reverse Mapping
+
+At each focus definition, point back to reference and source:
+
+```tla
+\* reference: base!HandleVote
+\* code: src/path/file.ext:<line-range-or-symbol>
+```
+
+For assumption/setup/variable/helper changes represented only in reference, add a concise comment explaining how that change alters the selected Actions, environment, or properties.

--- a/skills/incremental-modeling/references/generation/05-completeness-review.md
+++ b/skills/incremental-modeling/references/generation/05-completeness-review.md
@@ -8,7 +8,7 @@ After all generation edits, reread the complete old/new source diff and the chan
 
 Do not equate one code hunk with one spec edit. Do not stop after changing the first matching Action.
 
-Also inspect the final spec diff against the prior suite. Every semantic edit must be required by the source update, its dependency closure, or an evidence-backed property change. Remove collateral edits to unchanged Action boundaries, message production/consumption, retry behavior, or old special paths.
+Also inspect the final spec diff against the prior suite. Apply Chapter 2's repair criteria: every semantic edit needs an implementation or property justification. Record source-driven updates and repairs of old model defects separately. Remove unsupported behavior changes while retaining justified repairs, even where the source code is unchanged.
 
 ## 2. Close the Reference Semantics
 
@@ -26,11 +26,13 @@ Verify all relevant surfaces directly in the actual files:
 - equality of old/new projected post-state sets for every branch classified `NO_MODEL_CHANGE`;
 - agreement between mandatory instrumentation fields and non-vacuous Trace checks.
 
+Recheck the assumptions behind reused Actions and state representations, including why each affected behavior is enabled and what later consumers infer from its results. Consistent definitions across the suite are necessary, but their shared interpretation must also agree with the implementation. Record any intentional abstraction and its limits rather than treating agreement among generated artifacts as independent confirmation.
+
 If the review exposes a missing edit, revise the reference and repeat the affected checks. A syntactically valid partial update is not complete.
 
 ## 3. Close the Update Focus
 
-Verify:
+When `Update.tla` is used, verify:
 
 - every directly changed reference Action is represented in `AffectedActions`;
 - every high-risk producer/consumer/fault interaction identified by analysis is concrete in `InteractionActions`;
@@ -55,8 +57,10 @@ For `MODEL_CHANGE_REQUIRED`, finish only when:
 
 For `NO_MODEL_CHANGE`, finish only when:
 
-- evidence shows the update is outside the modeled behavior/property scope at the existing granularity;
+- evidence shows the source update leaves modeled behavior and correctness requirements unchanged at the chosen granularity;
 - every changed branch has equal old/new post-state sets after projection onto the existing model vocabulary;
-- semantic spec artifacts remain unchanged;
+- semantic spec artifacts remain unchanged, or every model repair is separately justified and the affected generation checks above pass;
 - no empty or documentary `Update.tla` was created;
 - the rationale is recorded in the existing brief/report for later validation.
+
+Repair-only work proceeds through validation and applicable model checking; a no-change source disposition does not waive those checks for modified semantic artifacts.

--- a/skills/incremental-modeling/references/generation/05-completeness-review.md
+++ b/skills/incremental-modeling/references/generation/05-completeness-review.md
@@ -55,12 +55,14 @@ Reopen the updated modeling brief and analysis report. Ensure every selected upd
 
 ## 5. Stop Conditions
 
+These conditions complete the current Generation pass. On a repair back-edge, recheck the affected artifacts and return to the calling Validation/Model Checking loop; prior execution of those phases does not prevent this handoff.
+
 For `MODEL_CHANGE_REQUIRED`, finish only when:
 
 - the complete reference suite is updated and syntax/config preflights pass;
 - `Update.tla` and its required cfgs exist and reference real MC/base definitions;
 - the completeness reread found no unresolved semantic gap;
-- no trace validation, TLC campaign, simulation, confirmation, or reproduction has been started.
+- executable checks within this Generation pass were limited to syntax and static configuration preflights; trace validation, TLC campaigns, and reproduction remain owned by their respective phases.
 
 For `NO_MODEL_CHANGE`, finish only when:
 

--- a/skills/incremental-modeling/references/generation/05-completeness-review.md
+++ b/skills/incremental-modeling/references/generation/05-completeness-review.md
@@ -12,6 +12,13 @@ Also inspect the final spec diff against the prior suite. Apply Chapter 2's repa
 
 ## 2. Close the Reference Semantics
 
+Completeness means both expressing the new behavior and keeping old behavior valid in new or refined contexts. Review in both directions:
+
+- **Source to model:** follow the operation from its entry through the changed code to its observable result. Check semantically distinct caller contexts, including surrounding guards and side effects, before generalizing a local conclusion to the whole operation.
+- **Model to source:** in states introduced or affected by the update, inspect the alternatives enabled by the complete `Next`. Can an old Action bypass, interrupt, or complete the new path in a way the implementation cannot? Include Actions that affect shared control state or enablement without mentioning new variables. Adding a more specific Action does not override an older one.
+
+Try to construct a distinguishing execution: a legal implementation path the model cannot represent, or a model path unsupported by the implementation. Before calling it a defect, account for the chosen scope, atomicity, and intentional abstraction; different step counts or representations alone are not errors. Use concrete mismatches to guide repairs and later checks, not as a reason to expand every model or disable every overlapping Action.
+
 Verify all relevant surfaces directly in the actual files:
 
 - constants, declarations, record/message fields, variable groups, assumptions, and type predicates;

--- a/skills/incremental-modeling/references/generation/05-completeness-review.md
+++ b/skills/incremental-modeling/references/generation/05-completeness-review.md
@@ -1,0 +1,62 @@
+# Chapter 5: Generation Completeness Review
+
+This is a semantic reread, not a request to emit a dependency graph, checklist artifact, or JSON contract. Assume the Agent can reason directly over the source and TLA+; use these prompts to prevent premature completion.
+
+## 1. Reread the Original Diff
+
+After all generation edits, reread the complete old/new source diff and the changed functions in context. For each semantic change, ask where else the same condition, value, state, message, assumption, or atomicity boundary participates.
+
+Do not equate one code hunk with one spec edit. Do not stop after changing the first matching Action.
+
+Also inspect the final spec diff against the prior suite. Every semantic edit must be required by the source update, its dependency closure, or an evidence-backed property change. Remove collateral edits to unchanged Action boundaries, message production/consumption, retry behavior, or old special paths.
+
+## 2. Close the Reference Semantics
+
+Verify all relevant surfaces directly in the actual files:
+
+- constants, declarations, record/message fields, variable groups, assumptions, and type predicates;
+- `Init`, restore/setup paths, and every required initial value;
+- every helper caller and every special/general call site implementing the mechanism;
+- every Action that reads, writes, preserves, sends, persists, retries, or recovers affected state;
+- real atomicity/interleaving boundaries;
+- `Next`, fairness, Action reachability, and removal of stale alternatives;
+- preserved and structural properties;
+- MC wrappers, counters, constraints, enabled cfg entries, and Scenario hunt coverage;
+- Trace wrappers, post-state checks, silent actions, event fields, capture timing, and instrumentation mapping.
+- equality of old/new projected post-state sets for every branch classified `NO_MODEL_CHANGE`;
+- agreement between mandatory instrumentation fields and non-vacuous Trace checks.
+
+If the review exposes a missing edit, revise the reference and repeat the affected checks. A syntactically valid partial update is not complete.
+
+## 3. Close the Update Focus
+
+Verify:
+
+- every directly changed reference Action is represented in `AffectedActions`;
+- every high-risk producer/consumer/fault interaction identified by analysis is concrete in `InteractionActions`;
+- every other reference Action capable of changing update-visible state or enablement is either concrete or covered by `EnvUpdate`;
+- all generated properties are evidence-backed and enabled by a real cfg;
+- discharge obligations name real omitted Actions and include correct frame conditions;
+- source, reference, and `Update.tla` mappings are bidirectional and point to existing definitions;
+- focused specs do not claim to replace full reference validation.
+
+## 4. Reconcile Analysis and Artifacts
+
+Reopen the updated modeling brief and analysis report. Ensure every selected update Scenario has corresponding model state/actions/properties/configs, and every excluded behavior has an explicit scope rationale. Remove stale recommendations that the final model no longer follows.
+
+## 5. Stop Conditions
+
+For `MODEL_CHANGE_REQUIRED`, finish only when:
+
+- the complete reference suite is updated and syntax/config preflights pass;
+- `Update.tla` and its required cfgs exist and reference real MC/base definitions;
+- the completeness reread found no unresolved semantic gap;
+- no trace validation, TLC campaign, simulation, confirmation, or reproduction has been started.
+
+For `NO_MODEL_CHANGE`, finish only when:
+
+- evidence shows the update is outside the modeled behavior/property scope at the existing granularity;
+- every changed branch has equal old/new post-state sets after projection onto the existing model vocabulary;
+- semantic spec artifacts remain unchanged;
+- no empty or documentary `Update.tla` was created;
+- the rationale is recorded in the existing brief/report for later validation.

--- a/skills/incremental-modeling/references/generation/modular-verification.md
+++ b/skills/incremental-modeling/references/generation/modular-verification.md
@@ -51,7 +51,7 @@ The generation phase only creates these operators/configs. Later validation must
 2. concrete focused checking;
 3. open focused checking;
 4. discharge checking;
-5. full checks again after any revision.
+5. full checks on the stabilized repaired suite under the [model-checking repair loop and final-check rules](../model-checking/01-update-focused-checking.md#counterexamples-and-back-edges), not after each individual edit.
 
 Focused checking never replaces full reference validation. When `EnvUpdate` is used, discharge is additional, not an alternative to full `MCNext`.
 

--- a/skills/incremental-modeling/references/generation/modular-verification.md
+++ b/skills/incremental-modeling/references/generation/modular-verification.md
@@ -1,0 +1,64 @@
+# Open Update Specs and Discharge Checking
+
+Read this chapter when a focused `Update.tla` omits reference Actions that can affect update-visible state or changed Action enablement.
+
+## Sources
+
+- Murat Demirbas, [Composition and Modular Verification of TLA+ specs](https://muratbuffalo.blogspot.com/2026/08/composition-and-modular-verification-of.html).
+- [Producer/consumer TLA+ and TLAPS artifact](https://github.com/muratdem/modularTLA/tree/main/producer-consumer-modular).
+
+## Why It Matters Here
+
+Do not conjoin `Update.tla` as a second closed behavior model with the reference. Closed specs that both write shared state can overconstrain each other. In Incremental Specula, reference Actions remain the sole behavior definitions; `Update.tla` selects them and optionally gives omitted context an explicit environment/rely action.
+
+## Open Update Pattern
+
+```tla
+OpenUpdateNext ==
+    \/ AffectedActions
+    \/ InteractionActions
+    \/ EnvUpdate
+```
+
+- Keep high-risk interactions concrete.
+- Let `EnvUpdate` describe only the remaining context effects relevant to update properties.
+- State explicitly which update-visible variables the environment may change and which it must preserve.
+- Avoid both extremes: an environment so strong that it excludes legal context, or so weak that properties become meaningless.
+
+## Discharge Obligations
+
+Check that every omitted real context Action is accepted by the rely:
+
+```tla
+DischargeContext ==
+    []((OmittedContextActions /\ Frame) => EnvUpdate)
+```
+
+Include frame conditions for private/MC variables. If discharge fails, investigate whether:
+
+- the context Action should be included concretely;
+- `EnvUpdate` is too strong or otherwise wrong;
+- a type-correct but unreachable state needs an already-established local invariant;
+- the reference model or update property is incorrect.
+
+Do not invent an assumption solely to silence a discharge counterexample.
+
+## Later Validation Contract
+
+The generation phase only creates these operators/configs. Later validation must run:
+
+1. update properties over full `MCNext`;
+2. concrete focused checking;
+3. open focused checking;
+4. discharge checking;
+5. full checks again after any revision.
+
+Focused checking never replaces full reference validation. When `EnvUpdate` is used, discharge is additional, not an alternative to full `MCNext`.
+
+## Chaos Universe and TLAPS
+
+A chaos/type universe can check single-step implications over all type-correct state pairs without constructing full reachability. Expect unreachable counterexamples; strengthen only with local invariants already established in the complete reference.
+
+Use TLC first. Consider writing discharge lemmas and checking them with TLAPS only after real cases show that finite bounds or state-space cost limit the TLC checks. Safety action relies fit this pattern; do not assume it directly handles liveness relies.
+
+Do not decompose the entire existing reference into open components. This method is a focused completeness guard around `Update.tla`, not a replacement architecture for Specula.

--- a/skills/incremental-modeling/references/model-checking/01-update-focused-checking.md
+++ b/skills/incremental-modeling/references/model-checking/01-update-focused-checking.md
@@ -1,0 +1,37 @@
+# Update-Focused Model Checking
+
+Use the installed Specula **validation-workflow** skill for trace/MC convergence and the installed **tla-checking-workflow** skill for TLC execution, counterexample analysis, classification, and fixes. Do not restate those methods here.
+
+## Entry Gate
+
+Begin only after the fresh new-version trace suite passes. First run the standard `MC.cfg` convergence round from the main validation workflow. Any semantic spec or invariant repair returns to full fresh trace validation before model checking continues.
+
+For `NO_MODEL_CHANGE`, when semantic artifacts are byte-identical and fresh trace validation passes, retain the prior model-checking evidence and stop. Do not create an empty `Update.tla` or rerun an unchanged state space merely to exercise this chapter.
+
+## Incremental Campaign
+
+For `MODEL_CHANGE_REQUIRED`, run in this order:
+
+1. **Full update check** — check update properties over complete `MCNext` using the generated full config. This is the guard against interactions omitted by focused models.
+2. **Concrete focused check** — run the generated `AffectedActions \/ InteractionActions` configs so TLC spends its state budget on the changed mechanism and its high-risk unchanged producers, consumers, retries, faults, persistence, and recovery.
+3. **Open and discharge checks** — when `EnvUpdate` exists, run the open config and the discharge config. Treat an open result as provisional until omitted real context Actions satisfy the rely/frame obligation.
+4. **Scenario hunts** — run the generated update Scenario configs with the BFS/simulation strategy from the main checking workflow. Each Scenario needs a reachability canary or witness; a property that passes only because its update interaction is unreachable is not coverage.
+5. **Final full check** — rerun the standard full model and full update properties after every repair made during focused checking.
+
+These are independent TLC campaigns. They restrict or widen the enabled Action set; they do not impose a single execution order. Scenario-specific monitors may observe a producer/affected/consumer path, but must not redefine reference behavior.
+
+Do not reduce bounds on update-relevant Actions or faults merely to make BFS deeper. Reduce unrelated domains when justified, then use the main workflow's simulation follow-up for depth.
+
+## Counterexamples and Back-Edges
+
+Apply the main checking workflow's classification unchanged. Incremental model checking adds only these routing rules:
+
+- A violation of a new or revised property is not automatically an invariant problem; a faithful updated model may have exposed an implementation bug.
+- A focused-only violation must also be admitted by full current reference behavior, or have a valid open/discharge basis, before it becomes a finding.
+- A finding is update-related only when its path crosses an affected Action, depends on updated setup/assumptions/state, or demonstrates that the update moved or removed a prior mask. Attribution does not change whether the bug is real.
+- Any Case A/B repair that changes semantic artifacts returns to the complete fresh trace suite, then restarts every affected campaign above.
+- Save actual Case C counterexamples and continue the remaining campaigns. Pass them to `../reproduction/01-confirm-counterexample.md`; do not reproduce a Scenario with no violation.
+
+## Completion
+
+Finish only when standard trace/MC convergence holds, every selected update Scenario is reachable, full/concrete/open/discharge campaigns have explicit outcomes, no Case A/B remains unresolved, and the final full checks have been rerun. Record timeout or resource exhaustion as limited coverage, never as a pass.

--- a/skills/incremental-modeling/references/model-checking/01-update-focused-checking.md
+++ b/skills/incremental-modeling/references/model-checking/01-update-focused-checking.md
@@ -4,9 +4,9 @@ Use the installed Specula **validation-workflow** skill for trace/MC convergence
 
 ## Entry Gate
 
-Begin only after the fresh new-version trace suite passes. First run the standard `MC.cfg` convergence round from the main validation workflow. Any semantic spec or invariant repair returns to full fresh trace validation before model checking continues.
+Begin only after the fresh new-version trace suite passes. Apply the no-change reuse rule below before starting new campaigns; otherwise first run the standard `MC.cfg` convergence round from the main validation workflow. Any semantic spec or invariant repair returns to full fresh trace validation before model checking continues.
 
-For `NO_MODEL_CHANGE`, when semantic artifacts are byte-identical and fresh trace validation passes, retain the prior model-checking evidence and stop. Do not create an empty `Update.tla` or rerun an unchanged state space merely to exercise this chapter.
+For `NO_MODEL_CHANGE`, when semantic artifacts are unchanged, fresh trace validation passes, and applicable prior model-checking evidence is available, retain that evidence and stop. If the reference was repaired or prior evidence is insufficient, run the main validation/checking loop on the current suite and check the repaired behavior and its interactions. Use applicable existing Update views or ordinary MC configs; repair-only work does not require a new `Update.tla`.
 
 ## Incremental Campaign
 
@@ -19,6 +19,8 @@ For `MODEL_CHANGE_REQUIRED`, run in this order:
 5. **Final full check** — rerun the standard full model and full update properties after every repair made during focused checking.
 
 These are independent TLC campaigns. They restrict or widen the enabled Action set; they do not impose a single execution order. Scenario-specific monitors may observe a producer/affected/consumer path, but must not redefine reference behavior.
+
+Check witness paths against the source assumptions they depend on. A reachability canary establishes a model path; a passing property establishes what was checked in that model. Neither alone validates the abstraction. Revisit generation when source evidence contradicts a reused guard, state meaning, or property interpretation, including defects inherited from the prior suite.
 
 Do not reduce bounds on update-relevant Actions or faults merely to make BFS deeper. Reduce unrelated domains when justified, then use the main workflow's simulation follow-up for depth.
 
@@ -34,4 +36,4 @@ Apply the main checking workflow's classification unchanged. Incremental model c
 
 ## Completion
 
-Finish only when standard trace/MC convergence holds, every selected update Scenario is reachable, full/concrete/open/discharge campaigns have explicit outcomes, no Case A/B remains unresolved, and the final full checks have been rerun. Record timeout or resource exhaustion as limited coverage, never as a pass.
+Finish only when standard trace/MC convergence holds, every selected update or repair Scenario is reachable, all applicable campaigns have explicit outcomes, no Case A/B remains unresolved, and final full checks required by repairs have been rerun. Record timeout or resource exhaustion as limited coverage, never as a pass.

--- a/skills/incremental-modeling/references/model-checking/01-update-focused-checking.md
+++ b/skills/incremental-modeling/references/model-checking/01-update-focused-checking.md
@@ -4,7 +4,7 @@ Use the installed Specula **validation-workflow** skill for trace/MC convergence
 
 ## Entry Gate
 
-Begin only after the fresh new-version trace suite passes. Apply the no-change reuse rule below before starting new campaigns; otherwise first run the standard `MC.cfg` convergence round from the main validation workflow. Any semantic spec or invariant repair returns to full fresh trace validation before model checking continues.
+Enter the campaign phase only after the complete fresh new-version trace suite passes. Apply the no-change reuse rule below before starting new campaigns; otherwise first run the standard `MC.cfg` convergence round from the main validation workflow. Subsequent repairs follow [Validation 3's local-feedback loop](../validation/03-trace-validation-loop.md#3-repair-with-local-feedback), not full trace replay after every edit.
 
 For `NO_MODEL_CHANGE`, when semantic artifacts are unchanged, fresh trace validation passes, and applicable prior model-checking evidence is available, retain that evidence and stop. If the reference was repaired or prior evidence is insufficient, run the main validation/checking loop on the current suite and check the repaired behavior and its interactions. Use applicable existing Update views or ordinary MC configs; repair-only work does not require a new `Update.tla`.
 
@@ -16,7 +16,7 @@ For `MODEL_CHANGE_REQUIRED`, run in this order:
 2. **Concrete focused check** — run the generated `AffectedActions \/ InteractionActions` configs so TLC spends its state budget on the changed mechanism and its high-risk unchanged producers, consumers, retries, faults, persistence, and recovery.
 3. **Open and discharge checks** — when `EnvUpdate` exists, run the open config and the discharge config. Treat an open result as provisional until omitted real context Actions satisfy the rely/frame obligation.
 4. **Scenario hunts** — run the generated update Scenario configs with the BFS/simulation strategy from the main checking workflow. Each Scenario needs a reachability canary or witness; a property that passes only because its update interaction is unreachable is not coverage.
-5. **Final full check** — rerun the standard full model and full update properties after every repair made during focused checking.
+5. **Final full check** — after repairs stabilize and the final full trace regression gate is satisfied, rerun the standard full model and full update properties if repairs invalidated their earlier results.
 
 These are independent TLC campaigns. They restrict or widen the enabled Action set; they do not impose a single execution order. Scenario-specific monitors may observe a producer/affected/consumer path, but must not redefine reference behavior.
 
@@ -31,9 +31,9 @@ Apply the main checking workflow's classification unchanged. Incremental model c
 - A violation of a new or revised property is not automatically an invariant problem; a faithful updated model may have exposed an implementation bug.
 - A focused-only violation must also be admitted by full current reference behavior, or have a valid open/discharge basis, before it becomes a finding.
 - A finding is update-related only when its path crosses an affected Action, depends on updated setup/assumptions/state, or demonstrates that the update moved or removed a prior mask. Attribution does not change whether the bug is real.
-- Any Case A/B repair that changes semantic artifacts returns to the complete fresh trace suite, then restarts every affected campaign above.
+- For Case A/B semantic repairs, use local source/trace/operator checks and batch related fixes. Recheck the repaired behavior in the affected campaign; earlier affected results are provisional until rerun on the final artifacts. Defer complete trace replay to the stable-candidate gate, and repeat affected final checks if later repairs invalidate them.
 - Save actual Case C counterexamples and continue the remaining campaigns. Pass them to `../reproduction/01-confirm-counterexample.md`; do not reproduce a Scenario with no violation.
 
 ## Completion
 
-Finish only when standard trace/MC convergence holds, every selected update or repair Scenario is reachable, all applicable campaigns have explicit outcomes, no Case A/B remains unresolved, and final full checks required by repairs have been rerun. Record timeout or resource exhaustion as limited coverage, never as a pass.
+Finish only when standard trace/MC convergence holds, every selected update or repair Scenario is reachable, all applicable campaigns have explicit outcomes, no Case A/B remains unresolved, and the full trace regression and required final model checks apply to the final artifacts. Record timeout or resource exhaustion as limited coverage, never as a pass.

--- a/skills/incremental-modeling/references/reproduction/01-confirm-counterexample.md
+++ b/skills/incremental-modeling/references/reproduction/01-confirm-counterexample.md
@@ -1,0 +1,35 @@
+# Reproduction Entry: Confirm an Incremental Counterexample
+
+This is a thin entry point. Read and follow the installed Specula **bug-confirmation** skill completely for investigation, reproduction, verdicts, evidence, and repair requests. Do not duplicate its escalation ladder or output formats here.
+
+## Preconditions
+
+- An actual TLC counterexample exists. A Scenario, code suspicion, or model-checking run with no violation is not an MC finding.
+- The finding names its violated property, saved TLC output/trace, current source revision, reference Actions, and update Scenario.
+- A focused-only violation must also be admitted by full current reference behavior, or be supported by a valid open/discharge argument. Otherwise return it to model-checking repair before reproduction.
+- Trace validation and model-checking evidence identify the current suite used to produce the finding.
+
+## Incremental Context
+
+Before delegating, attach only the evidence the main skill needs:
+
+- the changed source sites and source-reference-Update mappings;
+- the affected and interacting Actions in the counterexample;
+- relevant prior finding/reproduction/repair lineage from the old run;
+- whether the update introduced a new mechanism, moved an old mechanism, removed a mask, or merely made an existing path reachable.
+
+Confirm and reproduce against the new implementation revision. When the same test and environment are compatible with the old revision, run it as a control to distinguish introduced, newly exposed, and pre-existing behavior. The old-version control strengthens attribution but does not replace reproduction on the new version.
+
+## Delegate and Preserve Verdict Boundaries
+
+Use the main **bug-confirmation** workflow to:
+
+1. investigate code reachability and developer/known-status evidence;
+2. attempt reproduction through the real interface and its escalation ladder;
+3. verify that the observed sequence, consequence, invariant, and code path match this counterexample;
+4. emit the standard verdict and artifacts;
+5. issue a cited repair-request draft when the finding is a spec, invariant, or fault-model artifact.
+
+Never classify a new invariant violation as a model defect merely because it appears after the update. A faithful new model may have exposed a real implementation bug. Conversely, a syntactically valid focused counterexample is not a bug until code reachability and consequence are established.
+
+Accept MC counterexamples only. Do not discover or enqueue standalone code-review findings.

--- a/skills/incremental-modeling/references/validation/01-reuse-prior-harness.md
+++ b/skills/incremental-modeling/references/validation/01-reuse-prior-harness.md
@@ -1,0 +1,60 @@
+# Validation 1: Reuse the Prior Harness
+
+Treat the previous harness as a validated CI asset, not scaffolding to regenerate. Work in the new run; keep the prior `.specula-output/` immutable.
+
+## 1. Establish Provenance
+
+- Confirm the prior harness, traces, source revision, build configuration, and validation changelog belong to the supplied old run.
+- Preserve the prior system category and trace strategy: Category A single-file traces or Category B per-thread timebox traces.
+- Read the current `instrumentation-spec.md`, `Trace.tla`, and update Scenarios before editing the harness.
+- Read and apply the relevant category-specific parts of the installed Specula **harness-generation** skill. Do not repeat its language templates here.
+
+## 2. Rebase, Do Not Regenerate
+
+Copy the prior `harness/` and reusable scenario definitions into the current run. Reapply its patch or copy-and-patch recipe to the new source using symbol/context evidence rather than stale line numbers.
+
+Preserve working components unless the update invalidates them:
+
+- trace writer, ID mapping, timestamp/timebox strategy, preprocessor, and cleanup scripts;
+- build and test commands already proven by the prior run;
+- unaffected instrumentation points and scenario setup;
+- prior artifact/build caches only when source SHA, configuration, and provenance make reuse safe.
+
+Change only what is necessary for:
+
+- affected Actions and selected Interaction Actions;
+- new/revised event fields, capture timing, or Action names required by the current Trace spec;
+- source drift that prevents the old patch from applying;
+- new focused scenarios that the prior harness cannot trigger.
+
+If the update changes the system architecture enough that the prior harness cannot be rebased, record the exact incompatibility. Adapt the smallest reusable layer; do not silently replace the entire harness with weaker instrumentation.
+
+## 3. Densify Instrumentation Around the Update
+
+The update window deserves denser observation than unchanged code. Reuse all sound prior probes, then add enough update-local probes to observe the changed behavior entering, taking effect, and becoming visible to old context.
+
+For each update Scenario, instrument the real code boundaries that expose:
+
+- the old producer or setup state consumed by an affected Action;
+- the guard/branch identity and relevant pre-state at the affected Action;
+- the affected Action's committed post-state at its real atomic boundary;
+- the first unchanged consumer, persistence, retry, recovery, or message path that observes the result;
+- high-risk fault/interleaving boundaries selected as `InteractionActions`.
+
+Cover every changed special/general call site rather than assuming one probe represents them all. Capture the fields that distinguish old behavior, new behavior, and competing unchanged branches. When the prior harness already provides all of this evidence, retain it instead of adding duplicate events.
+
+“More instrumentation” means more semantic observation points around the update, not logging every changed line. Avoid unrelated probes and probe effects. For Category B, keep intervals tight and the hot path lock-free; prefer a few precise per-thread timebox events over shared logging that serializes the race.
+
+## 4. Close Instrumentation Semantics
+
+- Event names, field names, and pre/post capture timing must match `Trace.tla` and `instrumentation-spec.md` exactly.
+- Every mandatory update identity or post-state field must be emitted on the real changed path and required by Trace validation.
+- Never make a Trace check optional solely because the old harness lacks the field; update the harness instead.
+- Keep silent Actions narrowly guarded. Prefer observing an affected or high-risk interaction Action over making it silent.
+- Instrument real code, never a simulator, and never hand-write traces.
+
+Update `harness/INSTRUMENTATION.md` with only the changed points and the normal rebuild/rerun instructions.
+
+## 5. CI Reproducibility
+
+The current `harness/run.sh` must remain a one-command path that applies instrumentation to the new source, builds it, executes selected scenarios, and writes fresh traces. Wrap builds and tests in bounded timeouts and treat a timeout as evidence rather than blindly retrying.

--- a/skills/incremental-modeling/references/validation/01-reuse-prior-harness.md
+++ b/skills/incremental-modeling/references/validation/01-reuse-prior-harness.md
@@ -53,6 +53,8 @@ Cover every changed special/general call site rather than assuming one probe rep
 - Keep silent Actions narrowly guarded. Prefer observing an affected or high-risk interaction Action over making it silent.
 - Instrument real code, never a simulator, and never hand-write traces.
 
+For each update or repair effect claimed as validated, identify the actual Trace predicate comparing its captured result with the corresponding model state or outcome. Observing the event or checking unrelated fields is not enough. If the effect completes asynchronously, compare it at a later coherent observation point tied to the same operation; a weak check at the earlier event does not validate that effect. When no reliable comparison is available, report the effect as unvalidated rather than dropping the check and crediting the action.
+
 Update `harness/INSTRUMENTATION.md` with only the changed points and the normal rebuild/rerun instructions.
 
 ## 5. CI Reproducibility

--- a/skills/incremental-modeling/references/validation/02-update-focused-scenarios.md
+++ b/skills/incremental-modeling/references/validation/02-update-focused-scenarios.md
@@ -1,0 +1,50 @@
+# Validation 2: Update-Focused Scenarios and Traces
+
+Use the prior scenario suite as the regression base, then add the smallest set of scenarios needed to exercise the update and its interactions. Do not replace broad regression coverage with update-only tests.
+
+## 1. Rerun Prior Scenarios on the New Version
+
+Run compatible prior harness scenarios against the new implementation and collect fresh traces. Archived old-version traces remain immutable evidence; they are not substitutes for executing the new code.
+
+- Fresh traces from prior scenarios check that unchanged behavior still conforms to the updated or unchanged reference.
+- An archived trace that crosses intentionally removed behavior may be marked superseded with source evidence; do not weaken the new model to accept it.
+- A prior scenario that no longer builds or reaches its target needs a concrete source-drift disposition, not silent removal.
+
+## 2. Add Update Scenarios
+
+For every selected update Scenario, create a real execution that targets the corresponding source path and model Actions. Cover, when supported by the implementation:
+
+```text
+old producer -> affected Action -> old consumer
+old context -> affected Action -> crash/recovery
+old Action -> affected Action -> old Action
+affected Action -> retry/timeout/configuration change
+affected Action -> affected Action
+```
+
+Each scenario must name:
+
+- the `AffectedActions` and concrete `InteractionActions` it should emit;
+- the mandatory update fields and post-state consequence to observe;
+- the real test entry point and fault/timing control, if any;
+- which old property, revised property, or new interaction property it informs.
+
+Do not force an implementation sequence that cannot occur through normal APIs merely to imitate a model path.
+
+## 3. Category-Specific Trace Quality
+
+For Category A, preserve the real linear event order and collect the message/state fields needed to distinguish the changed path.
+
+For Category B, follow the installed **harness-generation** timebox method: per-thread writers, tight real intervals, post-state capture outside the interval, preprocessing, and genuine cross-thread overlap. The target interaction is a partial-order constraint, not an artificial total order.
+
+## 4. Coverage Gate
+
+Before trace validation:
+
+- every affected event appears in at least one fresh new-version trace, or has a cited environment limitation;
+- every high-risk producer/consumer/fault interaction appears in at least one scenario;
+- mandatory update fields are present and non-vacuous;
+- prior regression scenarios still have explicit fresh-run outcomes;
+- Category B has genuine overlap and contention rather than serialized traces.
+
+Record uncovered Actions as validation gaps. Do not count a scenario name, test file, or empty trace as coverage.

--- a/skills/incremental-modeling/references/validation/02-update-focused-scenarios.md
+++ b/skills/incremental-modeling/references/validation/02-update-focused-scenarios.md
@@ -12,7 +12,7 @@ Run compatible prior harness scenarios against the new implementation and collec
 
 ## 2. Add Update Scenarios
 
-For every selected update Scenario, create a real execution that targets the corresponding source path and model Actions. Cover, when supported by the implementation:
+For every selected update Scenario, obtain a real execution that targets the corresponding source path and model Actions. Reuse a suitable fresh new-version trace when available; add a scenario when existing executions leave a specific behavior, timing, or observation gap. A spec repair alone does not require a new scenario. Cover, when supported by the implementation:
 
 ```text
 old producer -> affected Action -> old consumer

--- a/skills/incremental-modeling/references/validation/03-trace-validation-loop.md
+++ b/skills/incremental-modeling/references/validation/03-trace-validation-loop.md
@@ -9,7 +9,12 @@ Follow the installed Specula **tla-trace-workflow** skill for validation, layere
 3. Validate fresh traces regenerated from the prior regression scenarios.
 4. Once the related repairs stabilize, run the trace workflow's parallel validation over every retained fresh new-version trace.
 
-For Category B, validation succeeds only when some legal timebox interleaving fully consumes the trace. A deadlocked or pruned ordering rejects only that ordering. Look for a full-consumption witness while retaining the semantic and field checks; disabling deadlock detection alone is not a success criterion. Without such a witness, an unfinished search leaves conformance unresolved.
+### Completion Evidence
+
+- **Category A (linear replay):** enable the suite's correctly defined temporal completion property, such as `TraceMatched` or `TraceFullyConsumed`, and retain its completed check result.
+- **Category B (timebox replay):** establish at least one legal interleaving that consumes every thread's trace while enforcing the semantic and field checks. A deadlocked or pruned ordering rejects only that ordering; a separate universal temporal completion check is not required for this existential criterion.
+
+A Category B completion witness may be obtained by checking the negation of the completion predicate: an expected invariant violation counts only when the saved path ends with every per-thread cursor past its final event and retains the required checks. An unrelated violation, a property name, or an error-free run with deadlock detection disabled is not a completion witness. Without a witness, an exhausted search establishes no match under the checked model/configuration; an unfinished search leaves conformance unresolved. These category-specific criteria also govern the final validation gate when applying the reused Specula skills.
 
 ## 2. Classify Before Editing
 

--- a/skills/incremental-modeling/references/validation/03-trace-validation-loop.md
+++ b/skills/incremental-modeling/references/validation/03-trace-validation-loop.md
@@ -22,6 +22,8 @@ For each failure, identify which evidence is wrong:
 
 A trace mismatch alone is not a code-bug verdict. Do not force the model to an intended paper algorithm, and do not weaken post-state checks to make a trace pass.
 
+Passing traces establish conformance for the observed executions; they do not validate every behavior the model permits. For the update's important assumptions and any model repair, use source-backed boundary scenarios and check that logged values have the intended abstract meaning. Do not derive a Trace expectation solely from the reference assignment it is meant to validate. Investigate contradictions even when the old suite used the same interpretation.
+
 ## 3. Reopen Generation When Evidence Changes
 
 Any semantic base/MC/Trace fix reopens the affected Generation chapters:
@@ -32,6 +34,6 @@ Any semantic base/MC/Trace fix reopens the affected Generation chapters:
 - recollect any trace whose event schema or capture timing changed;
 - restart validation from the first affected trace, then rerun the full fresh suite.
 
-For a prior `NO_MODEL_CHANGE` disposition, a fresh trace that demonstrates different projected behavior reopens the Chapter 1 decision gate. Do not preserve no-change merely to retain byte identity.
+For a prior `NO_MODEL_CHANGE` disposition, compare the mismatch with both source revisions. A missed change in projected implementation behavior reopens the Chapter 1 decision gate. An existing model defect requires repair and renewed validation, while the source-delta disposition remains unchanged. Record the reason separately so file changes are not mistaken for implementation changes.
 
 Record every harness, trace, and semantic fix concisely in `spec/changelog.md`, distinguishing archived-trace disposition from fresh-trace validation.

--- a/skills/incremental-modeling/references/validation/03-trace-validation-loop.md
+++ b/skills/incremental-modeling/references/validation/03-trace-validation-loop.md
@@ -1,0 +1,37 @@
+# Validation 3: Trace Validation Loop
+
+Follow the installed Specula **tla-trace-workflow** skill for validation, layered debugging, and evidence-backed fixes. This chapter defines only the incremental ordering and back-edges.
+
+## 1. Validate in Information Order
+
+1. Validate one short fresh trace that reaches an affected Action.
+2. Validate fresh interaction traces for producer/consumer/fault Scenarios.
+3. Validate fresh traces regenerated from the prior regression scenarios.
+4. Run the trace workflow's parallel validation over every retained fresh new-version trace.
+
+For Category B, validation succeeds only when some legal timebox interleaving fully consumes the trace. Do not diagnose a single pruned ordering as a mismatch.
+
+## 2. Classify Before Editing
+
+For each failure, identify which evidence is wrong:
+
+- **Harness/capture mismatch**: event name, field, identity, timing, ID mapping, preprocessing, or scenario setup disagrees with the real action. Fix the harness or mapping and recollect the trace.
+- **Reference/Trace modeling issue**: the new implementation can take a transition that the current reference or wrapper does not faithfully express. Fix the behavioral owner in the reference first, then update MC/Trace/Update mappings.
+- **Legitimately obsolete archived behavior**: an old-version trace traverses behavior intentionally removed by the update. Preserve and disposition the archived trace; fresh new-version traces remain the gate.
+- **Abstraction gap**: apply the main trace workflow's evidence test. Bridge it only when doing so preserves bug-finding value.
+
+A trace mismatch alone is not a code-bug verdict. Do not force the model to an intended paper algorithm, and do not weaken post-state checks to make a trace pass.
+
+## 3. Reopen Generation When Evidence Changes
+
+Any semantic base/MC/Trace fix reopens the affected Generation chapters:
+
+- repair the complete reference and all dependent wrappers/configs;
+- recheck Affected/Interaction Actions, `EnvUpdate`, properties, and source mappings;
+- rerun the generation completeness review;
+- recollect any trace whose event schema or capture timing changed;
+- restart validation from the first affected trace, then rerun the full fresh suite.
+
+For a prior `NO_MODEL_CHANGE` disposition, a fresh trace that demonstrates different projected behavior reopens the Chapter 1 decision gate. Do not preserve no-change merely to retain byte identity.
+
+Record every harness, trace, and semantic fix concisely in `spec/changelog.md`, distinguishing archived-trace disposition from fresh-trace validation.

--- a/skills/incremental-modeling/references/validation/03-trace-validation-loop.md
+++ b/skills/incremental-modeling/references/validation/03-trace-validation-loop.md
@@ -7,7 +7,7 @@ Follow the installed Specula **tla-trace-workflow** skill for validation, layere
 1. Validate one short fresh trace that reaches an affected Action.
 2. Validate fresh interaction traces for producer/consumer/fault Scenarios.
 3. Validate fresh traces regenerated from the prior regression scenarios.
-4. Run the trace workflow's parallel validation over every retained fresh new-version trace.
+4. Once the related repairs stabilize, run the trace workflow's parallel validation over every retained fresh new-version trace.
 
 For Category B, validation succeeds only when some legal timebox interleaving fully consumes the trace. Do not diagnose a single pruned ordering as a mismatch.
 
@@ -15,7 +15,7 @@ For Category B, validation succeeds only when some legal timebox interleaving fu
 
 For each failure, identify which evidence is wrong:
 
-- **Harness/capture mismatch**: event name, field, identity, timing, ID mapping, preprocessing, or scenario setup disagrees with the real action. Fix the harness or mapping and recollect the trace.
+- **Harness/capture mismatch**: event name, field, identity, timing, ID mapping, preprocessing, or scenario setup disagrees with the real action. Fix the responsible layer; reprocess retained raw events when sufficient, otherwise recollect the affected traces.
 - **Reference/Trace modeling issue**: the new implementation can take a transition that the current reference or wrapper does not faithfully express. Fix the behavioral owner in the reference first, then update MC/Trace/Update mappings.
 - **Legitimately obsolete archived behavior**: an old-version trace traverses behavior intentionally removed by the update. Preserve and disposition the archived trace; fresh new-version traces remain the gate.
 - **Abstraction gap**: apply the main trace workflow's evidence test. Bridge it only when doing so preserves bug-finding value.
@@ -24,16 +24,24 @@ A trace mismatch alone is not a code-bug verdict. Do not force the model to an i
 
 Passing traces establish conformance for the observed executions; they do not validate every behavior the model permits. For the update's important assumptions and any model repair, use source-backed boundary scenarios and check that logged values have the intended abstract meaning. Do not derive a Trace expectation solely from the reference assignment it is meant to validate. Investigate contradictions even when the old suite used the same interpretation.
 
-## 3. Reopen Generation When Evidence Changes
+## 3. Repair with Local Feedback
 
-Any semantic base/MC/Trace fix reopens the affected Generation chapters:
+Any semantic repair reopens the affected Generation chapters, but related edits may form one repair batch rather than triggering full replay after each edit:
 
 - repair the complete reference and all dependent wrappers/configs;
 - recheck Affected/Interaction Actions, `EnvUpdate`, properties, and source mappings;
-- rerun the generation completeness review;
-- recollect any trace whose event schema or capture timing changed;
-- restart validation from the first affected trace, then rerun the full fresh suite.
+- apply the generation completeness review to the batch, including its effects on unchanged behavior.
+
+Start with a source-to-model comparison that distinguishes a correct repair from a plausible wrong one: relevant guards, effects, and observable results. For executable feedback, prefer the original failing trace or a short retained trace that exercises the repaired behavior. A bounded local check of the actual TLA+ operators can help resolve a specific semantic uncertainty; do not copy their logic into a separate test model. Synthetic states are diagnostic inputs, not implementation traces or evidence of reachability.
+
+Choose feedback by what it can reveal, not by a fixed test count. Broaden replay when shared state, trace interpretation, or uncertain dependencies make a local selection unreliable. Local checks guide the next edit; they do not establish full convergence or replace required update coverage.
+
+Model-only repairs do not require a fresh implementation run when the source/build and scenario/capture assumptions still match the retained new-version traces. Reprocess raw events if that faithfully repairs the mapping; recollect only affected traces when captured information is missing or invalid. Add a real scenario or probe only to resolve a specific remaining uncertainty or required coverage gap. Do not weaken a required field check to avoid collection.
 
 For a prior `NO_MODEL_CHANGE` disposition, compare the mismatch with both source revisions. A missed change in projected implementation behavior reopens the Chapter 1 decision gate. An existing model defect requires repair and renewed validation, while the source-delta disposition remains unchanged. Record the reason separately so file changes are not mistaken for implementation changes.
 
-Record every harness, trace, and semantic fix concisely in `spec/changelog.md`, distinguishing archived-trace disposition from fresh-trace validation.
+## 4. Full Regression on the Stable Candidate
+
+After related repairs stabilize, replay the complete retained new-version suite against that candidate. This is required before initial model-checking campaign entry and, if later repairs invalidate it, again before final convergence. Reuse a completed full replay when its checked semantics, trace set, and capture assumptions still apply; do not rerun solely because another workflow boundary was reached. A failure reopens the affected repair batch.
+
+Record repairs, local checks, pending regression, and the final full-suite outcome concisely in `spec/changelog.md`. Do not report an intermediate candidate as fully validated or reuse results invalidated by later edits. Keep archived old-version evidence distinct from retained new-version traces.

--- a/skills/incremental-modeling/references/validation/03-trace-validation-loop.md
+++ b/skills/incremental-modeling/references/validation/03-trace-validation-loop.md
@@ -9,18 +9,21 @@ Follow the installed Specula **tla-trace-workflow** skill for validation, layere
 3. Validate fresh traces regenerated from the prior regression scenarios.
 4. Once the related repairs stabilize, run the trace workflow's parallel validation over every retained fresh new-version trace.
 
-For Category B, validation succeeds only when some legal timebox interleaving fully consumes the trace. Do not diagnose a single pruned ordering as a mismatch.
+For Category B, validation succeeds only when some legal timebox interleaving fully consumes the trace. A deadlocked or pruned ordering rejects only that ordering. Look for a full-consumption witness while retaining the semantic and field checks; disabling deadlock detection alone is not a success criterion. Without such a witness, an unfinished search leaves conformance unresolved.
 
 ## 2. Classify Before Editing
 
 For each failure, identify which evidence is wrong:
 
 - **Harness/capture mismatch**: event name, field, identity, timing, ID mapping, preprocessing, or scenario setup disagrees with the real action. Fix the responsible layer; reprocess retained raw events when sufficient, otherwise recollect the affected traces.
+- **Replay configuration mismatch**: finite domains or replay bounds cannot represent the recorded execution, including simultaneously live abstract identities. Adjust the replay configuration to the observed need, without changing implementation limits, removing field checks, or automatically expanding unrelated MC campaigns.
 - **Reference/Trace modeling issue**: the new implementation can take a transition that the current reference or wrapper does not faithfully express. Fix the behavioral owner in the reference first, then update MC/Trace/Update mappings.
 - **Legitimately obsolete archived behavior**: an old-version trace traverses behavior intentionally removed by the update. Preserve and disposition the archived trace; fresh new-version traces remain the gate.
 - **Abstraction gap**: apply the main trace workflow's evidence test. Bridge it only when doing so preserves bug-finding value.
 
 A trace mismatch alone is not a code-bug verdict. Do not force the model to an intended paper algorithm, and do not weaken post-state checks to make a trace pass.
+
+Before deferring a failed replay, localize the blocked guard/state and perform bounded, evidence-directed checks of replay configuration and trace interpretation. A prior "abstraction gap" label is a hypothesis, not a current diagnosis; other passing scenarios do not resolve the failure. If the investigation must stop within the available budget, record what was checked, what remains unresolved, and why further work was deferred. Do not relabel an unexplained mismatch as harmless limited coverage.
 
 Passing traces establish conformance for the observed executions; they do not validate every behavior the model permits. For the update's important assumptions and any model repair, use source-backed boundary scenarios and check that logged values have the intended abstract meaning. Do not derive a Trace expectation solely from the reference assignment it is meant to validate. Investigate contradictions even when the old suite used the same interpretation.
 
@@ -44,4 +47,4 @@ For a prior `NO_MODEL_CHANGE` disposition, compare the mismatch with both source
 
 After related repairs stabilize, replay the complete retained new-version suite against that candidate. This is required before initial model-checking campaign entry and, if later repairs invalidate it, again before final convergence. Reuse a completed full replay when its checked semantics, trace set, and capture assumptions still apply; do not rerun solely because another workflow boundary was reached. A failure reopens the affected repair batch.
 
-Record repairs, local checks, pending regression, and the final full-suite outcome concisely in `spec/changelog.md`. Do not report an intermediate candidate as fully validated or reuse results invalidated by later edits. Keep archived old-version evidence distinct from retained new-version traces.
+Record repairs, local checks, pending regression, and the final full-suite outcome concisely in `spec/changelog.md`. Bind each retained trace's outcome to the model/configuration actually checked; one completion log does not establish full-suite validation. Unresolved required replays or unvalidated key effects prevent full validation, even if the implementation tests passed or the workflow process exited normally. Keep archived old-version evidence distinct from retained new-version traces, and do not reuse results invalidated by later edits.

--- a/skills/incremental-modeling/references/validation/04-validation-completeness.md
+++ b/skills/incremental-modeling/references/validation/04-validation-completeness.md
@@ -1,0 +1,27 @@
+# Validation 4: Completeness and Handoff
+
+Finish incremental trace validation only when all of the following hold.
+
+## Harness and Provenance
+
+- The prior harness was reused or minimally rebased; every replacement has an explicit incompatibility rationale.
+- `harness/run.sh` applies to the new source and reproducibly builds, runs, and collects traces.
+- Updated instrumentation points cite real source symbols and agree with `instrumentation-spec.md` and `Trace.tla`.
+
+## Update Coverage
+
+- Instrumentation around the update observes its producer/setup, branch or pre-state, committed effect, and first high-risk unchanged consumer/fault boundary; any omitted layer has an evidence-backed reason.
+- Every `AffectedAction` is observed in a fresh trace or has a cited environment limitation.
+- Every selected high-risk Interaction Scenario has a fresh trace with the required producer/consumer/fault evidence.
+- Required identity and post-state fields are emitted and checked non-vacuously.
+- Category B trace quality includes real overlap, contention, and per-thread order.
+
+## Regression and Conformance
+
+- Compatible prior scenarios were rerun on the new implementation rather than represented only by archived traces.
+- Every archived trace has a retained, superseded, or environment-limited disposition.
+- All retained fresh new-version traces pass together after the final semantic or harness change.
+- `TraceMatched`/`TraceFullyConsumed` is enabled correctly, post-state validation is not a stub, and silent Actions are constrained.
+- The changelog records every fix and the final fresh trace inventory.
+
+Write a concise validation handoff containing the current source SHA, harness command, fresh trace paths, affected/interaction coverage, archived-trace dispositions, and whether validation changed semantic spec files. Do not claim full convergence or begin model checking until the model-checking part executes and returns to trace validation after any semantic repair.

--- a/skills/incremental-modeling/references/validation/04-validation-completeness.md
+++ b/skills/incremental-modeling/references/validation/04-validation-completeness.md
@@ -13,8 +13,10 @@ Finish incremental trace validation only when all of the following hold.
 - Instrumentation around the update observes its producer/setup, branch or pre-state, committed effect, and first high-risk unchanged consumer/fault boundary; any omitted layer has an evidence-backed reason.
 - Every `AffectedAction` is observed in a fresh trace or has a cited environment limitation.
 - Every selected high-risk Interaction Scenario has a fresh trace with the required producer/consumer/fault evidence.
-- Required identity and post-state fields are emitted and checked non-vacuously.
+- Required identity and result fields are emitted and compared by active Trace predicates at source-faithful observation points, following [Validation 1's comparison rule](01-reuse-prior-harness.md#4-close-instrumentation-semantics).
 - Category B trace quality includes real overlap, contention, and per-thread order.
+
+Report coverage for the selected scenarios and observed effects, not exhaustive interaction coverage. Unobserved interactions and effects whose results were not compared remain explicit gaps; a bounded coverage limitation is distinct from an unresolved replay mismatch.
 
 ## Regression and Conformance
 

--- a/skills/incremental-modeling/references/validation/04-validation-completeness.md
+++ b/skills/incremental-modeling/references/validation/04-validation-completeness.md
@@ -23,7 +23,7 @@ Report coverage for the selected scenarios and observed effects, not exhaustive 
 - Compatible prior scenarios were rerun on the new implementation rather than represented only by archived traces.
 - Every archived trace has a retained, superseded, or environment-limited disposition.
 - The complete retained new-version trace suite passes against the stable candidate under [Validation 3's final regression gate](03-trace-validation-loop.md#4-full-regression-on-the-stable-candidate); local checks alone do not satisfy this gate.
-- `TraceMatched`/`TraceFullyConsumed` is enabled correctly, post-state validation is not a stub, and silent Actions are constrained.
+- Each trace has [category-appropriate completion evidence](03-trace-validation-loop.md#completion-evidence): a completed temporal-property check for linear replay or a full-consumption witness for timebox replay. In either case, post-state checks are active and silent Actions are constrained; property names alone do not satisfy the gate.
 - The changelog records every fix and the final fresh trace inventory.
 
 Write a concise validation handoff containing the current source SHA, harness command, fresh trace paths, affected/interaction coverage, archived-trace dispositions, and whether validation changed semantic spec files. Initial model-checking campaigns require this gate to pass. Later semantic repairs use Validation 3's local-feedback loop; final workflow convergence still requires full trace regression and applicable model checking on the final artifacts.

--- a/skills/incremental-modeling/references/validation/04-validation-completeness.md
+++ b/skills/incremental-modeling/references/validation/04-validation-completeness.md
@@ -20,8 +20,8 @@ Finish incremental trace validation only when all of the following hold.
 
 - Compatible prior scenarios were rerun on the new implementation rather than represented only by archived traces.
 - Every archived trace has a retained, superseded, or environment-limited disposition.
-- All retained fresh new-version traces pass together after the final semantic or harness change.
+- The complete retained new-version trace suite passes against the stable candidate under [Validation 3's final regression gate](03-trace-validation-loop.md#4-full-regression-on-the-stable-candidate); local checks alone do not satisfy this gate.
 - `TraceMatched`/`TraceFullyConsumed` is enabled correctly, post-state validation is not a stub, and silent Actions are constrained.
 - The changelog records every fix and the final fresh trace inventory.
 
-Write a concise validation handoff containing the current source SHA, harness command, fresh trace paths, affected/interaction coverage, archived-trace dispositions, and whether validation changed semantic spec files. Do not claim full convergence or begin model checking until the model-checking part executes and returns to trace validation after any semantic repair.
+Write a concise validation handoff containing the current source SHA, harness command, fresh trace paths, affected/interaction coverage, archived-trace dispositions, and whether validation changed semantic spec files. Initial model-checking campaigns require this gate to pass. Later semantic repairs use Validation 3's local-feedback loop; final workflow convergence still requires full trace regression and applicable model checking on the final artifacts.

--- a/tests/unit/test_skill_install.py
+++ b/tests/unit/test_skill_install.py
@@ -87,6 +87,7 @@ class TestInstallSkills(SkillInstallCase):
                 "byom",
                 "code-analysis",
                 "harness-generation",
+                "incremental-modeling",
                 "spec-generation",
                 "tla-checking-workflow",
                 "tla-trace-workflow",


### PR DESCRIPTION
Add an `incremental-modeling` skill for evolving a prior Specula run against a new source revision. It covers model generation, reuse of the trace harness, update-focused model checking, and counterexample reproduction through the existing Specula skills.

The reference suite owns current behavior; `Update.tla` provides a focused checking view. The skill is discovered by the existing installer, with its expected skill list updated accordingly.

The workflow permits source-backed repairs of inherited model defects, rechecks reused abstraction assumptions, and distinguishes the source-delta decision from changes made to repair the model. Repairs return through validation and applicable model checking, including when the source delta remains `NO_MODEL_CHANGE`.

Review by commit:

- `fe16e08`: original skill, plus the installer test's expected skill name.
- `b40fa8f`: general repair and verification principles, without system-specific examples or additional workflow stages.
