### PR TITLE
Add CI initialization mode

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -151,6 +151,53 @@ specula run \
 
 Supported adapters are `claude-code` (default), `codex`, `copilot-cli`, `opencode`, and `pi`. Model names and effort values are interpreted by the selected agent. OpenCode and Pi model names use `provider/model` syntax.
 
+## Initialize a CI Baseline
+
+Use `--ci-init` to run the normal full pipeline with additional guidance for a
+deep, reusable model of the project's core logic and interactions:
+
+```bash
+specula run --ci-init \
+  --artifact=/absolute/path/to/source \
+  --guidance=/absolute/path/to/project-guidance.md \
+  "name|owner/repository|language|reference"
+```
+
+`--guidance` remains optional. Your text is preserved verbatim and combined with
+the built-in CI guidance, with your explicit scope and exclusions taking precedence.
+No extra model call rewrites the guidance. Both inputs and the effective guidance
+are saved under `runs/<run-id>/ci-init/inputs/` and injected through the existing
+phase prompts. Ordinary runs are unchanged.
+
+CI initialization supports one target and isolated output. It rejects `--byom`,
+`--skip-*`, and `--no-isolate`; `--dry-run` previews the full sequence without
+registering a baseline. Resume an interrupted initialization with
+`specula run --run-id=<run-id>`: its CI mode and original options are restored,
+and already completed phases are not repeated. As with ordinary runs, edits to
+an explicit guidance file are read on resume; each distinct effective input is
+retained without repeatedly appending CI guidance.
+
+At finalization, when a readable, nonempty `spec/base.tla` exists, initialization
+automatically registers the first baseline in `runs/<run-id>/ci-baseline.json`. The record links
+to a copied snapshot of the available specs, analysis, harness and traces, with
+file hashes, source commits/dirty-state observations (including original vs private
+checkout identity with `--keep-original`), missing assets, and the
+pipeline exit code. Paths in the record are relative to its `run_root`.
+The run's artifact checkout and common build/TLC scratch directories are not copied
+into the baseline; full run outputs remain in their normal locations. A dirty or
+unversioned source is reported as such, not certified by its HEAD commit alone.
+
+Registration is **not verification approval**. Baselines are marked `UNVERIFIED`;
+inspect the retained changelog, reports and logs for actual trace/MC outcomes,
+coverage limits and known issues. Validation failures do not prevent registration
+when a reference exists, and a successful process exit does not certify a model.
+Missing reference models are reported without registering an empty baseline.
+Later resumes preserve the first registration and save separate baseline snapshots;
+the command prints the newly saved record. No baseline is silently replaced.
+
+This entrypoint prepares assets only. Automated commit/schedule triggers and
+incremental baseline promotion are not enabled by `--ci-init`.
+
 ## Bring Your Own Model (BYOM)
 
 Use `--byom` when you already have a TLA+ model or other verification assets:
@@ -370,6 +417,7 @@ specula run [options] "name|owner/repository|language|reference"
 | `--artifact=PATH` | Set the target source checkout |
 | `--byom=PATH` | Start from a user-provided model file or verification-assets directory and run Phase 2 onward |
 | `--guidance=PATH` | Read optional modeling guidance for a single-target run |
+| `--ci-init` | Run full single-target CI initialization and register an unverified baseline |
 | `--keep-original` | Run against a full private source copy and write `changes.patch` |
 | `--tlc-memory-limit=SIZE` | Set the run-wide aggregate TLC heap + direct-memory budget; default is 80% of effective available memory at the first TLC start |
 | `--tlc-worker-limit=N` | Optionally bound aggregate TLC exploration workers; omitted means report-only |

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -165,38 +165,13 @@ specula run --ci-init \
 
 `--guidance` remains optional. Your text is preserved verbatim and combined with
 the built-in CI guidance, with your explicit scope and exclusions taking precedence.
-No extra model call rewrites the guidance. Both inputs and the effective guidance
-are saved under `runs/<run-id>/ci-init/inputs/` and injected through the existing
-phase prompts. Ordinary runs are unchanged.
 
-CI initialization supports one target and isolated output. It rejects `--byom`,
-`--skip-*`, and `--no-isolate`; `--dry-run` previews the full sequence without
-registering a baseline. Resume an interrupted initialization with
-`specula run --run-id=<run-id>`: its CI mode and original options are restored,
-and already completed phases are not repeated. As with ordinary runs, edits to
-an explicit guidance file are read on resume; each distinct effective input is
-retained without repeatedly appending CI guidance.
+Initialization saves a reference model and supporting verification assets as a
+baseline, recorded in `runs/<run-id>/ci-baseline.json`. This provides the starting
+point for future incremental CI checks, where the model can evolve alongside
+the project's code.
 
-At finalization, when a readable, nonempty `spec/base.tla` exists, initialization
-automatically registers the first baseline in `runs/<run-id>/ci-baseline.json`. The record links
-to a copied snapshot of the available specs, analysis, harness and traces, with
-file hashes, source commits/dirty-state observations (including original vs private
-checkout identity with `--keep-original`), missing assets, and the
-pipeline exit code. Paths in the record are relative to its `run_root`.
-The run's artifact checkout and common build/TLC scratch directories are not copied
-into the baseline; full run outputs remain in their normal locations. A dirty or
-unversioned source is reported as such, not certified by its HEAD commit alone.
-
-Registration is **not verification approval**. Baselines are marked `UNVERIFIED`;
-inspect the retained changelog, reports and logs for actual trace/MC outcomes,
-coverage limits and known issues. Validation failures do not prevent registration
-when a reference exists, and a successful process exit does not certify a model.
-Missing reference models are reported without registering an empty baseline.
-Later resumes preserve the first registration and save separate baseline snapshots;
-the command prints the newly saved record. No baseline is silently replaced.
-
-This entrypoint prepares assets only. Automated commit/schedule triggers and
-incremental baseline promotion are not enabled by `--ci-init`.
+To resume an interrupted initialization, run `specula run --run-id=<run-id>`.
 
 ## Bring Your Own Model (BYOM)
 

--- a/src/specula/ci_init.py
+++ b/src/specula/ci_init.py
@@ -1,0 +1,221 @@
+"""Guidance composition and run-scoped baseline registration for CI initialization.
+
+Registration preserves reusable artifacts; it deliberately makes no automatic
+semantic-quality verdict. The ordinary pipeline remains the execution owner.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import shutil
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from specula.prompts import render
+
+BASELINE_FILENAME = "ci-baseline.json"
+INPUTS_DIR = "ci-init/inputs"
+SNAPSHOTS_DIR = "ci-init/baselines"
+ASSET_DIRS = ("spec", "harness", "traces")
+# Generated execution state and source/build trees are not baseline inputs.
+_SCRATCH_DIRS = frozenset({".git", ".cache", "__pycache__", "states", "target", "node_modules"})
+
+
+class CIInitError(RuntimeError):
+    """CI initialization metadata cannot safely be recorded."""
+
+
+def _directory(root: Path, relative: str) -> Path:
+    current = root
+    for part in ("", *Path(relative).parts):
+        current = current / part
+        with contextlib.suppress(FileExistsError):
+            current.mkdir()
+        if not stat.S_ISDIR(current.lstat().st_mode):
+            raise CIInitError(f"not a real CI initialization directory: {current}")
+    return current
+
+
+def _write_once(path: Path, content: bytes) -> None:
+    try:
+        with path.open("xb") as stream:
+            stream.write(content)
+    except FileExistsError:
+        if not stat.S_ISREG(path.lstat().st_mode) or path.read_bytes() != content:
+            raise CIInitError(f"CI initialization input changed: {path}") from None
+
+
+def _json_bytes(value: object) -> bytes:
+    return (json.dumps(value, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def prepare_output_directory(run_dir: Path, target: str) -> Path:
+    """Keep guidance publication inside the real target output directory."""
+    return _directory(run_dir, f"{target}/.specula-output")
+
+
+def stage_inputs(run_dir: Path, user_text: str) -> tuple[str, Path]:
+    """Save original and effective guidance without reinterpreting user text."""
+    custom = render("ci-initialization")
+    effective = custom + ("\n## User-Provided Guidance\n\n" + user_text if user_text else "")
+    digest = hashlib.sha256(effective.encode("utf-8")).hexdigest()
+    destination = _directory(run_dir, f"{INPUTS_DIR}/{digest}")
+    for name, text in (
+        ("user-guidance.md", user_text),
+        ("ci-guidance.md", custom),
+        ("effective-guidance.md", effective),
+    ):
+        _write_once(destination / name, text.encode("utf-8"))
+    return effective, destination
+
+
+def fallback_guidance(run_dir: Path, candidate: Path) -> str:
+    """Freeze a legacy .prompt-extra input before publishing composed guidance."""
+    directory = _directory(run_dir, "ci-init")
+    original = directory / "user-guidance.md"
+    if original.exists() or original.is_symlink():
+        if not stat.S_ISREG(original.lstat().st_mode):
+            raise CIInitError(f"unsafe saved user guidance: {original}")
+        return original.read_text(encoding="utf-8")
+    text = candidate.read_text(errors="replace") if candidate.is_file() else ""
+    _write_once(original, text.encode("utf-8"))
+    return text
+
+
+def _regular_file(root: Path, relative: str) -> bool:
+    current = root
+    try:
+        if not stat.S_ISDIR(current.lstat().st_mode):
+            return False
+        for part in Path(relative).parts:
+            current /= part
+            mode = current.lstat().st_mode
+            if not (stat.S_ISREG(mode) or stat.S_ISDIR(mode)):
+                return False
+        return stat.S_ISREG(mode)
+    except OSError:
+        return False
+
+
+def _copy_assets(work_dir: Path, destination: Path) -> tuple[dict[str, str], list[str]]:
+    """Copy verification inputs without following source/cache/secret symlinks."""
+    files: dict[str, str] = {}
+    omitted: list[str] = []
+
+    def copy(path: Path) -> None:
+        relative = path.relative_to(work_dir)
+        mode = path.lstat().st_mode
+        if stat.S_ISDIR(mode):
+            if path.name in _SCRATCH_DIRS:
+                omitted.append(relative.as_posix())
+                return
+            for child in sorted(path.iterdir()):
+                copy(child)
+        elif stat.S_ISREG(mode):
+            target = destination / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, target)
+            digest = hashlib.sha256()
+            with target.open("rb") as stream:
+                for block in iter(lambda: stream.read(1024 * 1024), b""):
+                    digest.update(block)
+            files[relative.as_posix()] = digest.hexdigest()
+        else:
+            omitted.append(relative.as_posix())
+
+    for path in sorted(work_dir.iterdir()):
+        if path.name in ASSET_DIRS or path.suffix == ".md":
+            copy(path)
+    return files, omitted
+
+
+def register_baseline(
+    run_dir: Path,
+    work_dir: Path,
+    *,
+    target: str,
+    invocation: str,
+    inputs_dir: Path,
+    source: dict[str, Any],
+    pipeline_exit_code: int,
+) -> Path | None:
+    """Register the first available reference, retaining later resume snapshots.
+
+    A failed/incomplete validation does not prevent registration. Absence of a
+    readable, nonempty reference does. Existing registration is never replaced.
+    """
+    try:
+        relative_work = work_dir.relative_to(run_dir)
+    except ValueError as exc:
+        raise CIInitError("CI baseline outputs must be inside the run") from exc
+    if ".." in relative_work.parts:
+        raise CIInitError("CI baseline outputs must be inside the run")
+    if not _regular_file(run_dir, (relative_work / "spec/base.tla").as_posix()):
+        return None
+    if (work_dir / "spec/base.tla").stat().st_size == 0:
+        return None
+    if not invocation or not invocation.isalnum():
+        raise CIInitError("invalid CI initialization invocation identity")
+    parent = _directory(run_dir, SNAPSHOTS_DIR)
+    destination = parent / invocation
+    destination.mkdir()  # a resume gets its own identity; never overwrite a snapshot
+    assets = destination / ".specula-output"
+    assets.mkdir()
+    files, omitted = _copy_assets(work_dir, assets)
+    required = (
+        "modeling-brief.md",
+        "spec/MC.tla",
+        "spec/MC.cfg",
+        "spec/Trace.tla",
+        "spec/Trace.cfg",
+        "spec/instrumentation-spec.md",
+        "harness/run.sh",
+    )
+    record = {
+        "version": 1,
+        "kind": "ci-initialization",
+        "target": target,
+        "run_id": run_dir.name,
+        "run_root": str(run_dir.absolute()),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "source": source,
+        "pipeline_exit_code": pipeline_exit_code,
+        "validation_status": "UNVERIFIED",
+        "validation_note": "Registration is not a verification verdict; inspect the retained validation evidence.",
+        "assets": str(assets.relative_to(run_dir)),
+        "guidance": str(inputs_dir.relative_to(run_dir)),
+        "run_output": str(work_dir.relative_to(run_dir)),
+        "files_sha256": files,
+        "missing_artifacts": [name for name in required if name not in files],
+        "omitted_paths": omitted,
+    }
+    payload = _json_bytes(record)
+    manifest = destination / BASELINE_FILENAME
+    _write_once(manifest, payload)
+    # link publishes a complete file atomically, without replacing an earlier
+    # registered baseline (including when a later resume has better coverage).
+    registered = run_dir / BASELINE_FILENAME
+    try:
+        os.link(manifest, registered)
+    except FileExistsError:
+        if not _regular_file(run_dir, BASELINE_FILENAME):
+            raise CIInitError(f"unsafe existing baseline registration: {registered}") from None
+        try:
+            existing = json.loads(registered.read_text(encoding="utf-8"))
+            if (
+                not isinstance(existing, dict)
+                or existing.get("version") != 1
+                or existing.get("kind") != "ci-initialization"
+                or existing.get("target") != target
+                or existing.get("run_id") != run_dir.name
+            ):
+                raise ValueError("registration does not match this run")
+        except (ValueError, UnicodeError) as exc:
+            raise CIInitError(f"invalid existing baseline registration: {registered}") from exc
+        return manifest
+    return registered

--- a/src/specula/output_index.py
+++ b/src/specula/output_index.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import quote_from_bytes
 
+from specula.ci_init import BASELINE_FILENAME
+
 INDEX_FILENAME = "index.md"
 BYOM_REPORT_FILENAME = "byom-modification-report.md"
 PIPELINE_LOG_ENV = "SPECULA_PIPELINE_LOG"
@@ -323,6 +325,11 @@ def render_run_index(
         f"- Final summary: {summary_cell}",
         f"- Full pipeline log: {log_cell}",
     ]
+    baseline = run_root / BASELINE_FILENAME
+    if _is_file_under(run_root, baseline):
+        lines.append(
+            f"- CI baseline: {_link('Registration and verification evidence', baseline, run_root)} (unverified)"
+        )
     return "\n".join(lines) + "\n"
 
 

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -40,8 +40,8 @@ from typing import Any
 # process (see scripts/launch/adapters/claude-code.sh for why that matters).
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from specula import ci_init, resumelib
 from specula import quota as _quota
-from specula import resumelib
 from specula.agent_config import AgentConfigError, AgentRouting, AgentSelection, load_agent_routing
 from specula.output_index import (
     INDEX_FILENAME,
@@ -155,6 +155,8 @@ Options:
   --artifact=PATH        Path to system artifact/source code
   --byom=PATH            Use user-provided model artifacts and run Phase 2 onward
   --guidance=PATH        Target-specific modeling guidance (single-target runs only)
+  --ci-init              Build and register an initial CI baseline with core-depth guidance
+                         (one target, full pipeline, isolated output; registration is not verification)
   --keep-original        Work in a full private copy and write a reviewable changes.patch
   --tlc-memory-limit=SIZE
                          Aggregate -m + -M budget for TLCs in this run (default: auto,
@@ -379,6 +381,10 @@ class Pipeline:
         self.guidance_path: Path | None = None
         self.guidance_text: str | None = None
         self._guidance_given = False
+        self.ci_init = False
+        self._ci_init_given = False
+        self._ci_init_inputs: Path | None = None
+        self._ci_init_source_before: dict[str, Any] | None = None
         self.keep_original = False
         self._keep_original_given = False
         self._snapshot_sources: dict[str, Path] = {}
@@ -420,6 +426,9 @@ class Pipeline:
         for arg in argv:
             if arg == "--dry-run":
                 self.dry_run = True
+            elif arg == "--ci-init":
+                self.ci_init = True
+                self._ci_init_given = True
             elif arg == "--skip-analysis":
                 self.skip_analysis = True
             elif arg == "--skip-specgen":
@@ -584,6 +593,10 @@ class Pipeline:
         if not self.targets:
             self.targets.append(_logical_cwd().name)  # bash `basename "$PWD"` (logical)
         self._targets_given = targets_given
+        ci_error = self._ci_init_option_error()
+        if ci_error is not None:
+            print(f"ERROR: {ci_error}", file=sys.stderr)
+            return 1
         byom_error = self._byom_option_error()
         if byom_error is not None:
             print(f"ERROR: {byom_error}", file=sys.stderr)
@@ -682,6 +695,20 @@ class Pipeline:
             return "--byom requires isolated mode; remove --no-isolate (isolation is the default)"
         return None
 
+    def _ci_init_option_error(self) -> str | None:
+        if not self.ci_init:
+            return None
+        conflicts = [flag for flag in BYOM_CONFLICTING_FLAGS if flag in self.argv]
+        if self.byom_path is not None:
+            conflicts.append("--byom")
+        if conflicts:
+            return f"--ci-init conflicts with {', '.join(conflicts)}; initialization requests the full pipeline"
+        if len(self.targets) != 1:
+            return "--ci-init supports exactly one target per run"
+        if not self.isolate:
+            return "--ci-init requires isolated output; remove --no-isolate"
+        return None
+
     def confirm_without_guidance(self) -> bool:
         """Confirm an interactive run that has no target-specific guidance.
 
@@ -689,7 +716,7 @@ class Pipeline:
         workers redirect their output, so they take this non-interactive path
         even when the scheduler itself was started from a terminal.
         """
-        if self.guidance_path is not None:
+        if self.guidance_path is not None or self.ci_init:
             return True
         if not (sys.stdin.isatty() and sys.stdout.isatty()):
             print(
@@ -715,7 +742,7 @@ class Pipeline:
         resume configuration. Read only that field here; full validation and
         restoration remain resolve_run_dir's responsibility.
         """
-        if self.guidance_path is not None:
+        if self.guidance_path is not None or self.ci_init:
             return False
         if not self._run_id_given:
             return True
@@ -737,7 +764,7 @@ class Pipeline:
             # A legacy run without checkpoints can proceed only through
             # --fresh-context, so confirm before that reset can discard state.
             return self.fresh_context
-        return stored.get("guidance") is None
+        return stored.get("guidance") is None and stored.get("ci_init") is not True
 
     # ── workspace isolation (step 4; runs before the tee so pipeline.log can
     #    land in the run root) ──
@@ -844,6 +871,7 @@ class Pipeline:
             "artifact": self.artifact,
             "byom": str(self.byom_path) if self.byom_path is not None else None,
             "guidance": str(self.guidance_path) if self.guidance_path is not None else None,
+            **({"ci_init": True} if self.ci_init else {}),
         }
 
     def _restore_resume_configuration(self, raw: dict[str, Any], *, allow_overrides: bool = False) -> None:
@@ -851,6 +879,12 @@ class Pipeline:
             raise resumelib.ResumeError(
                 "this run was created without manual conversation checkpoints; pass --fresh-context to continue"
             )
+        stored_ci_init = raw.get("ci_init", False)
+        if not isinstance(stored_ci_init, bool):
+            raise resumelib.ResumeError("invalid stored CI initialization mode")
+        if self._ci_init_given and not stored_ci_init:
+            raise resumelib.ResumeError("cannot enable --ci-init on an existing ordinary run; start a new run")
+        self.ci_init = stored_ci_init
         stored_default = self._selection_from_document(raw.get("default"), "resume default")
         raw_routes = raw.get("routes")
         stored_routes: dict[str, AgentSelection] | None = None
@@ -1008,6 +1042,8 @@ class Pipeline:
         ):
             raise resumelib.ResumeError("invalid stored targets")
         if self._targets_given:
+            if self.ci_init and self.targets != stored_targets:
+                raise resumelib.ResumeError("CI initialization targets cannot change within a run; start a new run")
             if not allow_overrides and self.targets != stored_targets:
                 raise resumelib.ResumeError("targets differ from this run; pass --fresh-context to change them")
         else:
@@ -1046,6 +1082,10 @@ class Pipeline:
             raise resumelib.ResumeError(byom_error)
         if self.byom_path is not None:
             self.skip_analysis = True
+
+        ci_error = self._ci_init_option_error()
+        if ci_error is not None:
+            raise resumelib.ResumeError(ci_error)
 
         stored_artifact = raw.get("artifact")
         if not isinstance(stored_artifact, str):
@@ -1246,15 +1286,23 @@ class Pipeline:
         if self._run_id_given and run_preexisting:
             self._attached_existing_run = True
             try:
+                if self._ci_init_given and (metadata is None or metadata.get("ci_init") is not True):
+                    raise resumelib.ResumeError("cannot enable --ci-init on an existing ordinary run; start a new run")
                 if self.fresh_context:
                     try:
                         stored_configuration = resumelib.load_configuration(self.run_dir)
                     except resumelib.ResumeError:
+                        if metadata is not None and metadata.get("ci_init") is True:
+                            raise resumelib.ResumeError(
+                                "cannot restore CI initialization configuration; preserve this run and start a new run"
+                            ) from None
                         # Runs created before checkpoints have no configuration to
                         # restore. The fresh invocation becomes their baseline.
                         pass
                     else:
                         self._restore_resume_configuration(stored_configuration, allow_overrides=True)
+                        if metadata is not None and metadata.get("ci_init", False) != self.ci_init:
+                            raise resumelib.ResumeError("CI initialization mode disagrees with run metadata")
                     self._invalidate_fresh_context_summaries()
                     resumelib.initialize_run(self.run_dir, reset=True)
                     os.environ[resumelib.FRESH_ENV] = "1"
@@ -1263,6 +1311,8 @@ class Pipeline:
                     if metadata is None:
                         raise resumelib.ResumeError(f"cannot read run metadata from {meta_file}")
                     self._restore_resume_configuration(resumelib.load_configuration(self.run_dir))
+                    if metadata.get("ci_init", False) != self.ci_init:
+                        raise resumelib.ResumeError("CI initialization mode disagrees with run metadata")
                     active = resumelib.active_entries(self.run_dir)
                     if not active:
                         raise resumelib.ResumeError(
@@ -1503,6 +1553,7 @@ class Pipeline:
             "tlc_memory_limit": self.tlc_memory_limit or os.environ.get(MEMORY_LIMIT_ENV) or "auto",
             "tlc_worker_limit": self.tlc_worker_limit or os.environ.get(WORKER_LIMIT_ENV) or None,
             "resume_configuration": resume_configuration,
+            **({"ci_init": True} if self.ci_init else {}),
         }
         if self.agent_routing is not None:
             assert self.agent_config_path is not None
@@ -1627,7 +1678,7 @@ class Pipeline:
 
     def stage_guidance(self, names: list[str]) -> None:
         """Publish the guidance text read for this invocation to phase inputs."""
-        if self.guidance_text is None:
+        if self.guidance_text is None and not self.ci_init:
             return
         if len(self.targets) != 1 or len(names) != 1:
             raise SystemExit("ERROR: --guidance supports exactly one target per run")
@@ -1635,11 +1686,78 @@ class Pipeline:
         if not is_safe_target_name(name):
             raise SystemExit(f"ERROR: unsafe target name for --guidance: {name!r}")
         work_dir = Path(self.get_work_dir(name))
-        self._atomic_replace_text(work_dir / ".prompt-extra.md", self.guidance_text)
+        text = self.guidance_text
+        if self.ci_init:
+            assert self.run_dir is not None
+            work_dir = ci_init.prepare_output_directory(self.run_dir, name)
+            if text is None:
+                # Preserve the original compatibility input, not the composed
+                # .prompt-extra.md left by a previous invocation.
+                fallback = work_dir / ".prompt-extra.md"
+                if not fallback.is_file():
+                    fallback = SPECULA_ROOT / "case-studies" / name / ".prompt-extra.md"
+                text = ci_init.fallback_guidance(self.run_dir, fallback)
+            text, self._ci_init_inputs = ci_init.stage_inputs(self.run_dir, text)
+            log(f"CI initialization guidance: {self._ci_init_inputs / 'effective-guidance.md'}")
+        assert text is not None
+        self._atomic_replace_text(work_dir / ".prompt-extra.md", text)
         if self.run_dir is not None:
             # Phase launchers freeze this file within an invocation. Replace it
             # on resume so every phase started now sees the same current text.
-            self._atomic_replace_text(work_dir / ".prompt-extra.initial.md", self.guidance_text)
+            self._atomic_replace_text(work_dir / ".prompt-extra.initial.md", text)
+
+    def _ci_source_state(self, name: str) -> dict[str, Any]:
+        workspace = Workspace(self.targets, artifact=self.artifact, run_dir=self.run_dir)
+        source = self.run_dir / name / "source" if self.keep_original and self.run_dir else None
+        if source is None:
+            repo = workspace.find_repo_dir(name)
+            source = Path(repo) if repo else None
+        commit = _git_source_commit(source) if source is not None else None
+        dirty: bool | None = None
+        if source is not None and commit is not None:
+            result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(source),
+                    "-c",
+                    "core.fsmonitor=false",
+                    "status",
+                    "--porcelain",
+                    "--untracked-files=normal",
+                ],
+                env=clean_git_environment(),
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                dirty = bool(result.stdout)
+        original = self._snapshot_sources.get(name) if self.keep_original else source
+        return {
+            "path": str(source) if source is not None else None,
+            "commit": commit,
+            "dirty": dirty,
+            "source_mode": "snapshot" if self.keep_original else "in-place",
+            "original_path": str(original) if original is not None else None,
+            "original_commit": _git_source_commit(original) if original is not None else None,
+        }
+
+    def finalize_ci_initialization(self, exit_code: int) -> Path | None:
+        if not self.ci_init or self.dry_run or self.run_dir is None or self._ci_init_inputs is None:
+            return None
+        names = self.extract_names()
+        if len(names) != 1 or not is_safe_target_name(names[0]):
+            raise ci_init.CIInitError("cannot register CI baseline for an invalid target")
+        name = names[0]
+        return ci_init.register_baseline(
+            self.run_dir,
+            Path(self.get_work_dir(name)),
+            target=name,
+            invocation=os.environ.get(resumelib.INVOCATION_ENV, ""),
+            inputs_dir=self._ci_init_inputs,
+            source={"before": self._ci_init_source_before, "after": self._ci_source_state(name)},
+            pipeline_exit_code=exit_code,
+        )
 
     def _invalidate_fresh_context_summaries(self) -> None:
         assert self.run_dir is not None
@@ -3511,6 +3629,8 @@ class Pipeline:
             print(f"Guidance:     {self.guidance_path}")
         if self.byom_path is not None:
             print(f"BYOM input:   {self.byom_path}")
+        if self.ci_init:
+            print("CI mode:      initialization (registration does not imply verified coverage)")
         if self.run_dir:
             print(f"Run:          {self.run_id}  ({self.run_dir})")
         print()
@@ -3550,6 +3670,8 @@ class Pipeline:
         self.stage_guidance(names)
 
         self.prepare_source_snapshots(names)
+        if self.ci_init:
+            self._ci_init_source_before = self._ci_source_state(names[0])
         self.initialize_resource_summaries(names)
 
         start_time = int(time.time())
@@ -3783,6 +3905,20 @@ def main(argv: list[str]) -> int:
             result_index = p.refresh_output_indexes()
         if tee_rc != 0:
             code = tee_rc
+        if p.ci_init and not p.dry_run:
+            try:
+                baseline = p.finalize_ci_initialization(code)
+                message = (
+                    f"CI baseline saved (UNVERIFIED): {baseline}"
+                    if baseline is not None
+                    else "CI baseline not registered: no readable reference model was produced; run outputs were retained."
+                )
+                print(message, file=terminal_stdout, flush=True)
+                result_index = p.refresh_output_indexes()
+            except (OSError, ci_init.CIInitError) as exc:
+                print(f"CI baseline registration failed: {exc}", file=terminal_stdout, flush=True)
+                if code == 0:
+                    code = 1
         try:
             if code == 0 and result_index is not None:
                 with contextlib.suppress(OSError, UnicodeError):

--- a/src/specula/prompts/ci-initialization.md
+++ b/src/specula/prompts/ci-initialization.md
@@ -1,0 +1,21 @@
+## CI Initialization Guidance
+
+This run establishes a reusable modeling and verification baseline for future
+incremental checks. Run the normal Specula workflow; this guidance supplements,
+and does not replace, each phase's methodology.
+
+Respect the user's explicit priorities, scope, and exclusions. Within that scope,
+prioritize semantic depth in the core logic over breadth across peripheral features.
+Investigate the core state transitions and the interactions on which their correctness
+depends, including relevant failure, concurrency, and recovery paths. Let implementation
+evidence determine which mechanisms matter; do not add mechanisms merely to fill a list.
+
+Build a coherent reference covering that core, rather than a collection of isolated
+models for a few known bugs. Add detail where it can expose meaningful interactions,
+not to meet a model-size or line-count target. Keep important assumptions and remaining
+coverage gaps visible so later updates can revisit them.
+
+Produce reusable properties, scenarios, instrumentation, and harness assets through
+the existing workflow. Distinguish observed and checked behavior from unresolved
+questions and budget-limited exploration. Finding a real implementation bug does not
+by itself invalidate a faithful model; finishing the workflow is not a proof of safety.

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -166,6 +166,171 @@ class CliE2E(unittest.TestCase):
         self.assertIn("[DRY RUN] bash scripts/launch/launch_code_analysis.sh", out)
         self.assertIn("Pipeline completed", out)
 
+    def test_ci_init_dry_run_composes_guidance_and_keeps_full_sequence(self) -> None:
+        root = self.specroot()
+        work = self.workdir()
+        guidance = work / "guidance.md"
+        user_text = "Keep this scope and {{literal}} unchanged.\n"
+        guidance.write_text(user_text)
+        proc = self.run_cli(root, ["run", "--ci-init", "--dry-run", f"--guidance={guidance}", "footest"], cwd=work)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        run = self.sole_run_dir(root)
+        meta = json.loads((run / "run.json").read_text())
+        self.assertTrue(meta["ci_init"])
+        self.assertTrue(meta["resume_configuration"]["ci_init"])
+        self.assertEqual(meta["guidance"], str(guidance))
+        inputs = list((run / "ci-init/inputs").iterdir())
+        self.assertEqual(len(inputs), 1)
+        self.assertEqual((inputs[0] / "user-guidance.md").read_text(), user_text)
+        effective = (inputs[0] / "effective-guidance.md").read_text()
+        self.assertEqual((run / "footest/.specula-output/.prompt-extra.initial.md").read_text(), effective)
+        self.assertEqual(guidance.read_text(), user_text)
+        self.assertFalse((run / "ci-baseline.json").exists())
+        for launcher in (
+            "launch_code_analysis.sh",
+            "launch_spec_generation.sh",
+            "launch_harness_generation.sh",
+            "launch_spec_validation.sh",
+            "launch_bug_confirmation.sh",
+            "launch_bug_classification.sh",
+        ):
+            self.assertIn(launcher, proc.stdout)
+
+    def _ci_init_adapter(self, root: Path, *, interrupt_validation: bool = False) -> Path:
+        adapter = root / "scripts/launch/adapters/fake.sh"
+        adapter.write_text(
+            "#!/bin/sh\nset -eu\n"
+            "prompt= log= resume=\n"
+            'for arg do case "$arg" in\n'
+            "  --prompt-file=*) prompt=${arg#*=} ;;\n"
+            "  --log=*) log=${arg#*=} ;;\n"
+            "  --resume-state=*) resume=${arg#*=} ;;\n"
+            "esac; done\n"
+            'printf "%s\\n" "$SPECULA_PHASE" >> "$0.phases"\n'
+            'cp "$prompt" "$0.$SPECULA_PHASE.prompt"\n'
+            'case "$SPECULA_PHASE" in\n'
+            "  code_analysis)\n"
+            '    printf "# Fixture modeling brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
+            "    ;;\n"
+            "  spec_generation)\n"
+            '    mkdir -p "$SPECULA_WORK_DIR/spec"\n'
+            "    for file in base.tla MC.tla Trace.tla instrumentation-spec.md; do\n"
+            '      printf "fixture model\\n" > "$SPECULA_WORK_DIR/spec/$file"\n'
+            "    done\n"
+            "    ;;\n"
+            "  harness_generation)\n"
+            '    mkdir -p "$SPECULA_WORK_DIR/harness" "$SPECULA_WORK_DIR/traces"\n'
+            '    printf "#!/bin/sh\\n" > "$SPECULA_WORK_DIR/harness/run.sh"\n'
+            '    printf \'{"event":"fixture"}\\n\' > "$SPECULA_WORK_DIR/traces/fixture.ndjson"\n'
+            "    ;;\n"
+            "  spec_validation)\n"
+            '    printf x >> "$0.validation-count"\n'
+            f'    if [ {int(interrupt_validation)} -eq 1 ] && [ "$(wc -c < "$0.validation-count")" -eq 1 ]; then\n'
+            '      printf "fixture-session\\n" > "$resume"\n'
+            '      printf "interrupted\\n" > "$log"\n'
+            "      exit 9\n"
+            "    fi\n"
+            '    printf "# Fixture report\\nValidation remains unverified.\\n" > "$SPECULA_WORK_DIR/spec/bug-report.md"\n'
+            '    printf \'{"schema_version":"2","system":"footest","generated_by":"validation-workflow","findings":[]}\\n\' '
+            '> "$SPECULA_WORK_DIR/spec/findings.json"\n'
+            '    printf "# Fixture validation limits\\nMC was not run by this fixture.\\n" > "$SPECULA_WORK_DIR/spec/changelog.md"\n'
+            "    ;;\n"
+            "  bug_confirmation_turn)\n"
+            '    printf \'{"generated_by":"consolidate","findings":[]}\\n\' > "$SPECULA_WORK_DIR/spec/candidates.json"\n'
+            "    ;;\n"
+            "  bug_classification)\n"
+            '    printf "# Severity Classification\\n\\n## Summary\\n\\n## Per-entry classification\\n" > "$SPECULA_WORK_DIR/bug-severity.md"\n'
+            '    printf "No impact-bearing findings were recorded.\\n\\n## Findings\\n\\n- Other dispositions: 0.\\n\\n## Validation limits\\n\\nFixture only; no semantic validation was performed.\\n" > "$SPECULA_WORK_DIR/.summary-findings.md"\n'
+            "    ;;\n"
+            "  *) exit 97 ;;\n"
+            "esac\n"
+            'if [ -n "$log" ]; then printf "fixture completed\\n" > "$log"; fi\n'
+        )
+        adapter.chmod(0o755)
+        return adapter
+
+    def test_ci_init_registers_real_phase_outputs_without_claiming_validation(self) -> None:
+        root = self.specroot()
+        work = self.workdir()
+        artifact = work / "artifact"
+        artifact.mkdir()
+        adapter = self._ci_init_adapter(root)
+        guidance = work / "guidance.md"
+        guidance.write_text("User-specific scope, {{literal}}.\n")
+        proc = self.run_cli(
+            root,
+            ["run", "--ci-init", "--agent=fake", f"--artifact={artifact}", f"--guidance={guidance}", "footest"],
+            cwd=work,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        run = self.sole_run_dir(root)
+        baseline = json.loads((run / "ci-baseline.json").read_text())
+        self.assertEqual(baseline["pipeline_exit_code"], 0)
+        self.assertEqual(baseline["validation_status"], "UNVERIFIED")
+        self.assertEqual(baseline["source"]["before"]["path"], str(artifact))
+        self.assertIsNone(baseline["source"]["before"]["commit"])
+        snapshot = run / baseline["assets"]
+        self.assertEqual((snapshot / "spec/base.tla").read_text(), "fixture model\n")
+        self.assertTrue((snapshot / "harness/run.sh").is_file())
+        self.assertTrue((snapshot / "traces/fixture.ndjson").is_file())
+        self.assertIn("ci-baseline.json", (run / "index.md").read_text())
+        effective = (run / baseline["guidance"] / "effective-guidance.md").read_text()
+        phases = Path(f"{adapter}.phases").read_text().splitlines()
+        for phase in (
+            "code_analysis",
+            "spec_generation",
+            "harness_generation",
+            "spec_validation",
+            "bug_confirmation_turn",
+        ):
+            self.assertIn(phase, phases)
+            prompt = Path(f"{adapter}.{phase}.prompt").read_text()
+            self.assertIn(effective, prompt)
+        self.assertIn("bug_classification", phases)
+
+    def test_ci_init_resume_restores_mode_and_preserves_first_baseline(self) -> None:
+        root = self.specroot()
+        work = self.workdir()
+        artifact = work / "artifact"
+        artifact.mkdir()
+        adapter = self._ci_init_adapter(root, interrupt_validation=True)
+        first = self.run_cli(root, ["run", "--ci-init", "--agent=fake", f"--artifact={artifact}", "footest"], cwd=work)
+        self.assertEqual(first.returncode, 9, first.stdout + first.stderr)
+        run = self.sole_run_dir(root)
+        baseline = (run / "ci-baseline.json").read_bytes()
+        self.assertEqual(json.loads(baseline)["pipeline_exit_code"], 9)
+        effective = (run / "footest/.specula-output/.prompt-extra.initial.md").read_text()
+        resumed = self.run_cli(root, ["run", f"--run-id={run.name}"], cwd=work)
+        self.assertEqual(resumed.returncode, 0, resumed.stdout + resumed.stderr)
+        self.assertEqual((run / "ci-baseline.json").read_bytes(), baseline)
+        self.assertEqual((run / "footest/.specula-output/.prompt-extra.initial.md").read_text(), effective)
+        snapshots = list((run / "ci-init/baselines").iterdir())
+        self.assertEqual(len(snapshots), 2)
+        self.assertEqual(
+            {json.loads((path / "ci-baseline.json").read_text())["pipeline_exit_code"] for path in snapshots}, {0, 9}
+        )
+        phases = Path(f"{adapter}.phases").read_text().splitlines()
+        self.assertEqual(phases.count("code_analysis"), 1)
+        self.assertEqual(phases.count("spec_generation"), 1)
+        self.assertEqual(phases.count("harness_generation"), 1)
+        self.assertEqual(phases.count("spec_validation"), 2)
+        self.assertEqual(Path(f"{adapter}.spec_validation.prompt").read_text().count(effective), 1)
+
+    def test_ci_init_cannot_enable_on_an_existing_ordinary_dry_run(self) -> None:
+        root = self.specroot()
+        work = self.workdir()
+        first = self.run_cli(root, ["run", "--dry-run", "footest"], cwd=work)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        run = self.sole_run_dir(root)
+        before = (run / "run.json").read_bytes()
+        converted = self.run_cli(
+            root, ["run", "--ci-init", "--fresh-context", "--dry-run", f"--run-id={run.name}"], cwd=work
+        )
+        self.assertNotEqual(converted.returncode, 0)
+        self.assertIn("existing ordinary run", converted.stderr)
+        self.assertEqual((run / "run.json").read_bytes(), before)
+        self.assertFalse((run / "ci-init").exists())
+
     def test_byom_dry_run_skips_analysis_and_keeps_multi_target_pipeline(self) -> None:
         root = self.specroot(case_dirs=("alpha", "beta"))
         work = self.workdir()

--- a/tests/unit/test_ci_init.py
+++ b/tests/unit/test_ci_init.py
@@ -1,0 +1,258 @@
+"""CI initialization composes inputs and registers artifacts, not correctness."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from specula import ci_init, resumelib
+from specula import pipelinelib as pl
+
+
+class TestCIInit(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.run_dir = self.root / "run"
+        self.work = self.run_dir / "project" / ".specula-output"
+        self.work.mkdir(parents=True)
+
+    def artifact(self, name: str, text: str = "retained input\n") -> Path:
+        path = self.work / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+        return path
+
+    def register(self, invocation: str = "first", exit_code: int = 0) -> Path | None:
+        _, inputs = ci_init.stage_inputs(self.run_dir, "user scope\n")
+        return ci_init.register_baseline(
+            self.run_dir,
+            self.work,
+            target="project",
+            invocation=invocation,
+            inputs_dir=inputs,
+            source={"before": {"commit": "a" * 40}},
+            pipeline_exit_code=exit_code,
+        )
+
+    def test_composition_preserves_user_text_and_is_idempotent(self) -> None:
+        user = "  Explicit exclusions\n{{literal}} $HOME `not a command`\n\n"
+        effective, inputs = ci_init.stage_inputs(self.run_dir, user)
+        again, same_inputs = ci_init.stage_inputs(self.run_dir, user)
+        self.assertEqual((inputs / "user-guidance.md").read_text(), user)
+        self.assertEqual((inputs / "effective-guidance.md").read_text(), effective)
+        self.assertTrue(effective.endswith(user))
+        self.assertEqual((effective, inputs), (again, same_inputs))
+        self.assertEqual(effective.count((inputs / "ci-guidance.md").read_text()), 1)
+
+    def test_input_changes_keep_previous_effective_guidance(self) -> None:
+        previous, first = ci_init.stage_inputs(self.run_dir, "first")
+        current, second = ci_init.stage_inputs(self.run_dir, "second")
+        self.assertNotEqual(first, second)
+        self.assertEqual((first / "effective-guidance.md").read_text(), previous)
+        self.assertEqual((second / "effective-guidance.md").read_text(), current)
+
+    def test_tampered_input_snapshot_is_not_overwritten(self) -> None:
+        _, inputs = ci_init.stage_inputs(self.run_dir, "scope")
+        (inputs / "user-guidance.md").write_text("unexpected")
+        with self.assertRaises(ci_init.CIInitError):
+            ci_init.stage_inputs(self.run_dir, "scope")
+
+    def test_control_directory_cannot_be_a_symlink(self) -> None:
+        outside = self.root / "outside"
+        outside.mkdir()
+        (self.run_dir / "ci-init").symlink_to(outside, target_is_directory=True)
+        with self.assertRaises(ci_init.CIInitError):
+            ci_init.stage_inputs(self.run_dir, "scope")
+        self.assertEqual(list(outside.iterdir()), [])
+
+    def test_missing_or_empty_model_does_not_register(self) -> None:
+        self.assertIsNone(self.register())
+        self.artifact("spec/base.tla", "")
+        self.assertIsNone(self.register())
+        self.assertFalse((self.run_dir / ci_init.BASELINE_FILENAME).exists())
+
+    def test_failed_validation_still_registers_unverified_model(self) -> None:
+        self.artifact("spec/base.tla", "---- MODULE base ----\n====\n")
+        self.artifact("spec/changelog.md", "Trace validation failed; MC limited.\n")
+        self.artifact("harness/run.sh", "#!/bin/sh\nexit 0\n").chmod(0o755)
+        self.artifact("traces/captured.ndjson", '{"event":"actual"}\n')
+        record = self.register(exit_code=9)
+        assert record is not None
+        data = json.loads(record.read_text())
+        self.assertEqual(data["validation_status"], "UNVERIFIED")
+        self.assertEqual(data["pipeline_exit_code"], 9)
+        self.assertIn("spec/MC.tla", data["missing_artifacts"])
+        snapshot = self.run_dir / data["assets"]
+        self.assertEqual((snapshot / "spec/changelog.md").read_text(), "Trace validation failed; MC limited.\n")
+        self.assertTrue(os.access(snapshot / "harness/run.sh", os.X_OK))
+        for path, digest in data["files_sha256"].items():
+            self.assertEqual(hashlib.sha256((snapshot / path).read_bytes()).hexdigest(), digest)
+
+    def test_successful_process_does_not_certify_model(self) -> None:
+        self.artifact("spec/base.tla")
+        record = self.register()
+        assert record is not None
+        self.assertEqual(json.loads(record.read_text())["validation_status"], "UNVERIFIED")
+
+    def test_invalid_existing_registration_is_not_silently_accepted(self) -> None:
+        self.artifact("spec/base.tla")
+        (self.run_dir / ci_init.BASELINE_FILENAME).write_text("not a registration")
+        with self.assertRaises(ci_init.CIInitError):
+            self.register()
+        self.assertEqual((self.run_dir / ci_init.BASELINE_FILENAME).read_text(), "not a registration")
+
+    def test_resume_keeps_first_registration_and_artifacts(self) -> None:
+        model = self.artifact("spec/base.tla", "old reference\n")
+        first = self.register()
+        assert first is not None
+        original = first.read_bytes()
+        old_assets = self.run_dir / json.loads(original)["assets"]
+        model.write_text("repaired reference\n")
+        second = self.register(invocation="resumed")
+        assert second is not None
+        self.assertNotEqual(first, second)
+        self.assertEqual(first.read_bytes(), original)
+        self.assertEqual((old_assets / "spec/base.tla").read_text(), "old reference\n")
+        new_assets = self.run_dir / json.loads(second.read_text())["assets"]
+        self.assertEqual((new_assets / "spec/base.tla").read_text(), "repaired reference\n")
+
+    def test_artifact_symlinks_and_scratch_are_not_copied(self) -> None:
+        self.artifact("spec/base.tla")
+        self.artifact("spec/states/temporary", "intermediate")
+        self.artifact("artifact/private", "source tree")
+        secret = self.root / "secret"
+        secret.write_text("must not copy")
+        (self.work / "spec" / "linked.tla").symlink_to(secret)
+        record = self.register()
+        assert record is not None
+        data = json.loads(record.read_text())
+        self.assertIn("spec/linked.tla", data["omitted_paths"])
+        self.assertIn("spec/states", data["omitted_paths"])
+        self.assertNotIn("artifact/private", data["files_sha256"])
+        self.assertFalse((self.run_dir / data["assets"] / "spec/linked.tla").exists())
+
+    def test_symlinked_target_does_not_register_external_model(self) -> None:
+        self.artifact("spec/base.tla")
+        target = self.work.parent
+        outside = self.root / "outside"
+        target.rename(outside)
+        target.symlink_to(outside, target_is_directory=True)
+        self.assertIsNone(self.register())
+
+    def test_ci_mode_rejects_skips_byom_and_multiple_targets(self) -> None:
+        provided = self.root / "model.tla"
+        provided.write_text("provided")
+        invalid = [[flag, "project"] for flag in pl.BYOM_CONFLICTING_FLAGS]
+        invalid += [[f"--byom={provided}", "project"], ["a", "b"], ["--no-isolate", "project"]]
+        for args in invalid:
+            with self.subTest(args=args), contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(pl.Pipeline().parse_args(["--ci-init", *args]), 1)
+
+    def test_ci_mode_restores_on_resume_and_rejects_explicit_skip(self) -> None:
+        initial = pl.Pipeline()
+        self.assertIsNone(initial.parse_args(["--ci-init", "project"]))
+        saved = initial._resume_configuration_document()
+        resumed = pl.Pipeline()
+        self.assertIsNone(resumed.parse_args([]))
+        resumed._restore_resume_configuration(saved)
+        self.assertTrue(resumed.ci_init)
+        self.assertEqual(resumed.targets, ["project"])
+        invalid = pl.Pipeline()
+        self.assertIsNone(invalid.parse_args(["--skip-validate"]))
+        with self.assertRaisesRegex(resumelib.ResumeError, "--ci-init conflicts"):
+            invalid._restore_resume_configuration(saved)
+
+    def test_ordinary_run_cannot_be_converted_in_place(self) -> None:
+        ordinary = pl.Pipeline()
+        self.assertIsNone(ordinary.parse_args(["project"]))
+        saved = ordinary._resume_configuration_document()
+        self.assertNotIn("ci_init", saved)
+        for override in (False, True):
+            candidate = pl.Pipeline()
+            self.assertIsNone(candidate.parse_args(["--ci-init", "project"]))
+            with self.assertRaisesRegex(resumelib.ResumeError, "existing ordinary run"):
+                candidate._restore_resume_configuration(saved, allow_overrides=override)
+
+    def test_ci_fresh_context_cannot_change_project(self) -> None:
+        initial = pl.Pipeline()
+        self.assertIsNone(initial.parse_args(["--ci-init", "project"]))
+        replacement = pl.Pipeline()
+        self.assertIsNone(replacement.parse_args(["other-project"]))
+        with self.assertRaisesRegex(resumelib.ResumeError, "targets cannot change"):
+            replacement._restore_resume_configuration(initial._resume_configuration_document(), allow_overrides=True)
+
+    def test_private_source_identity_keeps_original_revision(self) -> None:
+        pipeline = pl.Pipeline()
+        pipeline.run_dir = self.run_dir
+        pipeline.keep_original = True
+        original = self.root / "source"
+        pipeline._snapshot_sources = {"project": original}
+        private = self.run_dir / "project/source"
+        commits = {original: "a" * 40, private: "b" * 40}
+        with (
+            mock.patch.object(pl, "_git_source_commit", side_effect=lambda path: commits[path]),
+            mock.patch("specula.pipelinelib.subprocess.run", return_value=subprocess.CompletedProcess([], 0, "", "")),
+        ):
+            state = pipeline._ci_source_state("project")
+        self.assertEqual(state["commit"], "b" * 40)
+        self.assertEqual(state["original_commit"], "a" * 40)
+        self.assertEqual(state["source_mode"], "snapshot")
+
+    def test_guidance_cannot_be_published_through_symlinked_target(self) -> None:
+        target = self.work.parent
+        outside = self.root / "outside"
+        target.rename(outside)
+        target.symlink_to(outside, target_is_directory=True)
+        pipeline = pl.Pipeline()
+        self.assertIsNone(pipeline.parse_args(["--ci-init", "project"]))
+        pipeline.run_dir = self.run_dir
+        with self.assertRaises(ci_init.CIInitError):
+            pipeline.stage_guidance(["project"])
+        self.assertFalse((outside / ".specula-output/.prompt-extra.md").exists())
+
+    def test_ci_default_guidance_never_prompts(self) -> None:
+        pipeline = pl.Pipeline()
+        self.assertIsNone(pipeline.parse_args(["--ci-init", "project"]))
+        with mock.patch("builtins.input", side_effect=AssertionError("must not prompt")):
+            self.assertFalse(pipeline.should_confirm_without_guidance_before_resolve())
+            self.assertTrue(pipeline.confirm_without_guidance())
+
+    def test_legacy_guidance_is_preserved_without_repeated_ci_prefix(self) -> None:
+        legacy = self.artifact(".prompt-extra.md", "user's existing guidance\n")
+        pipeline = pl.Pipeline()
+        self.assertIsNone(pipeline.parse_args(["--ci-init", "project"]))
+        pipeline.run_dir = self.run_dir
+        with contextlib.redirect_stdout(io.StringIO()):
+            pipeline.stage_guidance(["project"])
+            once = legacy.read_text()
+            pipeline.stage_guidance(["project"])
+        self.assertEqual(legacy.read_text(), once)
+        assert pipeline._ci_init_inputs is not None
+        self.assertEqual((pipeline._ci_init_inputs / "user-guidance.md").read_text(), "user's existing guidance\n")
+
+    def test_explicit_guidance_wins_over_compatibility_file(self) -> None:
+        self.artifact(".prompt-extra.md", "fallback that must not leak")
+        user = self.root / "guidance.md"
+        user.write_text("explicit scope\n")
+        pipeline = pl.Pipeline()
+        self.assertIsNone(pipeline.parse_args(["--ci-init", f"--guidance={user}", "project"]))
+        pipeline.run_dir = self.run_dir
+        with contextlib.redirect_stdout(io.StringIO()):
+            pipeline.stage_guidance(["project"])
+        effective = (self.work / ".prompt-extra.initial.md").read_text()
+        self.assertTrue(effective.endswith("explicit scope\n"))
+        self.assertNotIn("fallback that must not leak", effective)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `specula run --ci-init` for a single-target, full-pipeline initialization run. Compose the user's guidance with core-depth CI guidance using the existing prompt injection path.
- Persist original/effective guidance and register run-scoped snapshots of the available verification assets, source identity, missing assets, and pipeline outcome. Registration is explicitly unverified and does not reject artifacts solely because validation is incomplete.
- Restore CI mode on resume without duplicate guidance, preserve the first baseline registration, and keep ordinary run behavior unchanged. Add CLI validation, result navigation, and usage documentation.

## Scope

No automatic commit/schedule triggers, incremental checking entrypoint, or automatic baseline replacement. No live model initialization experiment has been run for this change. Baseline registration means artifacts are available for follow-up work, not that their semantics have been independently verified.
