### PR TITLE
Add persistent incremental CI workflow

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -173,6 +173,43 @@ the project's code.
 
 To resume an interrupted initialization, run `specula run --run-id=<run-id>`.
 
+## Incremental CI
+
+Choose a persistent directory for the project and initialize it once:
+
+```bash
+specula run --ci-init --ci-dir=/work/project-ci \
+  --artifact=/work/project --guidance=/work/project-guidance.md \
+  "name|owner/repository|language|reference"
+```
+
+After checking out a new commit in the source repository, run:
+
+```bash
+specula run --incremental --ci-dir=/work/project-ci
+```
+
+The command reads the current model and harness, computes the source changes,
+and runs one Agent through the complete incremental-modeling skill. Use the
+ordinary `--agent`, `--model`, and `--effort` options to select that Agent.
+The repository path and user guidance are reused; `--artifact` and `--guidance`
+can supply new inputs. Optional `--revision=SHA` checks that the source checkout
+is at the intended commit.
+
+Completed runs update `current/model/` in the CI directory. Reports, model diffs,
+logs, and resource usage are saved under `runs/<run-id>/`. Incomplete runs leave
+the current model unchanged. Resume the original Agent conversation with:
+
+```bash
+specula run --ci-dir=/work/project-ci --run-id=<run-id>
+```
+
+To start over, rerun the incremental command without `--run-id`. Runs sharing a
+CI directory must execute one at a time. Use a persistent directory outside the
+source checkout on a dedicated runner; automatic CI triggers are not installed
+by these commands. Completion follows the Agent's report and execution checks;
+consult `ci-report.md` for actual verification coverage and findings.
+
 ## Bring Your Own Model (BYOM)
 
 Use `--byom` when you already have a TLA+ model or other verification assets:

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -151,31 +151,17 @@ specula run \
 
 Supported adapters are `claude-code` (default), `codex`, `copilot-cli`, `opencode`, and `pi`. Model names and effort values are interpreted by the selected agent. OpenCode and Pi model names use `provider/model` syntax.
 
-## Initialize a CI Baseline
+## Add Specula to CI
 
-Use `--ci-init` to run the normal full pipeline with additional guidance for a
-deep, reusable model of the project's core logic and interactions:
+Specula maintains a reference model and harness that evolve with your project's
+code. Choose a persistent CI directory outside the source checkout, and use the
+same directory for initialization and subsequent checks.
 
-```bash
-specula run --ci-init \
-  --artifact=/absolute/path/to/source \
-  --guidance=/absolute/path/to/project-guidance.md \
-  "name|owner/repository|language|reference"
-```
+### Initialize once
 
-`--guidance` remains optional. Your text is preserved verbatim and combined with
-the built-in CI guidance, with your explicit scope and exclusions taking precedence.
-
-Initialization saves a reference model and supporting verification assets as a
-baseline, recorded in `runs/<run-id>/ci-baseline.json`. This provides the starting
-point for future incremental CI checks, where the model can evolve alongside
-the project's code.
-
-To resume an interrupted initialization, run `specula run --run-id=<run-id>`.
-
-## Incremental CI
-
-Choose a persistent directory for the project and initialize it once:
+Initialization runs the full Specula workflow, focusing on the depth of the core
+logic and its interactions. Optional `--guidance` supplies your modeling scope
+and priorities.
 
 ```bash
 specula run --ci-init --ci-dir=/work/project-ci \
@@ -183,32 +169,33 @@ specula run --ci-init --ci-dir=/work/project-ci \
   "name|owner/repository|language|reference"
 ```
 
-After checking out a new commit in the source repository, run:
+### Check updates
+
+For each update, check out the target commit in the source repository and run:
 
 ```bash
 specula run --incremental --ci-dir=/work/project-ci
 ```
 
-The command reads the current model and harness, computes the source changes,
-and runs one Agent through the complete incremental-modeling skill. Use the
-ordinary `--agent`, `--model`, and `--effort` options to select that Agent.
-The repository path and user guidance are reused; `--artifact` and `--guidance`
-can supply new inputs. Optional `--revision=SHA` checks that the source checkout
-is at the intended commit.
+Specula computes the changes since the current model's source version, then
+runs one Agent through the incremental-modeling workflow using the existing
+model and harness. The repository path and user guidance are reused. Use the
+ordinary `--agent`, `--model`, and `--effort` options to select the Agent.
 
-Completed runs update `current/model/` in the CI directory. Reports, model diffs,
-logs, and resource usage are saved under `runs/<run-id>/`. Incomplete runs leave
-the current model unchanged. Resume the original Agent conversation with:
+Completed runs update `current/model/` in the CI directory. Reports, diffs, logs,
+and resource usage are saved under `runs/<run-id>/` in the same directory.
+
+### Resume an interrupted run
+
+Incomplete runs leave the current model unchanged. Resume the original Agent
+conversation and working directory with:
 
 ```bash
 specula run --ci-dir=/work/project-ci --run-id=<run-id>
 ```
 
-To start over, rerun the incremental command without `--run-id`. Runs sharing a
-CI directory must execute one at a time. Use a persistent directory outside the
-source checkout on a dedicated runner; automatic CI triggers are not installed
-by these commands. Completion follows the Agent's report and execution checks;
-consult `ci-report.md` for actual verification coverage and findings.
+To start over, rerun the incremental command without `--run-id`. Run checks
+sharing a CI directory one at a time.
 
 ## Bring Your Own Model (BYOM)
 

--- a/scripts/launch/launch_incremental.sh
+++ b/scripts/launch/launch_incremental.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Run one Agent through the complete incremental-modeling skill.
+set -euo pipefail
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/../../src/specula/phaselib.py" incremental "$@"

--- a/src/specula/adapters/utils/run_lock.py
+++ b/src/specula/adapters/utils/run_lock.py
@@ -7,6 +7,7 @@ import stat
 from collections.abc import Mapping
 
 RUN_LOCK_FD_ENV = "SPECULA_RUN_LOCK_FD"
+CI_LOCK_FD_ENV = "SPECULA_CI_LOCK_FD"
 
 
 class RunLockError(OSError):
@@ -16,14 +17,17 @@ class RunLockError(OSError):
 def inherited_run_lock_fds(env: Mapping[str, str] | None = None) -> tuple[int, ...]:
     """Return the validated run-lock lease inherited from the dispatcher."""
     source = os.environ if env is None else env
-    raw = source.get(RUN_LOCK_FD_ENV)
-    if raw is None:
-        return ()
-    try:
-        fd = int(raw)
-        info = os.fstat(fd)
-    except (OSError, ValueError) as exc:
-        raise RunLockError("inherited Specula run lock is unavailable") from exc
-    if fd < 3 or not stat.S_ISREG(info.st_mode):
-        raise RunLockError("inherited Specula run lock is invalid")
-    return (fd,)
+    descriptors: list[int] = []
+    for key in (RUN_LOCK_FD_ENV, CI_LOCK_FD_ENV):
+        raw = source.get(key)
+        if raw is None:
+            continue
+        try:
+            fd = int(raw)
+            info = os.fstat(fd)
+        except (OSError, ValueError) as exc:
+            raise RunLockError("inherited Specula run lock is unavailable") from exc
+        if fd < 3 or not stat.S_ISREG(info.st_mode):
+            raise RunLockError("inherited Specula run lock is invalid")
+        descriptors.append(fd)
+    return tuple(dict.fromkeys(descriptors))

--- a/src/specula/ci_phase.py
+++ b/src/specula/ci_phase.py
@@ -1,0 +1,79 @@
+"""One native Agent conversation for the entire incremental skill."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from specula import ci_init, stop_gate
+from specula.ci_store import CIError, read_json
+from specula.phaselib import AgentFiles, Phase, Workspace, _last_message_path
+from specula.prompts import render
+from specula.skill_refs import prompt_skill_ids
+
+
+class IncrementalPhase(Phase):
+    key = "incremental"
+    title = "Specula — Incremental CI"
+
+    @staticmethod
+    def _rate_limit_retries() -> int:
+        return 0
+
+    def check(self, ws: Workspace, names: list[str]) -> bool:
+        return ws.run_dir is not None and (ws.run_dir / "ci-input.json").is_file()
+
+    def agent_files(self, ws: Workspace, name: str) -> AgentFiles:
+        work = ws.work_dir(name)
+        return {
+            "log": work / "incremental.log",
+            "pid": work / "incremental.pid",
+            "prompt": work / ".incremental-prompt.md",
+            "mkdirs": [work],
+        }
+
+    def build_prompt(self, ws: Workspace, target: str) -> str:
+        assert ws.run_dir is not None
+        inputs = read_json(ws.run_dir / "ci-input.json")
+        prompt = render(
+            "incremental",
+            skill=prompt_skill_ids("incremental-modeling"),
+            target=target,
+            old_source=inputs["old_source"],
+            new_source=str(ws.find_repo_dir(target)),
+            source_diff=str(ws.run_dir / "source.diff"),
+            old_model=inputs["old_model"],
+            work_dir=str(ws.work_dir(target)),
+            run_id=ws.run_dir.name,
+        )
+        return self._with_extra(ws, target, prompt)
+
+    def finalize_outputs(
+        self, ws: Workspace, names: list[str], *, adapter: Path, dry_run: bool
+    ) -> list[tuple[str, int]]:
+        if dry_run:
+            return []
+        assert ws.run_dir is not None
+        failures: list[tuple[str, int]] = []
+        for name in names:
+            work = ws.work_dir(name)
+            log = self.agent_files(ws, name)["log"]
+            response = _last_message_path(log) if adapter.stem == "codex" else log
+            try:
+                if not ci_init._regular_file(work, response.name):
+                    raise CIError("missing current Agent final response")
+                expected = f"SPECULA_INCREMENTAL_COMPLETE {ws.run_dir.name}"
+                if response.read_text(errors="replace").strip().splitlines()[-1:] != [expected]:
+                    raise CIError("Agent did not report completion of the incremental workflow")
+                for required in ("ci-report.md", "spec/base.tla", "harness/run.sh"):
+                    if not ci_init._regular_file(work, required) or not (work / required).read_bytes().strip():
+                        raise CIError(f"missing required result: {required}")
+                if stop_gate._accept_main(self.key, str(work)) != 0:
+                    raise CIError("incremental run left blocked or unfinished work")
+            except (OSError, ValueError, CIError) as exc:
+                print(f"ERROR: {exc}; current model will not be updated")
+                failures.append((name, 1))
+        return failures
+
+    def summarize(self, ws: Workspace, names: list[str]) -> None:
+        for name in names:
+            print(f"Incremental report: {ws.work_dir(name) / 'ci-report.md'}")

--- a/src/specula/ci_store.py
+++ b/src/specula/ci_store.py
@@ -1,0 +1,214 @@
+"""Persistent project state and immutable inputs for incremental CI runs."""
+
+from __future__ import annotations
+
+import difflib
+import fcntl
+import hashlib
+import json
+import os
+import secrets
+import stat
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from specula import ci_init
+from specula.adapters.utils.run_lock import CI_LOCK_FD_ENV
+from specula.snapshotlib import SourceSnapshot, clean_git_environment
+
+
+class CIError(RuntimeError):
+    """A CI run cannot safely prepare or publish its inputs."""
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not stat.S_ISREG(path.lstat().st_mode):
+        raise CIError(f"not a regular CI record: {path}")
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict):
+        raise CIError(f"not a CI record: {path}")
+    return value
+
+
+def write_json(path: Path, value: object) -> None:
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}")
+    with temporary.open("x") as stream:
+        json.dump(value, stream, indent=2)
+        stream.write("\n")
+    temporary.replace(path)
+
+
+def git(repo: Path, *args: str, output: Path | None = None) -> str:
+    command = ["git", "-c", "core.hooksPath=/dev/null", "-c", "core.fsmonitor=false", "-C", str(repo), *args]
+    if output is not None:
+        with output.open("xb") as stream:
+            result = subprocess.run(command, env=clean_git_environment(), stdout=stream, stderr=subprocess.PIPE)
+        text = ""
+        error = result.stderr.decode(errors="replace")
+    else:
+        completed = subprocess.run(command, env=clean_git_environment(), capture_output=True, text=True)
+        result = completed  # type: ignore[assignment]
+        text, error = completed.stdout, completed.stderr
+    if result.returncode:
+        raise CIError(f"git {args[0]} failed: {error.strip()[:500]}")
+    return text.strip()
+
+
+def freeze_source(snapshot: SourceSnapshot, destination: Path) -> None:
+    """Keep history and the exact pre-instrumentation tree, including dirty source."""
+    if not snapshot.is_git:
+        raise CIError("persistent CI requires a Git source repository")
+    git(
+        destination.parent,
+        "clone",
+        "--quiet",
+        "--no-local",
+        "--no-checkout",
+        "--template=",
+        str(snapshot.source),
+        str(destination),
+    )
+    git(destination, "fetch", "--quiet", str(snapshot.baseline_git), snapshot.baseline)
+    # The baseline contains raw bytes; do not apply checkout text conversions.
+    (destination / ".git/info").mkdir(exist_ok=True)
+    (destination / ".git/info/attributes").write_text("* -filter -ident -text !eol !working-tree-encoding\n")
+    git(destination, "checkout", "--quiet", "--detach", snapshot.baseline)
+
+
+def asset_hashes(root: Path) -> dict[str, str]:
+    if not stat.S_ISDIR(root.lstat().st_mode):
+        raise CIError(f"model assets are not a real directory: {root}")
+    result: dict[str, str] = {}
+    for path in root.rglob("*"):
+        mode = path.lstat().st_mode
+        if stat.S_ISDIR(mode):
+            continue
+        if not stat.S_ISREG(mode):
+            raise CIError(f"unsupported persistent model asset: {path}")
+        result[path.relative_to(root).as_posix()] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return result
+
+
+class CIStore:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.fd: int | None = None
+
+    def acquire(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        if self.root.is_symlink() or not self.root.is_dir():
+            raise CIError(f"CI directory is not a real directory: {self.root}")
+        fd = os.open(self.root / ".lock", os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
+        try:
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise CIError("CI lock is not a regular file")
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BaseException:
+            os.close(fd)
+            raise
+        self.fd = fd
+        os.environ[CI_LOCK_FD_ENV] = str(fd)
+        ci_init._directory(self.root, "runs")
+
+    def close(self) -> None:
+        if self.fd is not None:
+            if os.environ.get(CI_LOCK_FD_ENV) == str(self.fd):
+                os.environ.pop(CI_LOCK_FD_ENV, None)
+            # Native Agent descendants inherit this lease, as with the run lock.
+            os.close(self.fd)
+            self.fd = None
+
+    def current_token(self) -> str | None:
+        path = self.root / "current"
+        try:
+            mode = path.lstat().st_mode
+        except FileNotFoundError:
+            return None
+        if not stat.S_ISLNK(mode):
+            raise CIError(f"refusing to replace a non-CI current path: {path}")
+        token = os.readlink(path)
+        self.path(token)
+        return token
+
+    def path(self, relative: str) -> Path:
+        path = Path(relative)
+        if path.is_absolute() or not path.parts or ".." in path.parts:
+            raise CIError(f"unsafe CI path: {relative}")
+        result = self.root
+        for part in path.parts:
+            result /= part
+            if result.is_symlink():
+                raise CIError(f"unexpected symlink in CI state: {result}")
+        return result
+
+    def current(self) -> dict[str, Any]:
+        token = self.current_token()
+        if token is None:
+            raise CIError("CI directory has no current model; run --ci-init --ci-dir=PATH first")
+        directory = self.path(token)
+        state = read_json(directory / "state.json")
+        if state.get("version") != 1:
+            raise CIError("unsupported CI state version")
+        if asset_hashes(directory / "model") != state.get("files_sha256"):
+            raise CIError(
+                "current model assets changed outside CI; preserve them and reinitialize in a new CI directory"
+            )
+        source = self.path(state["source"])
+        if git(source, "rev-parse", "HEAD") != state["snapshot_commit"] or git(source, "status", "--porcelain"):
+            raise CIError("current model's saved source was modified outside CI")
+        state["token"] = token
+        state["model_path"] = str(directory / "model")
+        return state
+
+    def publish(self, run_dir: Path, work: Path, inputs: dict[str, Any]) -> Path:
+        if self.current_token() != inputs["previous"]:
+            raise CIError("current model advanced since this run started; start a new incremental run")
+        for required in ("spec/base.tla", "harness/run.sh"):
+            if not ci_init._regular_file(work, required) or not (work / required).read_bytes().strip():
+                raise CIError(f"cannot publish without {required}")
+        # Verify the old input was not edited by the run.
+        previous = self.current() if inputs["previous"] is not None else None
+        destination = ci_init._directory(run_dir, f"ci-published/{secrets.token_hex(16)}")
+        assets = destination / "model"
+        assets.mkdir()
+        files, omitted = ci_init._copy_assets(work, assets)
+        for filename in ("summary.md", ".summary-findings.md", "index.md"):
+            if filename in files:
+                (assets / filename).unlink()
+                del files[filename]
+        unsafe = [p for p in omitted if Path(p).name not in ci_init._SCRATCH_DIRS]
+        if unsafe:
+            raise CIError(f"model contains unsupported assets: {unsafe[:5]}")
+        if previous is not None:
+            # Diff only model/configuration text, never TLC states or run logs.
+            prior = Path(previous["model_path"])
+            names = set(files) | set(previous["files_sha256"])
+            with (run_dir / "model.diff").open("w") as stream:
+                for name in sorted(names):
+                    if Path(name).suffix not in {".tla", ".cfg"}:
+                        continue
+                    before = (
+                        (prior / name).read_text().splitlines(keepends=True) if name in previous["files_sha256"] else []
+                    )
+                    after = (assets / name).read_text().splitlines(keepends=True) if name in files else []
+                    stream.writelines(difflib.unified_diff(before, after, fromfile=f"a/{name}", tofile=f"b/{name}"))
+        state = {
+            "version": 1,
+            "target": inputs["target"],
+            "artifact": inputs["artifact"],
+            "source": inputs["source"],
+            "source_commit": inputs["source_commit"],
+            "snapshot_commit": inputs["snapshot_commit"],
+            "dirty": inputs["dirty"],
+            "guidance": inputs["guidance"],
+            "run_id": run_dir.name,
+            "files_sha256": files,
+            "verification": "Agent-reported workflow completion; inspect retained evidence, not a proof of safety.",
+        }
+        write_json(destination / "state.json", state)
+        token = destination.relative_to(self.root).as_posix()
+        temporary = self.root / f".current-{secrets.token_hex(8)}"
+        temporary.symlink_to(token)
+        temporary.replace(self.root / "current")
+        return self.root / "current"

--- a/src/specula/ci_workflow.py
+++ b/src/specula/ci_workflow.py
@@ -1,0 +1,259 @@
+"""CI CLI scaffolding; the incremental skill owns the verification workflow."""
+
+from __future__ import annotations
+
+import contextlib
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+from specula import ci_init, resumelib
+from specula.ci_store import CIError, CIStore, freeze_source, git, read_json, write_json
+from specula.pipelinelib import Pipeline
+from specula.snapshotlib import load_sources
+
+
+class CIPipeline(Pipeline):
+    def __init__(self) -> None:
+        super().__init__()
+        self.incremental = False
+        self.ci_dir: Path | None = None
+        self.revision: str | None = None
+        self.store: CIStore | None = None
+        self.inputs: dict[str, Any] | None = None
+
+    def parse_args(self, argv: list[str]) -> int | None:
+        ordinary: list[str] = []
+        for arg in argv:
+            if arg == "--incremental":
+                self.incremental = True
+            elif arg.startswith("--ci-dir="):
+                raw = arg.split("=", 1)[1]
+                if not raw or self.ci_dir is not None:
+                    print("ERROR: specify --ci-dir=PATH exactly once", file=sys.stderr)
+                    return 1
+                self.ci_dir = Path(raw).expanduser().absolute()
+                if self.ci_dir.is_symlink():
+                    print("ERROR: --ci-dir must not be a symlink", file=sys.stderr)
+                    return 1
+                self.ci_dir = self.ci_dir.resolve()
+            elif arg.startswith("--revision="):
+                self.revision = arg.split("=", 1)[1]
+                if not self.revision or self.revision.startswith("-"):
+                    print("ERROR: --revision requires a Git revision", file=sys.stderr)
+                    return 1
+            else:
+                ordinary.append(arg)
+        rc = super().parse_args(ordinary)
+        if rc is not None:
+            return rc
+        self.argv = list(argv)
+        if self.ci_dir is None:
+            print("ERROR: --incremental requires --ci-dir=PATH", file=sys.stderr)
+            return 1
+        if (self.ci_init and self.incremental) or not (self.ci_init or self.incremental or self._run_id_given):
+            print("ERROR: choose --ci-init, --incremental, or --run-id with --ci-dir", file=sys.stderr)
+            return 1
+        if not self.isolate or self.byom_path is not None or len(self.targets) != 1:
+            print("ERROR: persistent CI requires one target, isolated output, and no --byom", file=sys.stderr)
+            return 1
+        if any(arg.startswith("--skip-") for arg in argv) or self._enable_reviews_given:
+            print("ERROR: CI runs the complete workflow; skip and review flags are not supported", file=sys.stderr)
+            return 1
+        if self.fresh_context:
+            print("ERROR: resume the original conversation, or omit --run-id to start a new CI run", file=sys.stderr)
+            return 1
+        if self.incremental:
+            if (self._policy_retries_given and self.policy_retries) or (
+                self._transient_resumes_given and self.transient_resumes
+            ):
+                print("ERROR: incremental CI does not retry failed Agent calls automatically", file=sys.stderr)
+                return 1
+            self.policy_retries = self.transient_resumes = 0
+            self.skip_classification = True  # Findings live in the single Agent's ci-report.md.
+        self.keep_original = True
+        self._isolate_explicit = True
+        self.store = CIStore(self.ci_dir)
+        return None
+
+    def run_storage_root(self) -> Path:
+        assert self.ci_dir is not None
+        return self.ci_dir / "runs"
+
+    def should_confirm_without_guidance_before_resolve(self) -> bool:
+        return False  # CI reuses its persisted user guidance when none is supplied.
+
+    def _resume_configuration_document(self) -> dict[str, Any]:
+        return {
+            **super()._resume_configuration_document(),
+            "ci_directory": str(self.ci_dir),
+            "incremental": self.incremental,
+            "revision": self.revision,
+        }
+
+    def _restore_resume_configuration(self, raw: dict[str, Any], *, allow_overrides: bool = False) -> None:
+        if raw.get("ci_directory") != str(self.ci_dir):
+            raise resumelib.ResumeError("CI directory differs from the original conversation")
+        mode = raw.get("incremental")
+        if not isinstance(mode, bool) or (self.incremental and not mode):
+            raise resumelib.ResumeError("CI run mode differs from the original conversation")
+        if self.revision is not None and self.revision != raw.get("revision"):
+            raise resumelib.ResumeError("target revision cannot change on resume; start a new run")
+        self.incremental = mode
+        self.revision = raw.get("revision")
+        super()._restore_resume_configuration(raw, allow_overrides=allow_overrides)
+        if self.incremental:
+            self.skip_classification = True
+
+    def _position_at_manual_resume_phase(self, active: list[dict[str, Any]] | None = None) -> None:
+        if self.incremental:
+            if self._manual_resume_phase != "incremental":
+                raise resumelib.ResumeError("expected the original incremental Agent conversation")
+            return
+        super()._position_at_manual_resume_phase(active)
+
+    def resolve_run_dir(self, *, acquire_lock: bool = False) -> int | None:
+        assert self.store is not None
+        try:
+            self.store.acquire()
+            attaching = self._run_id_given and (self.run_storage_root() / self.run_id).exists()
+            if self.incremental and not attaching:
+                current = self.store.current()
+                if self._targets_given and self.targets != [current["target"]]:
+                    raise CIError("CI directory belongs to another target")
+                self.targets = [current["target"]]
+                if not self._artifact_given:
+                    self.artifact = current["artifact"]
+                if not self._guidance_given:
+                    self.guidance_text = current["guidance"]
+            elif self.ci_init and not attaching and self.store.current_token() is not None:
+                raise CIError("CI directory is already initialized; use --incremental or choose a new directory")
+            rc = super().resolve_run_dir(acquire_lock=acquire_lock)
+            if rc is not None:
+                self.store.close()
+            return rc
+        except BlockingIOError:
+            print("ERROR: another run is using this CI directory; retry after it finishes", file=sys.stderr)
+        except (OSError, ValueError, CIError, ci_init.CIInitError) as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        self._release_run_lock()
+        return 1
+
+    def _release_run_lock(self) -> None:
+        super()._release_run_lock()
+        if self.store is not None:
+            self.store.close()
+
+    def prepare_source_snapshots(self, names: list[str]) -> None:
+        super().prepare_source_snapshots(names)
+        if self.dry_run:
+            return
+        assert self.run_dir is not None and self.store is not None and self.ci_dir is not None
+        record = self.run_dir / "ci-input.json"
+        if record.exists():
+            self.inputs = read_json(record)
+            if self.store.current_token() != self.inputs["previous"]:
+                raise CIError("current model advanced since this run started; start a new incremental run")
+            return
+        name = names[0]
+        snapshot = load_sources(self.run_dir)[name]
+        source_commit = git(snapshot.source, "rev-parse", "HEAD")
+        if (
+            self.revision is not None
+            and git(snapshot.source, "rev-parse", f"{self.revision}^{{commit}}") != source_commit
+        ):
+            raise CIError("--artifact is not checked out at --revision; check out the intended commit first")
+        dirty = bool(git(snapshot.source, "status", "--porcelain", "--untracked-files=normal"))
+        source = self.run_dir / "ci-source"
+        freeze_source(snapshot, source)
+        previous = self.store.current_token()
+        inputs: dict[str, Any] = {
+            "version": 1,
+            "target": self.targets[0],
+            "artifact": str(snapshot.original),
+            "source": source.relative_to(self.ci_dir).as_posix(),
+            "source_commit": source_commit,
+            "snapshot_commit": snapshot.baseline,
+            "dirty": dirty,
+            "guidance": self.guidance_text or "",
+            "previous": previous,
+        }
+        if self.ci_init:
+            assert self._ci_init_inputs is not None
+            inputs["guidance"] = (self._ci_init_inputs / "user-guidance.md").read_text()
+        else:
+            current = self.store.current()
+            old_source = self.store.path(current["source"])
+            git(source, "merge-base", "--is-ancestor", current["source_commit"], source_commit)
+            git(source, "fetch", "--quiet", str(old_source), current["snapshot_commit"])
+            git(
+                source,
+                "diff",
+                "--binary",
+                "--no-ext-diff",
+                "--no-textconv",
+                current["snapshot_commit"],
+                snapshot.baseline,
+                "--",
+                output=self.run_dir / "source.diff",
+            )
+            inputs["old_source"] = str(old_source)
+            inputs["old_model"] = current["model_path"]
+            work = ci_init.prepare_output_directory(self.run_dir, name)
+            ci_init._copy_assets(Path(current["model_path"]), work)
+            # Prior run summaries remain available in old_model; they are not
+            # this run's findings, completion evidence, or resource history.
+            for filename in ("summary.md", ".summary-findings.md", "ci-report.md"):
+                (work / filename).unlink(missing_ok=True)
+        write_json(record, inputs)
+        self.inputs = inputs
+
+    def _max_parallel_summary(self) -> str:
+        return "1 workflow Agent" if self.incremental else super()._max_parallel_summary()
+
+    def _summary_validation_limits(self) -> tuple[str, ...]:
+        if self.incremental:
+            return (
+                "See ci-report.md for actual verification coverage and remaining limits; completion is not a proof of safety.",
+            )
+        return super()._summary_validation_limits()
+
+    def main(self) -> int:
+        if not self.incremental:
+            return super().main()
+        self.validate_agent_adapter()
+        names = self.extract_names()
+        self.prepare_source_snapshots(names)
+        if self._attached_existing_run and self.guidance_path is None and self.inputs is not None:
+            self.guidance_text = self.inputs["guidance"]
+        self.stage_guidance(names)
+        self.initialize_resource_summaries(names)
+        print(f"CI directory: {self.ci_dir}\nRun: {self.run_id}\nSource update: {self.run_dir}/source.diff")
+        with self.resource_phase("incremental", names):
+            self._phase("INCREMENTAL WORKFLOW", "launch_incremental.sh", self._phase_args(names))
+        return 0
+
+    def finalize_ci_run(self, exit_code: int) -> str | None:
+        if self.dry_run:
+            return None
+        resume = f"specula run --ci-dir={shlex.quote(str(self.ci_dir))} --run-id={self.run_id}"
+        if exit_code:
+            if self.run_dir is not None and resumelib.active_entries(self.run_dir):
+                return f"Current CI model unchanged. To resume the conversation: {resume}"
+            return "Current CI model unchanged. No unfinished conversation is available; fix the error and start a new run."
+        if self.inputs is None or self.store is None or self.run_dir is None:
+            raise CIError("no frozen CI inputs; current model unchanged")
+        source = self.store.path(self.inputs["source"])
+        if git(source, "rev-parse", "HEAD") != self.inputs["snapshot_commit"] or git(source, "status", "--porcelain"):
+            raise CIError("pre-instrumentation source was modified during the run")
+        name = self.extract_names()[0]
+        work = Path(self.get_work_dir(name))
+        publication = dict(self.inputs)
+        if self.incremental and self.guidance_text is not None:
+            publication["guidance"] = self.guidance_text
+        current = self.store.publish(self.run_dir, work, publication)
+        if self.resource_summary is not None:
+            with contextlib.suppress(OSError, ValueError):
+                self.resource_summary.complete_run([name])
+        return f"Current CI model updated: {current}/model\nResults and usage: {work}/summary.md"

--- a/src/specula/ci_workflow.py
+++ b/src/specula/ci_workflow.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import contextlib
 import shlex
+import stat
 import sys
 from pathlib import Path
 from typing import Any
 
 from specula import ci_init, resumelib
 from specula.ci_store import CIError, CIStore, freeze_source, git, read_json, write_json
-from specula.pipelinelib import Pipeline
+from specula.pipelinelib import Pipeline, _valid_run_id
 from specula.snapshotlib import load_sources
 
 
@@ -113,11 +114,32 @@ class CIPipeline(Pipeline):
             return
         super()._position_at_manual_resume_phase(active)
 
+    def _require_resume_run(self) -> None:
+        if not self._run_id_given:
+            return
+        assert self.store is not None
+        if not _valid_run_id(self.run_id):
+            raise CIError(f"invalid --run-id '{self.run_id}' (allowed: [A-Za-z0-9._-]+)")
+        run_dir = self.store.path(f"runs/{self.run_id}")
+        try:
+            mode = run_dir.lstat().st_mode
+        except FileNotFoundError as exc:
+            raise CIError(
+                f"CI run '{self.run_id}' does not exist; cannot resume. Omit --run-id to start a new run."
+            ) from exc
+        if not stat.S_ISDIR(mode):
+            raise CIError(f"CI run '{self.run_id}' is not a real run directory; cannot resume")
+
     def resolve_run_dir(self, *, acquire_lock: bool = False) -> int | None:
         assert self.store is not None
         try:
+            # A CI --run-id only resumes: reject typos before creating storage.
+            self._require_resume_run()
             self.store.acquire()
-            attaching = self._run_id_given and (self.run_storage_root() / self.run_id).exists()
+            # Recheck under the project lease before the ordinary resolver,
+            # whose non-CI semantics also allow naming a new run.
+            self._require_resume_run()
+            attaching = self._run_id_given
             if self.incremental and not attaching:
                 current = self.store.current()
                 if self._targets_given and self.targets != [current["target"]]:

--- a/src/specula/output_index.py
+++ b/src/specula/output_index.py
@@ -200,6 +200,11 @@ def render_target_index(name: str, work_dir: Path, *, pipeline_log: Path | None 
     byom_report = work_dir / BYOM_REPORT_FILENAME
     if _is_file_under(work_dir, byom_report):
         lines.append(f"- {_document('BYOM modification report', byom_report, work_dir)} — Changes to supplied assets")
+    ci_report = work_dir / "ci-report.md"
+    if _is_file_under(work_dir, ci_report):
+        lines.append(
+            f"- {_document('Incremental CI report', ci_report, work_dir)} — Model update and verification results"
+        )
 
     lines += [
         "",

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -3756,6 +3756,10 @@ def main(argv: list[str]) -> int:
     # non-UTF-8 locale must not kill the launcher on the first non-ASCII byte.
     if hasattr(sys.stdout, "reconfigure"):
         sys.stdout.reconfigure(line_buffering=True, errors="replace")
+    if argv and argv[0] == "incremental":
+        from specula.ci_phase import IncrementalPhase
+
+        PHASES["incremental"] = IncrementalPhase()
     if not argv or argv[0] not in PHASES:
         print(f"usage: phaselib.py <phase> [options] <target>...\nphases: {', '.join(PHASES)}", file=sys.stderr)
         return 2

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -40,8 +40,10 @@ from typing import Any
 # process (see scripts/launch/adapters/claude-code.sh for why that matters).
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    sys.modules["specula.pipelinelib"] = sys.modules[__name__]
 from specula import ci_init, resumelib
 from specula import quota as _quota
+from specula.adapters.utils.run_lock import inherited_run_lock_fds
 from specula.agent_config import AgentConfigError, AgentRouting, AgentSelection, load_agent_routing
 from specula.output_index import (
     INDEX_FILENAME,
@@ -157,6 +159,9 @@ Options:
   --guidance=PATH        Target-specific modeling guidance (single-target runs only)
   --ci-init              Build and register an initial CI baseline with core-depth guidance
                          (one target, full pipeline, isolated output; registration is not verification)
+  --ci-dir=PATH          Persistent project directory shared by initialization and incremental runs
+  --incremental          Run one Agent through the incremental-modeling skill using --ci-dir
+  --revision=REF         Verify that the supplied CI source is checked out at this revision
   --keep-original        Work in a full private copy and write a reviewable changes.patch
   --tlc-memory-limit=SIZE
                          Aggregate -m + -M budget for TLCs in this run (default: auto,
@@ -749,7 +754,7 @@ class Pipeline:
         if not _valid_run_id(self.run_id):
             return False  # resolve_run_dir reports the invalid ID
 
-        run_dir = SPECULA_ROOT / "runs" / self.run_id
+        run_dir = self.run_storage_root() / self.run_id
         try:
             run_info = run_dir.lstat()
         except FileNotFoundError:
@@ -1197,6 +1202,13 @@ class Pipeline:
             os.close(fd)
         self._run_lock_fd = None
 
+    def run_storage_root(self) -> Path:
+        return SPECULA_ROOT / "runs"
+
+    def finalize_ci_run(self, exit_code: int) -> str | None:
+        """Publish persistent CI state after output and log finalization."""
+        return None
+
     def resolve_run_dir(self, *, acquire_lock: bool = False) -> int | None:
         """Establish the per-run root. Returns an exit code for an invalid
         --run-id (pre-tee, like the option errors), None to proceed.
@@ -1230,7 +1242,7 @@ class Pipeline:
                 return 1
             if not self._run_id_given:
                 self.run_id = generate_run_id()
-            self.run_dir = SPECULA_ROOT / "runs" / self.run_id
+            self.run_dir = self.run_storage_root() / self.run_id
 
         run_preexisting = self.run_dir.exists()
         locked_here = False
@@ -2960,7 +2972,7 @@ class Pipeline:
         pass_fds: tuple[int, ...] = ()
         if self._run_lock_fd is not None:
             env[resumelib.RUN_LOCK_FD_ENV] = str(self._run_lock_fd)
-            pass_fds = (self._run_lock_fd,)
+            pass_fds = inherited_run_lock_fds(env)
         else:
             env.pop(resumelib.RUN_LOCK_FD_ENV, None)
         if self._resource_phase_key is not None and self._resource_invocation_id is not None:
@@ -3827,7 +3839,12 @@ def main(argv: list[str]) -> int:
     if hasattr(sys.stdout, "reconfigure"):
         sys.stdout.reconfigure(line_buffering=True)
 
-    p = Pipeline()
+    if "--incremental" in argv or any(arg.startswith("--ci-dir=") for arg in argv):
+        from specula.ci_workflow import CIPipeline
+
+        p: Pipeline = CIPipeline()
+    else:
+        p = Pipeline()
     rc = p.parse_args(argv)
     if rc is not None:
         # --help / unknown option exit before the tee starts, like the bash
@@ -3919,6 +3936,14 @@ def main(argv: list[str]) -> int:
                 print(f"CI baseline registration failed: {exc}", file=terminal_stdout, flush=True)
                 if code == 0:
                     code = 1
+        try:
+            ci_message = p.finalize_ci_run(code)
+            if ci_message is not None:
+                print(ci_message, file=terminal_stdout, flush=True)
+        except Exception as exc:
+            print(f"CI state was not updated: {exc}", file=terminal_stdout, flush=True)
+            if code == 0:
+                code = 1
         try:
             if code == 0 and result_index is not None:
                 with contextlib.suppress(OSError, UnicodeError):

--- a/src/specula/prompts/incremental.md
+++ b/src/specula/prompts/incremental.md
@@ -1,0 +1,37 @@
+# Incremental CI Task: {{target}}
+
+Read the installed Specula skill {{skill}} and its guide. Execute its complete
+workflow in one continuous session: generation, trace validation, model checking,
+and reproduction when an actual counterexample requires it. Apply the referenced
+Specula methods. You own the analysis, planning, repairs, and verification loop.
+
+## Inputs
+
+- Original source update (before instrumentation): {{source_diff}}
+- Old source: {{old_source}}
+- New source working copy: {{new_source}}
+- Prior Specula artifacts: {{old_model}}
+- Working artifacts, initially copied from the prior model: {{work_dir}}
+
+Treat old source and artifacts as read-only evidence. Make all changes in the new
+source working copy and working artifacts. Rebase the existing harness onto the
+new source; do not include instrumentation changes in the source update itself.
+Keep the stage artifacts required by the skill as you work. They record evidence,
+not automatic stage-completion or conversation-resume checkpoints.
+
+## Finish
+
+Write a concise `{{work_dir}}/ci-report.md` explaining the modeling decision,
+model changes or repairs, trace validation, checking coverage, findings and
+reproduction outcomes, with paths to actual commands, logs, traces and reports.
+Distinguish limited exploration from unresolved required validation. A real code
+bug does not by itself invalidate a faithful model or prevent workflow completion.
+
+Only when the skill's applicable completion conditions are satisfied and all
+started work has been observed, end your final response with this exact line:
+
+SPECULA_INCREMENTAL_COMPLETE {{run_id}}
+
+If work remains unresolved or execution is interrupted, report what remains and
+do not emit that line. The current CI model will remain unchanged. On manual
+resume, continue this same conversation and workspace; do not restart completed work.

--- a/src/specula/resource_summary.py
+++ b/src/specula/resource_summary.py
@@ -67,6 +67,8 @@ PHASES = (
     PhaseDefinition("phase4b", "Phase 4b", ("bug-classification.usage.json",)),
 )
 PHASE_BY_KEY = {phase.key: phase for phase in PHASES}
+INCREMENTAL_PHASE = PhaseDefinition("incremental", "Incremental workflow", ("incremental.usage.json",))
+PHASE_BY_KEY[INCREMENTAL_PHASE.key] = INCREMENTAL_PHASE
 
 _TURN_USAGE_RE = re.compile(r"^turn[0-9]{2}_(?:A|B|A-repair)\.usage\.json$")
 _FINDING_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
@@ -199,7 +201,7 @@ class TargetState:
     target: str
     run_complete: bool = False
     history_incomplete: bool = False
-    phases: dict[str, PhaseState] = field(default_factory=lambda: {phase.key: PhaseState() for phase in PHASES})
+    phases: dict[str, PhaseState] = field(default_factory=lambda: {key: PhaseState() for key in PHASE_BY_KEY})
     invocation_signatures: dict[str, str] = field(default_factory=dict)
     sessions: dict[str, SessionState] = field(default_factory=dict)
     maximum_parallelism: str = "-"
@@ -238,6 +240,9 @@ class TargetState:
             return None
         phases_data = _string_mapping(data.get("phases")) or {}
         phases = {phase.key: PhaseState.from_object(phases_data.get(phase.key)) for phase in PHASES}
+        phases["incremental"] = (
+            PhaseState.from_object(phases_data["incremental"]) if "incremental" in phases_data else PhaseState()
+        )
         configuration = _string_mapping(data.get("configuration")) or {}
         return cls(
             target=expected_target,
@@ -917,7 +922,13 @@ def render_summary(
     total_cost = 0.0
     total_cost_observed = False
     incomplete = not state.run_complete or state.history_incomplete
-    for definition in PHASES:
+    incremental = state.phases.get("incremental")
+    definitions = (
+        (INCREMENTAL_PHASE,)
+        if incremental is not None and (incremental.runtime_observed or incremental.tokens_observed)
+        else PHASES
+    )
+    for definition in definitions:
         phase = state.phases[definition.key]
         runtime_available = phase.runtime_observed and not phase.runtime_incomplete
         runtime = _format_runtime(phase.runtime_seconds) if runtime_available else "-"
@@ -1090,6 +1101,8 @@ def _report_links(work_dir: Path | None) -> list[str]:
         ("Severity report", "bug-severity.md"),
     )
     lines: list[str] = []
+    if work_dir is not None and _safe_regular_file(work_dir, work_dir / "ci-report.md"):
+        lines.append("- [Incremental CI report](ci-report.md)")
     for label, filename in reports:
         if work_dir is not None and _safe_regular_file(work_dir, work_dir / filename):
             lines.append(f"- [{label}]({filename})")

--- a/tests/e2e/test_incremental_ci.py
+++ b/tests/e2e/test_incremental_ci.py
@@ -130,10 +130,37 @@ class IncrementalCLI(unittest.TestCase):
         original = (self.ci / "current/model/spec/base.tla").read_bytes()
         self.change_source("documentation-only fixture update\n")
         Path(str(self.adapter) + ".nochange").touch()
-        result = self.run_ci("--incremental", "--agent=fake", "--run-id=chosen-id")
+        result = self.run_ci("--incremental", "--agent=fake")
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertEqual((self.ci / "current/model/spec/base.tla").read_bytes(), original)
         self.assertEqual(CIStore(self.ci).current()["source_commit"], self.git("rev-parse", "HEAD"))
+
+    def test_unknown_run_id_cannot_start_or_publish_a_new_workflow(self) -> None:
+        self.initialize()
+        current = (self.ci / "current").resolve()
+        state = (current / "state.json").read_bytes()
+        model = (current / "model/spec/base.tla").read_bytes()
+        runs = set((self.ci / "runs").iterdir())
+        phases = Path(str(self.adapter) + ".phases").read_bytes()
+        for index, flags in enumerate(([], ["--incremental"], ["--ci-init"], ["--dry-run"])):
+            with self.subTest(flags=flags):
+                result = self.run_ci(
+                    *flags, f"--run-id=missing-{index}", "--agent=fake", f"--artifact={self.source}", "footest"
+                )
+                self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("does not exist; cannot resume", result.stderr)
+                self.assertEqual(set((self.ci / "runs").iterdir()), runs)
+                self.assertEqual(Path(str(self.adapter) + ".phases").read_bytes(), phases)
+                self.assertEqual((self.ci / "current").resolve(), current)
+                self.assertEqual((current / "state.json").read_bytes(), state)
+                self.assertEqual((current / "model/spec/base.tla").read_bytes(), model)
+
+    def test_unknown_run_id_does_not_create_a_ci_directory(self) -> None:
+        result = self.run_ci("--run-id=missing", "--agent=fake", f"--artifact={self.source}", "footest")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not exist; cannot resume", result.stderr)
+        self.assertFalse(self.ci.exists())
+        self.assertFalse(Path(str(self.adapter) + ".phases").exists())
 
     def test_zero_exit_and_existing_artifacts_are_not_completion(self) -> None:
         self.initialize()

--- a/tests/e2e/test_incremental_ci.py
+++ b/tests/e2e/test_incremental_ci.py
@@ -1,0 +1,218 @@
+"""Exercise the real CLI and native resume wiring with a deterministic adapter.
+
+The fixture does not perform semantic verification or call an LLM.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+import test_cli_pipeline as fixtures
+
+from specula.ci_store import CIStore
+
+
+class IncrementalCLI(unittest.TestCase):
+    def setUp(self) -> None:
+        self.helper = fixtures.CliE2E()
+        self.addCleanup(self.helper.doCleanups)
+        self.root = self.helper.specroot()
+        self.work = self.helper.workdir()
+        self.source = self.work / "source"
+        self.source.mkdir()
+        self.git("init", "-q")
+        self.git("config", "user.name", "Fixture")
+        self.git("config", "user.email", "fixture@example.com")
+        (self.source / "logic.txt").write_text("initial\n")
+        self.commit("initial")
+        self.initial_sha = self.git("rev-parse", "HEAD")
+        self.ci = self.work / "ci"
+        self.adapter = self.helper._ci_init_adapter(self.root)
+        script = self.adapter.read_text()
+        script = script.replace(
+            'case "$SPECULA_PHASE" in\n',
+            'case "$SPECULA_PHASE" in\n'
+            "  incremental)\n"
+            '    if [ -f "$0.fail" ]; then\n'
+            '      printf "fixture-native-session\\n" > "$resume"\n'
+            '      printf "unfinished edit\\n" > "$SPECULA_WORK_DIR/spec/base.tla"\n'
+            '      printf "interrupted\\n" > "$log"\n'
+            "      exit 9\n"
+            "    fi\n"
+            '    if [ -f "$0.reject" ]; then printf "not complete\\n" > "$log"; exit 0; fi\n'
+            '    if [ -f "$resume" ]; then cp "$resume" "$0.resumed"; fi\n'
+            '    if [ ! -f "$0.nochange" ]; then printf "updated fixture model\\n" > "$SPECULA_WORK_DIR/spec/base.tla"; fi\n'
+            '    printf "# CI fixture report\\nNo real verification performed.\\n" > "$SPECULA_WORK_DIR/ci-report.md"\n'
+            '    printf \'{"agent":"codex","session_id":"fixture-native-session","usage":{"total_tokens":150,"cached_input_tokens":50},"total_cost_usd":0.01,"usage_complete":true}\\n\' > "${log%.log}.usage.json"\n'
+            '    printf "SPECULA_INCREMENTAL_COMPLETE %s\\n" "$(basename "$SPECULA_RUN_DIR")" > "$log"\n'
+            "    exit 0\n"
+            "    ;;\n",
+        )
+        self.adapter.write_text(script)
+
+    def git(self, *args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(self.source), *args], check=True, capture_output=True, text=True
+        ).stdout.strip()
+
+    def commit(self, message: str) -> None:
+        self.git("add", ".")
+        self.git("commit", "-qm", message)
+
+    def run_ci(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return self.helper.run_cli(self.root, ["run", f"--ci-dir={self.ci}", *args], cwd=self.work)
+
+    def initialize(self) -> None:
+        result = self.run_ci("--ci-init", "--agent=fake", f"--artifact={self.source}", "footest")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue((self.ci / "current/model/spec/base.tla").is_file())
+
+    def change_source(self, text: str) -> None:
+        (self.source / "logic.txt").write_text(text)
+        self.commit("update")
+
+    def latest(self) -> Path:
+        return (self.ci / "runs/latest").resolve()
+
+    def test_initialization_then_single_agent_incremental_update(self) -> None:
+        self.initialize()
+        old = (self.ci / "current").resolve()
+        self.change_source("updated\n")
+        result = self.run_ci("--incremental", "--agent=fake")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        state = CIStore(self.ci).current()
+        self.assertEqual(state["source_commit"], self.git("rev-parse", "HEAD"))
+        self.assertNotEqual((self.ci / "current").resolve(), old)
+        self.assertEqual((old / "model/spec/base.tla").read_text(), "fixture model\n")
+        self.assertEqual((self.ci / "current/model/spec/base.tla").read_text(), "updated fixture model\n")
+        self.assertIn("-initial\n+updated", (self.latest() / "source.diff").read_text())
+        self.assertTrue((self.latest() / "model.diff").is_file())
+        self.assertEqual((self.source / "logic.txt").read_text(), "updated\n")
+        self.assertEqual(self.git("status", "--porcelain"), "")
+        self.assertEqual(Path(str(self.adapter) + ".phases").read_text().splitlines()[-1], "incremental")
+        self.assertIn("Incremental workflow", (self.latest() / "footest/.specula-output/summary.md").read_text())
+        usage = json.loads((self.latest() / "footest/.specula-output/.resource-summary-state.json").read_text())
+        self.assertEqual(usage["phases"]["incremental"]["total_tokens"], 150)
+        self.assertEqual(usage["phases"]["incremental"]["cost_usd"], 0.01)
+        self.assertTrue(usage["run_complete"])
+
+    def test_failure_keeps_current_and_resume_uses_original_conversation_and_source(self) -> None:
+        self.initialize()
+        old = (self.ci / "current").resolve()
+        self.change_source("version B\n")
+        sha_b = self.git("rev-parse", "HEAD")
+        flag = Path(str(self.adapter) + ".fail")
+        flag.touch()
+        first = self.run_ci("--incremental", "--agent=fake")
+        self.assertEqual(first.returncode, 9, first.stdout + first.stderr)
+        self.assertEqual((self.ci / "current").resolve(), old)
+        run = self.latest()
+        original_diff = (run / "source.diff").read_bytes()
+        self.change_source("version C\n")
+        flag.unlink()
+        resumed = self.run_ci(f"--run-id={run.name}")
+        self.assertEqual(resumed.returncode, 0, resumed.stdout + resumed.stderr)
+        self.assertEqual(CIStore(self.ci).current()["source_commit"], sha_b)
+        self.assertEqual((run / "source.diff").read_bytes(), original_diff)
+        self.assertEqual(Path(str(self.adapter) + ".resumed").read_text(), "fixture-native-session\n")
+        prompt = Path(str(self.adapter) + ".incremental.prompt").read_text()
+        self.assertIn("exact session", prompt)
+        self.assertNotIn("# Incremental CI Task", prompt)
+        usage = json.loads((run / "footest/.specula-output/.resource-summary-state.json").read_text())
+        self.assertEqual(usage["phases"]["incremental"]["total_tokens"], 150)
+        self.assertTrue(usage["phases"]["incremental"]["usage_incomplete"])
+
+    def test_no_model_change_still_advances_source_version(self) -> None:
+        self.initialize()
+        original = (self.ci / "current/model/spec/base.tla").read_bytes()
+        self.change_source("documentation-only fixture update\n")
+        Path(str(self.adapter) + ".nochange").touch()
+        result = self.run_ci("--incremental", "--agent=fake", "--run-id=chosen-id")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual((self.ci / "current/model/spec/base.tla").read_bytes(), original)
+        self.assertEqual(CIStore(self.ci).current()["source_commit"], self.git("rev-parse", "HEAD"))
+
+    def test_zero_exit_and_existing_artifacts_are_not_completion(self) -> None:
+        self.initialize()
+        old = (self.ci / "current").resolve()
+        self.change_source("version B\n")
+        Path(str(self.adapter) + ".reject").touch()
+        result = self.run_ci("--incremental", "--agent=fake")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual((self.ci / "current").resolve(), old)
+        self.assertIn("did not report completion", result.stdout)
+
+    def test_new_run_after_failure_uses_cumulative_diff(self) -> None:
+        self.initialize()
+        self.change_source("version B\n")
+        flag = Path(str(self.adapter) + ".fail")
+        flag.touch()
+        self.assertEqual(self.run_ci("--incremental", "--agent=fake").returncode, 9)
+        failed = self.latest()
+        self.change_source("version C\n")
+        flag.unlink()
+        result = self.run_ci("--incremental", "--agent=fake")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        diff = (self.latest() / "source.diff").read_text()
+        self.assertIn("-initial\n+version C", diff)
+        current = (self.ci / "current").resolve()
+        stale = self.run_ci(f"--run-id={failed.name}")
+        self.assertNotEqual(stale.returncode, 0)
+        self.assertEqual((self.ci / "current").resolve(), current)
+
+    def test_ci_directory_lock_rejects_concurrent_invocation(self) -> None:
+        self.initialize()
+        store = CIStore(self.ci)
+        store.acquire()
+        try:
+            result = self.run_ci("--incremental", "--agent=fake")
+        finally:
+            store.close()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("another run", result.stderr)
+
+    def test_dirty_initial_source_is_preserved_in_the_update_diff(self) -> None:
+        (self.source / "logic.txt").write_text("dirty initial\n")
+        (self.source / "untracked.txt").write_text("initial extra\n")
+        self.initialize()
+        state = CIStore(self.ci).current()
+        self.assertTrue(state["dirty"])
+        self.assertEqual((self.ci / state["source"] / "logic.txt").read_text(), "dirty initial\n")
+        self.change_source("new committed source\n")
+        result = self.run_ci("--incremental", "--agent=fake")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("-dirty initial\n+new committed source", (self.latest() / "source.diff").read_text())
+
+    def test_wrong_target_revision_does_not_launch_agent(self) -> None:
+        self.initialize()
+        self.change_source("version B\n")
+        phases = Path(str(self.adapter) + ".phases").read_text()
+        result = self.run_ci("--incremental", "--agent=fake", f"--revision={self.initial_sha}")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(Path(str(self.adapter) + ".phases").read_text(), phases)
+
+    def test_dry_run_does_not_publish_or_instrument(self) -> None:
+        result = self.run_ci("--ci-init", "--dry-run", f"--artifact={self.source}", "footest")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertFalse((self.ci / "current").exists())
+        self.assertEqual(self.git("status", "--porcelain"), "")
+
+    def test_saved_inputs_identify_both_versions_and_original_user_guidance(self) -> None:
+        guidance = self.work / "guidance.md"
+        guidance.write_text("Only the core protocol.\n")
+        initial = self.run_ci(
+            "--ci-init", "--agent=fake", f"--artifact={self.source}", f"--guidance={guidance}", "footest"
+        )
+        self.assertEqual(initial.returncode, 0, initial.stdout + initial.stderr)
+        self.change_source("update\n")
+        result = self.run_ci("--incremental", "--agent=fake")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        inputs = json.loads((self.latest() / "ci-input.json").read_text())
+        self.assertTrue(Path(inputs["old_source"]).is_dir())
+        self.assertTrue(Path(inputs["old_model"]).is_dir())
+        prompt = Path(str(self.adapter) + ".incremental.prompt").read_text()
+        self.assertIn("Only the core protocol.", prompt)
+        self.assertNotIn("## CI Initialization Guidance", prompt)

--- a/tests/unit/test_ci_store.py
+++ b/tests/unit/test_ci_store.py
@@ -142,3 +142,18 @@ class StoreTests(unittest.TestCase):
                     pipeline.parse_args(["--incremental", f"--ci-dir={self.root / 'not-created'}", *extra]), 1
                 )
         self.assertFalse((self.root / "not-created").exists())
+
+    def test_ci_resume_rejects_missing_invalid_and_symlinked_runs_before_locking(self) -> None:
+        alias = self.root / "runs/alias"
+        alias.symlink_to(self.run_dir, target_is_directory=True)
+        (self.root / "runs/file").write_text("not a run directory")
+        for run_id in ("missing", "", "../first", "alias", "file"):
+            with self.subTest(run_id=run_id), contextlib.redirect_stderr(io.StringIO()):
+                pipeline = CIPipeline()
+                self.assertIsNone(pipeline.parse_args([f"--ci-dir={self.root}", f"--run-id={run_id}"]))
+                assert pipeline.store is not None
+                with mock.patch.object(pipeline.store, "acquire") as acquire:
+                    self.assertEqual(pipeline.resolve_run_dir(acquire_lock=True), 1)
+                acquire.assert_not_called()
+        self.assertFalse((self.root / "runs/missing").exists())
+        self.assertFalse((self.root / ".lock").exists())

--- a/tests/unit/test_ci_store.py
+++ b/tests/unit/test_ci_store.py
@@ -1,0 +1,144 @@
+"""Persistent state is replaced only as a complete, version-bound publication."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from specula.adapters.utils.run_lock import CI_LOCK_FD_ENV, RUN_LOCK_FD_ENV, inherited_run_lock_fds
+from specula.ci_store import CIError, CIStore, asset_hashes, git
+from specula.ci_workflow import CIPipeline
+
+
+class StoreTests(unittest.TestCase):
+    def setUp(self) -> None:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.root = Path(directory.name)
+        self.store = CIStore(self.root)
+        self.run_dir = self.root / "runs/first"
+        self.work = self.run_dir / "project/.specula-output"
+        (self.work / "spec").mkdir(parents=True)
+        (self.work / "harness").mkdir()
+        (self.work / "spec/base.tla").write_text("model\n")
+        (self.work / "harness/run.sh").write_text("#!/bin/sh\n")
+        self.source = self.run_dir / "ci-source"
+        self.source.mkdir()
+        git(self.source, "init", "--quiet")
+        (self.source / "code").write_text("source\n")
+        git(self.source, "add", ".")
+        git(self.source, "commit", "--quiet", "-m", "fixture")
+        commit = git(self.source, "rev-parse", "HEAD")
+        self.inputs = {
+            "previous": None,
+            "target": "project",
+            "artifact": str(self.source),
+            "source": "runs/first/ci-source",
+            "source_commit": commit,
+            "snapshot_commit": commit,
+            "dirty": False,
+            "guidance": "scope",
+        }
+
+    def test_publication_copies_assets_and_binds_source(self) -> None:
+        current = self.store.publish(self.run_dir, self.work, self.inputs)
+        state = self.store.current()
+        self.assertEqual(state["source_commit"], self.inputs["source_commit"])
+        self.assertEqual(state["files_sha256"], asset_hashes(current / "model"))
+        (self.work / "spec/base.tla").write_text("working edit\n")
+        self.assertEqual((current / "model/spec/base.tla").read_text(), "model\n")
+
+    def test_stale_publication_does_not_replace_current(self) -> None:
+        self.store.publish(self.run_dir, self.work, self.inputs)
+        current = self.store.current_token()
+        with self.assertRaisesRegex(CIError, "advanced"):
+            self.store.publish(self.run_dir, self.work, self.inputs)
+        self.assertEqual(self.store.current_token(), current)
+
+    def test_missing_harness_does_not_publish(self) -> None:
+        (self.work / "harness/run.sh").unlink()
+        with self.assertRaisesRegex(CIError, "harness"):
+            self.store.publish(self.run_dir, self.work, self.inputs)
+        self.assertIsNone(self.store.current_token())
+
+    def test_model_diff_excludes_tlc_states_and_execution_logs(self) -> None:
+        self.store.publish(self.run_dir, self.work, self.inputs)
+        next_inputs = {**self.inputs, "previous": self.store.current_token()}
+        (self.work / "spec/base.tla").write_text("changed model\n")
+        (self.work / "spec/states").mkdir()
+        (self.work / "spec/states/intermediate").write_text("never inline this state data")
+        (self.work / "spec/MC.out").write_text("TLC log")
+        self.store.publish(self.run_dir, self.work, next_inputs)
+        diff = (self.run_dir / "model.diff").read_text()
+        self.assertIn("-model\n+changed model", diff)
+        self.assertNotIn("intermediate", diff)
+        self.assertNotIn("TLC log", diff)
+        self.assertFalse((self.root / "current/model/spec/states").exists())
+
+    def test_external_model_symlink_is_not_adopted(self) -> None:
+        outside = self.root / "external.tla"
+        outside.write_text("external")
+        (self.work / "spec/helper.tla").symlink_to(outside)
+        with self.assertRaisesRegex(CIError, "unsupported assets"):
+            self.store.publish(self.run_dir, self.work, self.inputs)
+        self.assertIsNone(self.store.current_token())
+        self.assertEqual(outside.read_text(), "external")
+
+    def test_current_symlink_cannot_escape_store(self) -> None:
+        (self.root / "current").symlink_to("../outside")
+        with self.assertRaises(CIError):
+            self.store.current()
+
+    def test_regular_current_file_is_not_replaced(self) -> None:
+        (self.root / "current").write_text("user file")
+        with self.assertRaises(CIError):
+            self.store.publish(self.run_dir, self.work, self.inputs)
+        self.assertEqual((self.root / "current").read_text(), "user file")
+
+    def test_modified_current_assets_and_source_are_detected(self) -> None:
+        current = self.store.publish(self.run_dir, self.work, self.inputs)
+        (self.source / "code").write_text("unexpected source change")
+        with self.assertRaisesRegex(CIError, "saved source"):
+            self.store.current()
+        (self.source / "code").write_text("source\n")
+        (current / "model/spec/base.tla").write_text("unexpected model change")
+        with self.assertRaisesRegex(CIError, "model assets"):
+            self.store.current()
+
+    def test_ci_lease_is_inherited_with_the_run_lease(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.store.acquire()
+            try:
+                with tempfile.TemporaryFile() as run_lock:
+                    env = {CI_LOCK_FD_ENV: str(self.store.fd), RUN_LOCK_FD_ENV: str(run_lock.fileno())}
+                    self.assertEqual(inherited_run_lock_fds(env), (run_lock.fileno(), self.store.fd))
+                assert self.store.fd is not None
+                child = subprocess.Popen(["sleep", "10"], pass_fds=(self.store.fd,))
+                self.addCleanup(child.wait)
+                self.addCleanup(child.terminate)
+                self.store.close()
+                with self.assertRaises(BlockingIOError):
+                    CIStore(self.root).acquire()
+            finally:
+                self.store.close()
+
+    def test_invalid_mode_flags_fail_before_creating_ci_storage(self) -> None:
+        for extra in (
+            ["--skip-validate"],
+            ["--ci-init"],
+            ["--no-isolate"],
+            ["--enable-reviews"],
+            ["--policy-retries=1"],
+        ):
+            with self.subTest(extra=extra), contextlib.redirect_stderr(io.StringIO()):
+                pipeline = CIPipeline()
+                self.assertEqual(
+                    pipeline.parse_args(["--incremental", f"--ci-dir={self.root / 'not-created'}", *extra]), 1
+                )
+        self.assertFalse((self.root / "not-created").exists())


### PR DESCRIPTION
## Summary

- Add `specula run --incremental --ci-dir=PATH` to run one Agent through the complete incremental-modeling skill.
- Let initialization and updates share a persistent project directory containing one current model and harness.
- Freeze the actual old/new source trees, generate the cumulative source diff before instrumentation, and work in an isolated copy.
- Reuse native conversation resume, process cleanup, run locking, logs, and resource accounting. Failed or incomplete runs leave the current model unchanged; recovery is explicitly requested by the user.
- Publish the model, harness, and source identity together after completion. Preserve per-run reports, model diffs, and usage records.

## Usage

```bash
specula run --ci-init --ci-dir=/work/project-ci \
  --artifact=/work/project "project|owner/repository|language|reference"
specula run --incremental --ci-dir=/work/project-ci
specula run --ci-dir=/work/project-ci --run-id=<run-id>
```

Ordinary agent/model/guidance options remain available. An incremental invocation uses one Agent configuration, not separate per-phase routing. `--revision=SHA` verifies the source checkout's intended commit.

Automatic commit/schedule triggers and user-supplied model/harness initialization are outside this PR. Source isolation uses the existing `--keep-original` implementation and its supported checkout layouts.
