### PR TITLE
Add automatic CI integration and result inheritance

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -210,11 +210,15 @@ Copy the [workflow template](../examples/ci/specula-ci.yml) into your project's
 `SPECULA_EFFORT`. Edit the branch filters to suit your repository. Each
 independently evolving branch needs its own initialized CI directory.
 
-Direct pushes check new mainline commits in order. Same-repository PRs check the
-proposed merged code without changing the branch's current model. When the code
-is merged, matching completed results are inherited without another Agent run.
-Rebased PR commits are inherited as one checked update, not reported as separate
-checks of every intermediate version.
+Each push checks the cumulative diff from the last successful model baseline to
+the pushed version. One check may include several commits; intermediate versions
+are not checked separately. Scheduled checks use the latest branch version.
+Once the model reaches that version, delayed events for earlier commits do not
+repeat the work or move the model backward.
+
+Same-repository PRs check the proposed merged code without changing the branch's
+current model. When the code is merged, matching completed results are inherited
+without another Agent run, including squash and rebase merges.
 Changes to the code, model baseline, or check configuration require a new check.
 External-fork PRs do not run automatically on the runner.
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -197,6 +197,37 @@ specula run --ci-dir=/work/project-ci --run-id=<run-id>
 To start over, rerun the incremental command without `--run-id`. Run checks
 sharing a CI directory one at a time.
 
+### Run automatically with GitHub Actions
+
+Install Specula, the selected agent, and the project's build dependencies under
+the account running a dedicated Linux runner labeled `specula`. Initialize the
+CI directory under that same account so later runs can reuse its files and
+Agent sessions.
+
+Copy the [workflow template](../examples/ci/specula-ci.yml) into your project's
+`.github/workflows/specula-ci.yml`. Set the repository variables
+`SPECULA_CI_DIR` and `SPECULA_MODEL`; optionally set `SPECULA_AGENT` and
+`SPECULA_EFFORT`. Edit the branch filters to suit your repository. Each
+independently evolving branch needs its own initialized CI directory.
+
+Direct pushes check new mainline commits in order. Same-repository PRs check the
+proposed merged code without changing the branch's current model. When the code
+is merged, matching completed results are inherited without another Agent run.
+Rebased PR commits are inherited as one checked update, not reported as separate
+checks of every intermediate version.
+Changes to the code, model baseline, or check configuration require a new check.
+External-fork PRs do not run automatically on the runner.
+
+Manual runs are available in the Actions tab. Uncomment `schedule` to enable
+cron; use `SPECULA_CI_BRANCH` to select a non-default branch for scheduled runs.
+Change `SPECULA_CI_ENVIRONMENT` when updating the runner's toolchain or external
+configuration so older check results are not reused under a different setup.
+
+The Actions summary lists each revision's outcome, with downloadable reports
+and usage summaries. Full working files and conversation state stay in the CI
+directory. Failed checks are reported, not automatically retried; use the
+existing resume command or request an explicit manual rerun.
+
 ## Bring Your Own Model (BYOM)
 
 Use `--byom` when you already have a TLA+ model or other verification assets:

--- a/examples/ci/specula-ci.yml
+++ b/examples/ci/specula-ci.yml
@@ -1,0 +1,84 @@
+name: Specula CI
+
+on:
+  push:
+    branches: [main] # Set the branches you want to watch.
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Target branch (empty uses the configured/default branch)
+        required: false
+        type: string
+      revision:
+        description: Specific commit on that branch (empty checks the latest)
+        required: false
+        type: string
+      force:
+        description: Explicitly rerun an already attempted check
+        type: boolean
+        default: false
+  # Uncomment to enable scheduled checks; cron uses UTC.
+  # schedule:
+  #   - cron: '17 2 * * *'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+# Use the dedicated runner's job queue. Do not add a concurrency group that
+# cancels earlier pending runs. The event adapter also serializes CI storage.
+jobs:
+  check:
+    # pull_request_target uses the base workflow, so a fork cannot remove this
+    # guard. Only same-repository PR code runs on the privileged runner.
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, specula]
+    timeout-minutes: 1440
+    env:
+      CI_DIR: ${{ vars.SPECULA_CI_DIR }}
+      SPECULA_AGENT: ${{ vars.SPECULA_AGENT || 'codex' }}
+      SPECULA_MODEL: ${{ vars.SPECULA_MODEL }}
+      SPECULA_EFFORT: ${{ vars.SPECULA_EFFORT || 'high' }}
+      # Change this when the runner toolchain/configuration changes.
+      SPECULA_CI_ENVIRONMENT: ${{ vars.SPECULA_CI_ENVIRONMENT || '1' }}
+      TARGET_BRANCH: ${{ inputs.branch || vars.SPECULA_CI_BRANCH }}
+      TARGET_REVISION: ${{ inputs.revision }}
+      FORCE_CHECK: ${{ inputs.force }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check the update
+        shell: bash
+        env:
+          REPORTS: ${{ runner.temp }}/specula-${{ github.run_id }}-${{ github.run_attempt }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          : "${CI_DIR:?Set the SPECULA_CI_DIR repository variable}"
+          : "${SPECULA_MODEL:?Set an explicit SPECULA_MODEL repository variable}"
+          args=(--ci-dir="$CI_DIR" --artifact="$GITHUB_WORKSPACE" --reports-dir="$REPORTS"
+                --agent="$SPECULA_AGENT" --model="$SPECULA_MODEL" --effort="$SPECULA_EFFORT")
+          if [[ "$GITHUB_EVENT_NAME" == schedule || "$GITHUB_EVENT_NAME" == workflow_dispatch ]]; then
+            [[ -z "$TARGET_BRANCH" ]] || args+=(--branch="$TARGET_BRANCH")
+          fi
+          [[ -z "$TARGET_REVISION" ]] || args+=(--revision="$TARGET_REVISION")
+          [[ "$FORCE_CHECK" != true ]] || args+=(--force)
+          # Use the trusted Specula installation on the runner, not PR-provided scripts.
+          specula ci "${args[@]}"
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: specula-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/specula-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: warn

--- a/examples/ci/specula-ci.yml
+++ b/examples/ci/specula-ci.yml
@@ -28,7 +28,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 # Use the dedicated runner's job queue. Do not add a concurrency group that
 # cancels earlier pending runs. The event adapter also serializes CI storage.
@@ -61,7 +60,6 @@ jobs:
         shell: bash
         env:
           REPORTS: ${{ runner.temp }}/specula-${{ github.run_id }}-${{ github.run_attempt }}
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           : "${CI_DIR:?Set the SPECULA_CI_DIR repository variable}"

--- a/scripts/launch/launch_github_ci.sh
+++ b/scripts/launch/launch_github_ci.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Trusted GitHub event entrypoint; verification stays in launch_pipeline.sh.
+set -euo pipefail
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/../../src/specula/github_ci.py" "$@"

--- a/src/specula/adapters/utils/run_lock.py
+++ b/src/specula/adapters/utils/run_lock.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping
 
 RUN_LOCK_FD_ENV = "SPECULA_RUN_LOCK_FD"
 CI_LOCK_FD_ENV = "SPECULA_CI_LOCK_FD"
+CI_EVENT_LOCK_FD_ENV = "SPECULA_CI_EVENT_LOCK_FD"
 
 
 class RunLockError(OSError):
@@ -18,7 +19,7 @@ def inherited_run_lock_fds(env: Mapping[str, str] | None = None) -> tuple[int, .
     """Return the validated run-lock lease inherited from the dispatcher."""
     source = os.environ if env is None else env
     descriptors: list[int] = []
-    for key in (RUN_LOCK_FD_ENV, CI_LOCK_FD_ENV):
+    for key in (RUN_LOCK_FD_ENV, CI_LOCK_FD_ENV, CI_EVENT_LOCK_FD_ENV):
         raw = source.get(key)
         if raw is None:
             continue

--- a/src/specula/ci_identity.py
+++ b/src/specula/ci_identity.py
@@ -1,0 +1,49 @@
+"""Content identities used to reuse a completed CI result, not semantic grading."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from specula.ci_workflow import CIPipeline
+
+SPECULA_ROOT = Path(__file__).resolve().parents[2]
+
+
+@lru_cache(maxsize=1)
+def method_digest() -> str:
+    digest = hashlib.sha256()
+    for folder in ("src/specula", "skills", "scripts/launch"):
+        for path in sorted((SPECULA_ROOT / folder).rglob("*")):
+            if path.is_file() and "__pycache__" not in path.parts and path.suffix in {".py", ".md", ".sh", ".yaml"}:
+                digest.update(path.relative_to(SPECULA_ROOT).as_posix().encode())
+                digest.update(b"\0")
+                digest.update(path.read_bytes())
+                digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def check_key(pipeline: CIPipeline, guidance: str) -> str | None:
+    selection = pipeline._agent_selection()
+    model, effort = pipeline._resolved_run_tuning(selection)
+    # Unspecified native model defaults can change outside Specula's control.
+    if not model:
+        return None
+    document = {
+        "method": method_digest(),
+        "agent": selection.agent,
+        "model": model,
+        "effort": effort,
+        "profile": pipeline.claude_alias,
+        "max_turns": pipeline.max_turns,
+        "guidance": guidance,
+        "memory": pipeline.tlc_memory_limit or os.environ.get("SPECULA_TLC_MEMORY_LIMIT") or "auto",
+        "workers": pipeline.tlc_worker_limit or os.environ.get("SPECULA_TLC_WORKER_LIMIT"),
+        "environment": os.environ.get("SPECULA_CI_ENVIRONMENT", ""),
+    }
+    return hashlib.sha256(json.dumps(document, sort_keys=True).encode()).hexdigest()

--- a/src/specula/ci_inheritance.py
+++ b/src/specula/ci_inheritance.py
@@ -1,0 +1,83 @@
+"""Reuse completed PR results when the merged source and check inputs match."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+from pathlib import Path
+from typing import Any
+
+from specula import ci_init
+from specula.ci_store import CIError, CIStore, git, read_json, write_json
+
+
+def result_key(base: str, tree: str, configuration: str) -> str:
+    return hashlib.sha256(json.dumps([base, tree, configuration]).encode()).hexdigest()
+
+
+def register_candidate(store: CIStore, token: str) -> None:
+    candidate = store.snapshot(token)
+    configuration = candidate.get("check_key")
+    if not configuration or candidate.get("dirty") is not False:
+        return
+    directory = ci_init._directory(store.root, ".github-ci/candidates")
+    key = result_key(candidate["previous"], candidate["source_tree"], configuration)
+    write_json(directory / f"{key}.json", {"snapshot": token})
+
+
+def candidate_for(store: CIStore, current: dict[str, Any], tree: str, configuration: str) -> dict[str, Any] | None:
+    key = result_key(current["token"], tree, configuration)
+    path = store.path(f".github-ci/candidates/{key}.json")
+    if not path.exists():
+        return None
+    candidate = store.snapshot(read_json(path)["snapshot"])
+    if (candidate.get("previous"), candidate.get("source_tree"), candidate.get("check_key")) != (
+        current["token"],
+        tree,
+        configuration,
+    ):
+        raise CIError("candidate index does not match its immutable check inputs")
+    source = store.path(candidate["source"])
+    if (
+        candidate.get("dirty") is not False
+        or git(source, "rev-parse", f"{candidate['snapshot_commit']}^{{tree}}") != tree
+    ):
+        return None
+    return candidate
+
+
+def inherit(store: CIStore, source: Path, commit: str, configuration: str | None) -> dict[str, Any] | None:
+    """Caller holds the ordinary CI store lease; no Agent or TLC is launched."""
+    if configuration is None:
+        return None
+    current = store.current()
+    tree = git(source, "rev-parse", f"{commit}^{{tree}}")
+    from_current = current.get("source_tree") == tree and current.get("check_key") == configuration
+    if from_current:
+        candidate = current
+    else:
+        found = candidate_for(store, current, tree, configuration)
+        if found is None:
+            return None
+        candidate = found
+    checked_source = store.path(candidate["source"])
+    if (
+        candidate.get("dirty") is not False
+        or git(checked_source, "rev-parse", f"{candidate['snapshot_commit']}^{{tree}}") != tree
+    ):
+        return None
+    git(source, "merge-base", "--is-ancestor", current["source_commit"], commit)
+    if from_current and current["source_commit"] == commit:
+        return {**current, "reuse_kind": "current"}
+    destination = ci_init._directory(store.root, f"inheritances/{secrets.token_hex(16)}")
+    inputs = {
+        **candidate,
+        "previous": current["token"],
+        "artifact": str(source),
+        "source_commit": commit,
+        "checked_source_commit": candidate.get("checked_source_commit", candidate["source_commit"]),
+        "evidence_run_id": candidate.get("evidence_run_id", candidate["run_id"]),
+    }
+    store.publish(destination, Path(candidate["model_path"]), inputs)
+    return {**store.current(), "reuse_kind": "current" if from_current else "candidate"}

--- a/src/specula/ci_inheritance.py
+++ b/src/specula/ci_inheritance.py
@@ -16,6 +16,16 @@ def result_key(base: str, tree: str, configuration: str) -> str:
     return hashlib.sha256(json.dumps([base, tree, configuration]).encode()).hexdigest()
 
 
+def matches_source(store: CIStore, checked: dict[str, Any], tree: str, configuration: str) -> bool:
+    """Match the frozen, pre-instrumentation source, not just its original HEAD."""
+    return (
+        checked.get("source_tree") == tree
+        and checked.get("check_key") == configuration
+        and checked.get("dirty") is False
+        and git(store.path(checked["source"]), "rev-parse", f"{checked['snapshot_commit']}^{{tree}}") == tree
+    )
+
+
 def register_candidate(store: CIStore, token: str) -> None:
     candidate = store.snapshot(token)
     configuration = candidate.get("check_key")
@@ -38,11 +48,7 @@ def candidate_for(store: CIStore, current: dict[str, Any], tree: str, configurat
         configuration,
     ):
         raise CIError("candidate index does not match its immutable check inputs")
-    source = store.path(candidate["source"])
-    if (
-        candidate.get("dirty") is not False
-        or git(source, "rev-parse", f"{candidate['snapshot_commit']}^{{tree}}") != tree
-    ):
+    if not matches_source(store, candidate, tree, configuration):
         return None
     return candidate
 
@@ -53,7 +59,7 @@ def inherit(store: CIStore, source: Path, commit: str, configuration: str | None
         return None
     current = store.current()
     tree = git(source, "rev-parse", f"{commit}^{{tree}}")
-    from_current = current.get("source_tree") == tree and current.get("check_key") == configuration
+    from_current = matches_source(store, current, tree, configuration)
     if from_current:
         candidate = current
     else:
@@ -61,12 +67,6 @@ def inherit(store: CIStore, source: Path, commit: str, configuration: str | None
         if found is None:
             return None
         candidate = found
-    checked_source = store.path(candidate["source"])
-    if (
-        candidate.get("dirty") is not False
-        or git(checked_source, "rev-parse", f"{candidate['snapshot_commit']}^{{tree}}") != tree
-    ):
-        return None
     git(source, "merge-base", "--is-ancestor", current["source_commit"], commit)
     if from_current and current["source_commit"] == commit:
         return {**current, "reuse_kind": "current"}

--- a/src/specula/ci_store.py
+++ b/src/specula/ci_store.py
@@ -95,10 +95,27 @@ class CIStore:
         self.root = root
         self.fd: int | None = None
 
-    def acquire(self) -> None:
+    def acquire(self, *, allow_inherited: bool = False) -> None:
         self.root.mkdir(parents=True, exist_ok=True)
         if self.root.is_symlink() or not self.root.is_dir():
             raise CIError(f"CI directory is not a real directory: {self.root}")
+        inherited = os.environ.get(CI_LOCK_FD_ENV) if allow_inherited else None
+        if inherited is not None:
+            try:
+                descriptor = int(inherited)
+                info = os.fstat(descriptor)
+                expected = (self.root / ".lock").lstat()
+            except (ValueError, OSError) as exc:
+                raise CIError("inherited CI lease is unavailable") from exc
+            if (
+                not stat.S_ISREG(info.st_mode)
+                or not stat.S_ISREG(expected.st_mode)
+                or (info.st_dev, info.st_ino) != (expected.st_dev, expected.st_ino)
+            ):
+                raise CIError("inherited CI lease belongs to another directory")
+            self.fd = os.dup(descriptor)
+            os.environ[CI_LOCK_FD_ENV] = str(self.fd)
+            return
         fd = os.open(self.root / ".lock", os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
         try:
             if not stat.S_ISREG(os.fstat(fd).st_mode):
@@ -146,6 +163,10 @@ class CIStore:
         token = self.current_token()
         if token is None:
             raise CIError("CI directory has no current model; run --ci-init --ci-dir=PATH first")
+        return self.snapshot(token)
+
+    def snapshot(self, token: str) -> dict[str, Any]:
+        """Load a completed model publication without assuming it is current."""
         directory = self.path(token)
         state = read_json(directory / "state.json")
         if state.get("version") != 1:
@@ -161,7 +182,7 @@ class CIStore:
         state["model_path"] = str(directory / "model")
         return state
 
-    def publish(self, run_dir: Path, work: Path, inputs: dict[str, Any]) -> Path:
+    def publish(self, run_dir: Path, work: Path, inputs: dict[str, Any], *, advance: bool = True) -> Path:
         if self.current_token() != inputs["previous"]:
             raise CIError("current model advanced since this run started; start a new incremental run")
         for required in ("spec/base.tla", "harness/run.sh"):
@@ -205,9 +226,21 @@ class CIStore:
             "run_id": run_dir.name,
             "files_sha256": files,
             "verification": "Agent-reported workflow completion; inspect retained evidence, not a proof of safety.",
+            "previous": inputs["previous"],
+            "check_key": inputs.get("check_key"),
+            "source_tree": inputs.get("source_tree")
+            or git(self.path(inputs["source"]), "rev-parse", f"{inputs['source_commit']}^{{tree}}"),
+            "checked_source_commit": inputs.get("checked_source_commit", inputs["source_commit"]),
+            "evidence_run_id": inputs.get("evidence_run_id", run_dir.name),
         }
         write_json(destination / "state.json", state)
         token = destination.relative_to(self.root).as_posix()
+        if not advance:
+            return destination
+        return self.advance(token)
+
+    def advance(self, token: str) -> Path:
+        self.path(token)
         temporary = self.root / f".current-{secrets.token_hex(8)}"
         temporary.symlink_to(token)
         temporary.replace(self.root / "current")

--- a/src/specula/ci_workflow.py
+++ b/src/specula/ci_workflow.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import contextlib
+import os
+import re
 import shlex
 import stat
 import sys
@@ -10,6 +12,8 @@ from pathlib import Path
 from typing import Any
 
 from specula import ci_init, resumelib
+from specula.ci_identity import check_key
+from specula.ci_inheritance import register_candidate
 from specula.ci_store import CIError, CIStore, freeze_source, git, read_json, write_json
 from specula.pipelinelib import Pipeline, _valid_run_id
 from specula.snapshotlib import load_sources
@@ -23,12 +27,17 @@ class CIPipeline(Pipeline):
         self.revision: str | None = None
         self.store: CIStore | None = None
         self.inputs: dict[str, Any] | None = None
+        self.candidate = False
+        self._candidate_given = False
+        self.receipt: Path | None = None
 
     def parse_args(self, argv: list[str]) -> int | None:
         ordinary: list[str] = []
         for arg in argv:
             if arg == "--incremental":
                 self.incremental = True
+            elif arg == "--ci-candidate":
+                self.candidate = self._candidate_given = True
             elif arg.startswith("--ci-dir="):
                 raw = arg.split("=", 1)[1]
                 if not raw or self.ci_dir is not None:
@@ -52,6 +61,9 @@ class CIPipeline(Pipeline):
         self.argv = list(argv)
         if self.ci_dir is None:
             print("ERROR: --incremental requires --ci-dir=PATH", file=sys.stderr)
+            return 1
+        if self.candidate and (self.ci_init or not (self.incremental or self._run_id_given)):
+            print("ERROR: --ci-candidate requires an incremental run", file=sys.stderr)
             return 1
         if (self.ci_init and self.incremental) or not (self.ci_init or self.incremental or self._run_id_given):
             print("ERROR: choose --ci-init, --incremental, or --run-id with --ci-dir", file=sys.stderr)
@@ -91,6 +103,7 @@ class CIPipeline(Pipeline):
             "ci_directory": str(self.ci_dir),
             "incremental": self.incremental,
             "revision": self.revision,
+            "candidate": self.candidate,
         }
 
     def _restore_resume_configuration(self, raw: dict[str, Any], *, allow_overrides: bool = False) -> None:
@@ -102,6 +115,10 @@ class CIPipeline(Pipeline):
         if self.revision is not None and self.revision != raw.get("revision"):
             raise resumelib.ResumeError("target revision cannot change on resume; start a new run")
         self.incremental = mode
+        candidate = raw.get("candidate", False)
+        if not isinstance(candidate, bool) or (self._candidate_given and not candidate):
+            raise resumelib.ResumeError("candidate publication mode cannot change on resume")
+        self.candidate = candidate
         self.revision = raw.get("revision")
         super()._restore_resume_configuration(raw, allow_overrides=allow_overrides)
         if self.incremental:
@@ -135,7 +152,7 @@ class CIPipeline(Pipeline):
         try:
             # A CI --run-id only resumes: reject typos before creating storage.
             self._require_resume_run()
-            self.store.acquire()
+            self.store.acquire(allow_inherited=os.environ.get("SPECULA_CI_BORROW_LEASE") == "1")
             # Recheck under the project lease before the ordinary resolver,
             # whose non-CI semantics also allow naming a new run.
             self._require_resume_run()
@@ -154,6 +171,14 @@ class CIPipeline(Pipeline):
             rc = super().resolve_run_dir(acquire_lock=acquire_lock)
             if rc is not None:
                 self.store.close()
+            elif not self.dry_run:
+                request = os.environ.get("SPECULA_CI_RECEIPT")
+                if request:
+                    if re.fullmatch(r"[0-9a-f]{32}", request) is None:
+                        raise CIError("invalid CI receipt identity")
+                    directory = ci_init._directory(self.store.root, ".github-ci/receipts")
+                    self.receipt = directory / f"{request}.json"
+                    write_json(self.receipt, {"run_id": self.run_id, "complete": False})
             return rc
         except BlockingIOError:
             print("ERROR: another run is using this CI directory; retry after it finishes", file=sys.stderr)
@@ -274,8 +299,19 @@ class CIPipeline(Pipeline):
         publication = dict(self.inputs)
         if self.incremental and self.guidance_text is not None:
             publication["guidance"] = self.guidance_text
-        current = self.store.publish(self.run_dir, work, publication)
+        publication["check_key"] = check_key(self, publication["guidance"])
+        current = self.store.publish(self.run_dir, work, publication, advance=False)
+        token = current.relative_to(self.store.root).as_posix()
+        result = {"run_id": self.run_id, "complete": True, "candidate": self.candidate, "snapshot": token}
+        write_json(self.run_dir / "ci-result.json", result)
+        if self.receipt is not None:
+            write_json(self.receipt, result)
+        if not self.candidate:
+            current = self.store.advance(token)
+        else:
+            register_candidate(self.store, token)
         if self.resource_summary is not None:
             with contextlib.suppress(OSError, ValueError):
                 self.resource_summary.complete_run([name])
-        return f"Current CI model updated: {current}/model\nResults and usage: {work}/summary.md"
+        label = "CI candidate saved; current model unchanged" if self.candidate else "Current CI model updated"
+        return f"{label}: {current}/model\nResults and usage: {work}/summary.md"

--- a/src/specula/cli.py
+++ b/src/specula/cli.py
@@ -29,6 +29,7 @@ SCRIPTS_DIR = SPECULA_ROOT / "scripts"
 # The order here is the order shown in `specula --help`.
 COMMANDS: list[tuple[str, str, str]] = [
     ("run", "launch/launch_pipeline.sh", "Run the full pipeline (all phases: analysis -> classification)"),
+    ("ci", "launch/launch_github_ci.sh", "Handle a GitHub event using a persistent CI model"),
     ("batch", "exp/scheduler.sh", "Batch-run the pipeline over a task queue (workers, quota gate, retries)"),
     ("analyze", "launch/launch_code_analysis.sh", "Phase 1 - static code analysis -> modeling brief"),
     ("specgen", "launch/launch_spec_generation.sh", "Phase 2 - generate TLA+ specs from the modeling brief"),

--- a/src/specula/github_ci.py
+++ b/src/specula/github_ci.py
@@ -12,7 +12,6 @@ import re
 import secrets
 import shutil
 import stat
-import subprocess
 import sys
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -25,7 +24,7 @@ if __package__ in (None, ""):
 from specula import ci_init
 from specula.adapters.utils.run_lock import CI_EVENT_LOCK_FD_ENV
 from specula.ci_identity import check_key
-from specula.ci_inheritance import candidate_for, inherit, result_key
+from specula.ci_inheritance import candidate_for, inherit, matches_source, result_key
 from specula.ci_store import CIError, CIStore, git, read_json, write_json
 from specula.ci_workflow import CIPipeline
 from specula.pipelinelib import Pipeline, _valid_run_id
@@ -41,45 +40,12 @@ def mapping(value: object) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
-def is_merged_pr(event: Event) -> bool:
-    """Distinguish a rebased PR group from an ordinary multi-commit push."""
-    query = ".[] | {merged_at, merge_commit_sha, branch: .base.ref} | @json"
-    try:
-        result = subprocess.run(
-            [
-                "gh",
-                "api",
-                "--paginate",
-                f"repos/{event.repository}/commits/{event.target}/pulls?per_page=100",
-                "--jq",
-                query,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        raise CIError("could not confirm PR merge identity; no replacement check was started") from exc
-    if result.returncode:
-        raise CIError("could not confirm PR merge identity; check GitHub CLI read access to pull requests")
-    for line in result.stdout.splitlines():
-        item = mapping(json.loads(line))
-        if (
-            item.get("merged_at")
-            and item.get("merge_commit_sha") == event.target
-            and item.get("branch") == event.branch
-        ):
-            return True
-    return False
-
-
 @dataclass(frozen=True)
 class Event:
     repository: str
     branch: str
     kind: str
     target: str
-    before: str | None = None
     pr_number: int | None = None
 
     @classmethod
@@ -100,7 +66,7 @@ class Event:
             number = payload.get("number")
             if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
                 raise CIError("invalid PR number")
-            return cls(repository, branch, "pr", sha(head.get("sha")), payload.get("before"), number)
+            return cls(repository, branch, "pr", sha(head.get("sha")), pr_number=number)
         if name == "merge_group":
             group = mapping(payload.get("merge_group"))
             ref = group.get("base_ref", "")
@@ -119,7 +85,7 @@ class Event:
         if name == "push" and payload.get("deleted"):
             return None
         target = sha(payload.get("after") if name == "push" else environment.get("GITHUB_SHA"))
-        return cls(repository, ref[len("refs/heads/") :], name, target, payload.get("before"))
+        return cls(repository, ref[len("refs/heads/") :], name, target)
 
 
 class GitHubCI:
@@ -223,8 +189,8 @@ class GitHubCI:
         return key
 
     def _attempt_path(self, event: Event, commit: str, configuration: str | None) -> Path:
-        # A failed SHA remains attempted even when later commits advance the
-        # model. Only an explicit manual force request reruns that task.
+        # Do not automatically retry a failed task. Native resume can supply a
+        # completed result; newer targets include its changes cumulatively.
         candidate = event.kind in {"pr", "candidate"}
         source_id = git(self.source, "rev-parse", f"{commit}^{{tree}}") if candidate else commit
         identity = json.dumps(
@@ -276,15 +242,13 @@ class GitHubCI:
         current = self.store.current()
         configuration = self.configuration(current)
         attempt_path = self._attempt_path(event, commit, configuration)
-        if attempt_path.exists() and not force:
-            previous = read_json(attempt_path)
-            self.rows.append({**previous, "status": f"already attempted ({previous['status']})"})
-            return 0 if previous.get("complete") is True else 1
         git(self.source, "checkout", "--quiet", "--detach", commit)
+        # A native resume can publish a result after this event recorded a
+        # failure. Reconcile validated publications before consulting attempts.
         if candidate and not force and configuration is not None:
             tree = git(self.source, "rev-parse", f"{commit}^{{tree}}")
             reused_candidate = candidate_for(self.store, current, tree, configuration)
-            from_current = current.get("source_tree") == tree and current.get("check_key") == configuration
+            from_current = matches_source(self.store, current, tree, configuration)
             if from_current or reused_candidate is not None:
                 evidence = current if from_current else reused_candidate
                 assert evidence is not None
@@ -309,6 +273,10 @@ class GitHubCI:
                 write_json(attempt_path, result)
                 self.rows.append(result)
                 return 0
+        if attempt_path.exists() and not force:
+            previous = read_json(attempt_path)
+            self.rows.append({**previous, "status": f"already attempted ({previous['status']})"})
+            return 0 if previous.get("complete") is True else 1
         result = {"commit": commit, "status": "incomplete", "complete": False}
         write_json(attempt_path, result)
         code, receipt = self._invoke(candidate=candidate)
@@ -361,70 +329,34 @@ class GitHubCI:
                 else:
                     target = event.target
                 return self.check(event, target, candidate=True, force=force)
-            cursor_path = self.directory / "cursor.json"
-            cursor = read_json(cursor_path)["commit"] if cursor_path.exists() else current["source_commit"]
-            with contextlib.suppress(CIError):
-                git(self.source, "merge-base", "--is-ancestor", cursor, current["source_commit"])
-                cursor = current["source_commit"]
+            target = event.target
             if event.kind in {"schedule", "workflow_dispatch"}:
                 target = self._branch_tip(event.branch, event.target)
                 if revision:
                     requested = git(self.source, "rev-parse", "--verify", f"{revision}^{{commit}}")
                     git(self.source, "merge-base", "--is-ancestor", requested, target)
                     target = requested
-                dispatch_code = self.check(event, target, candidate=False, force=force)
-                if dispatch_code == 0:
-                    write_json(cursor_path, {"commit": target})
-                return dispatch_code
-            try:
-                git(self.source, "merge-base", "--is-ancestor", cursor, event.target)
-            except CIError:
-                git(self.source, "merge-base", "--is-ancestor", event.target, cursor)
-                previous = self._attempt_path(event, event.target, self.configuration(current))
-                if previous.exists():
-                    result = read_json(previous)
-                    self.rows.append({**result, "status": f"already attempted ({result['status']})"})
-                    return 0 if result.get("complete") is True else 1
-                self.rows.append(
-                    {
-                        "commit": event.target,
-                        "status": "superseded by a newer branch event; no new check",
-                        "complete": False,
-                    }
-                )
-                return 0
-            commits = git(
-                self.source, "rev-list", "--reverse", "--first-parent", f"{cursor}..{event.target}"
-            ).splitlines()
-            if not commits:
-                return self.check(event, event.target, candidate=False)
-            # A rebased PR can create several mainline SHAs even though its
-            # final merged tree was already checked. Inherit that group before
-            # advancing through intermediate commits invalidates its baseline.
-            if len(commits) > 1 and event.before == cursor:
-                configuration = self.configuration(current)
-                tree = git(self.source, "rev-parse", f"{event.target}^{{tree}}")
-                ready = candidate_for(self.store, current, tree, configuration)
-                if ready is not None and is_merged_pr(event):
-                    inherited = inherit(self.store, self.source, event.target, configuration)
-                    assert inherited is not None
+            if target != current["source_commit"]:
+                try:
+                    git(self.source, "merge-base", "--is-ancestor", current["source_commit"], target)
+                except CIError:
+                    git(self.source, "merge-base", "--is-ancestor", target, current["source_commit"])
+                    if revision or force:
+                        raise CIError(
+                            "requested revision is older than the current model; cannot move it backward"
+                        ) from None
                     self.rows.append(
                         {
-                            "commit": event.target,
-                            "status": "inherited PR result (final merged tree)",
-                            "complete": True,
-                            "run_id": inherited["evidence_run_id"],
-                            "commit_group": commits,
+                            "commit": target,
+                            "status": f"included in cumulative update to {current['source_commit']}; no separate check for this event",
+                            "complete": False,
+                            "run_id": current["evidence_run_id"],
                         }
                     )
-                    write_json(cursor_path, {"commit": event.target})
                     return 0
-            failures = 0
-            for commit in commits:
-                if self.check(event, commit, candidate=False):
-                    failures += 1
-                write_json(cursor_path, {"commit": commit})
-            return 1 if failures else 0
+            # The incremental runner diffs from the last successful snapshot to
+            # this target, including all intervening net changes in one run.
+            return self.check(event, target, candidate=False, force=force)
 
     def report(self, error: str | None = None) -> None:
         self.reports.mkdir(parents=True, exist_ok=False)
@@ -433,10 +365,6 @@ class GitHubCI:
             lines.append(
                 f"| {html.escape(str(row['commit']))} | {html.escape(str(row['status']))} | {html.escape(str(row.get('run_id') or '-'))} |"
             )
-            if row.get("commit_group"):
-                lines.append(
-                    f"\nThis PR's {len(row['commit_group'])} mainline commits were adopted as one checked update; intermediate commits were not separately checked.\n"
-                )
             run_id = row.get("run_id")
             if not isinstance(run_id, str) or not _valid_run_id(run_id):
                 continue
@@ -466,6 +394,7 @@ class GitHubCI:
             lines += ["", f"Error: {html.escape(error)}"]
         lines += [
             "",
+            "Each update checks the cumulative diff to its target, not every intermediate version separately.",
             "Reused/inherited rows launch no additional Agent; their usage summaries belong to the original run.",
             "Reports describe actual coverage; completion is not a proof of safety.",
             "",
@@ -505,7 +434,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.branch and event is not None:
             if args.event_name not in {"schedule", "workflow_dispatch"} and args.branch != event.branch:
                 raise CIError("configured branch does not match the source event")
-            event = Event(event.repository, args.branch, event.kind, event.target, event.before, event.pr_number)
+            event = Event(event.repository, args.branch, event.kind, event.target, pr_number=event.pr_number)
         if args.force and args.event_name != "workflow_dispatch":
             raise CIError("--force is only available for an explicit manual dispatch")
         if args.revision and (args.event_name != "workflow_dispatch" or args.revision.startswith("-")):

--- a/src/specula/github_ci.py
+++ b/src/specula/github_ci.py
@@ -1,0 +1,535 @@
+"""GitHub event adapter for the existing incremental CI workflow."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import html
+import json
+import os
+import re
+import secrets
+import shutil
+import stat
+import subprocess
+import sys
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from specula import ci_init
+from specula.adapters.utils.run_lock import CI_EVENT_LOCK_FD_ENV
+from specula.ci_identity import check_key
+from specula.ci_inheritance import candidate_for, inherit, result_key
+from specula.ci_store import CIError, CIStore, git, read_json, write_json
+from specula.ci_workflow import CIPipeline
+from specula.pipelinelib import Pipeline, _valid_run_id
+
+
+def sha(value: object) -> str:
+    if not isinstance(value, str) or re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", value) is None:
+        raise CIError("event does not identify an exact Git commit")
+    return value
+
+
+def mapping(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def is_merged_pr(event: Event) -> bool:
+    """Distinguish a rebased PR group from an ordinary multi-commit push."""
+    query = ".[] | {merged_at, merge_commit_sha, branch: .base.ref} | @json"
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                "--paginate",
+                f"repos/{event.repository}/commits/{event.target}/pulls?per_page=100",
+                "--jq",
+                query,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise CIError("could not confirm PR merge identity; no replacement check was started") from exc
+    if result.returncode:
+        raise CIError("could not confirm PR merge identity; check GitHub CLI read access to pull requests")
+    for line in result.stdout.splitlines():
+        item = mapping(json.loads(line))
+        if (
+            item.get("merged_at")
+            and item.get("merge_commit_sha") == event.target
+            and item.get("branch") == event.branch
+        ):
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class Event:
+    repository: str
+    branch: str
+    kind: str
+    target: str
+    before: str | None = None
+    pr_number: int | None = None
+
+    @classmethod
+    def parse(cls, name: str, payload: dict[str, Any], environment: dict[str, str]) -> Event | None:
+        repository = mapping(payload.get("repository")).get("full_name")
+        if not isinstance(repository, str) or repository != environment.get("GITHUB_REPOSITORY"):
+            raise CIError("event repository does not match GITHUB_REPOSITORY")
+        if name in {"pull_request", "pull_request_target"}:
+            pr = mapping(payload.get("pull_request"))
+            head = mapping(pr.get("head"))
+            if mapping(head.get("repo")).get("full_name") != repository:
+                return None  # Never acquire a runner-side CI lease for an external fork.
+            if payload.get("action") not in {"opened", "reopened", "synchronize", "ready_for_review"}:
+                return None
+            branch = mapping(pr.get("base")).get("ref")
+            if not isinstance(branch, str):
+                raise CIError("PR event has no target branch")
+            number = payload.get("number")
+            if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
+                raise CIError("invalid PR number")
+            return cls(repository, branch, "pr", sha(head.get("sha")), payload.get("before"), number)
+        if name == "merge_group":
+            group = mapping(payload.get("merge_group"))
+            ref = group.get("base_ref", "")
+            if (
+                payload.get("action") != "checks_requested"
+                or not isinstance(ref, str)
+                or not ref.startswith("refs/heads/")
+            ):
+                raise CIError("unsupported merge-group event")
+            return cls(repository, ref[len("refs/heads/") :], "candidate", sha(group.get("head_sha")))
+        if name not in {"push", "schedule", "workflow_dispatch"}:
+            raise CIError(f"unsupported CI event: {name}")
+        ref = payload.get("ref") if name == "push" else environment.get("GITHUB_REF")
+        if not isinstance(ref, str) or not ref.startswith("refs/heads/"):
+            raise CIError("CI events must select a branch, not a tag or an arbitrary ref")
+        if name == "push" and payload.get("deleted"):
+            return None
+        target = sha(payload.get("after") if name == "push" else environment.get("GITHUB_SHA"))
+        return cls(repository, ref[len("refs/heads/") :], name, target, payload.get("before"))
+
+
+class GitHubCI:
+    def __init__(self, ci_dir: Path, artifact: Path, reports: Path, options: list[str]) -> None:
+        self.store = CIStore(ci_dir.resolve())
+        self.artifact = artifact.resolve()
+        self.reports = reports.resolve()
+        self.options = options
+        self.directory = self.store.root / ".github-ci"
+        self.source = self.directory / "source"
+        self.fd: int | None = None
+        self.rows: list[dict[str, Any]] = []
+
+    def validate_reports(self) -> None:
+        if self.reports == self.reports.parent or self.reports.exists():
+            raise CIError("--reports-dir must name a new report directory")
+        for root in (self.store.root, self.artifact):
+            if self.reports.is_relative_to(root) or root.is_relative_to(self.reports):
+                raise CIError("report exports must be outside CI storage and source checkouts")
+
+    @contextlib.contextmanager
+    def serialized(self) -> Iterator[None]:
+        # Jobs queue on the dedicated runner. This lease also protects shared
+        # storage when more than one runner is configured, without canceling jobs.
+        self.store.current()
+        ci_init._directory(self.store.root, ".github-ci")
+        fd = os.open(self.directory / "lock", os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            os.close(fd)
+            raise CIError("automation lease is not a regular file")
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            self.fd = fd
+            os.environ[CI_EVENT_LOCK_FD_ENV] = str(fd)
+            self.store.acquire()
+            yield
+        finally:
+            self.store.close()
+            self.fd = None
+            os.environ.pop(CI_EVENT_LOCK_FD_ENV, None)
+            os.close(fd)
+
+    def prepare(self, event: Event) -> None:
+        git(self.artifact, "check-ref-format", f"refs/heads/{event.branch}")
+        state_path = self.directory / "branch.json"
+        identity = {"repository": event.repository, "branch": event.branch}
+        if state_path.exists():
+            if read_json(state_path) != identity:
+                raise CIError("this CI directory tracks another repository/branch; configure a separate directory")
+        else:
+            write_json(state_path, identity)
+        if not self.source.exists():
+            git(
+                self.directory,
+                "clone",
+                "--quiet",
+                "--no-local",
+                "--template=",
+                str(self.artifact),
+                str(self.source),
+            )
+        elif self.source.is_symlink():
+            raise CIError("managed source must not be a symlink")
+        if git(self.source, "status", "--porcelain"):
+            raise CIError("managed CI checkout was modified outside the workflow")
+        git(self.source, "fetch", "--quiet", str(self.artifact), event.target)
+        git(
+            self.source,
+            "fetch",
+            "--quiet",
+            str(self.artifact),
+            "+refs/heads/*:refs/remotes/input/heads/*",
+            "+refs/remotes/origin/*:refs/remotes/input/origin/*",
+        )
+        git(self.source, "checkout", "--quiet", "--detach", event.target)
+        ci_init._directory(self.store.root, ".github-ci/attempts")
+
+    @contextlib.contextmanager
+    def prepared(self, event: Event) -> Iterator[None]:
+        with self.serialized():
+            self.prepare(event)
+            try:
+                yield
+            finally:
+                # A PR candidate must not become the default source checkout
+                # used by a later manual branch update.
+                with contextlib.suppress(CIError):
+                    target = self._branch_tip(event.branch, self.store.current()["source_commit"])
+                    git(self.source, "checkout", "--quiet", "--detach", target)
+
+    def configuration(self, current: dict[str, Any]) -> str:
+        pipeline = CIPipeline()
+        if pipeline.parse_args(["--incremental", f"--ci-dir={self.store.root}", *self.options]) is not None:
+            raise CIError("invalid incremental execution options")
+        guidance = pipeline.guidance_text
+        if guidance is None and pipeline.guidance_path is not None:
+            guidance = pipeline.guidance_path.read_text(errors="replace")
+        key = check_key(pipeline, current["guidance"] if guidance is None else guidance)
+        if key is None:
+            raise CIError("automatic CI needs an explicit model (--model or a configured model environment variable)")
+        return key
+
+    def _attempt_path(self, event: Event, commit: str, configuration: str | None) -> Path:
+        # A failed SHA remains attempted even when later commits advance the
+        # model. Only an explicit manual force request reruns that task.
+        candidate = event.kind in {"pr", "candidate"}
+        source_id = git(self.source, "rev-parse", f"{commit}^{{tree}}") if candidate else commit
+        identity = json.dumps(
+            [
+                event.repository,
+                event.branch,
+                candidate,
+                event.pr_number,
+                source_id,
+                self.store.current_token() if candidate else None,
+                configuration,
+            ]
+        )
+        return self.directory / "attempts" / f"{result_key(identity, '', '')}.json"
+
+    def _invoke(self, *, candidate: bool) -> tuple[int, dict[str, Any]]:
+        request = secrets.token_hex(16)
+        previous = os.environ.get("SPECULA_CI_RECEIPT")
+        prior_borrow = os.environ.get("SPECULA_CI_BORROW_LEASE")
+        os.environ["SPECULA_CI_RECEIPT"] = request
+        os.environ["SPECULA_CI_BORROW_LEASE"] = "1"
+        code = 0
+        try:
+            Pipeline()._run_launcher(
+                "launch_pipeline.sh",
+                [
+                    "--incremental",
+                    f"--ci-dir={self.store.root}",
+                    f"--artifact={self.source}",
+                    *(["--ci-candidate"] if candidate else []),
+                    *self.options,
+                ],
+            )
+        except SystemExit as exc:
+            code = exc.code if isinstance(exc.code, int) else 1
+        finally:
+            if prior_borrow is None:
+                os.environ.pop("SPECULA_CI_BORROW_LEASE", None)
+            else:
+                os.environ["SPECULA_CI_BORROW_LEASE"] = prior_borrow
+            if previous is None:
+                os.environ.pop("SPECULA_CI_RECEIPT", None)
+            else:
+                os.environ["SPECULA_CI_RECEIPT"] = previous
+        receipt = self.directory / "receipts" / f"{request}.json"
+        return code, read_json(receipt) if receipt.is_file() else {}
+
+    def check(self, event: Event, commit: str, *, candidate: bool, force: bool = False) -> int:
+        current = self.store.current()
+        configuration = self.configuration(current)
+        attempt_path = self._attempt_path(event, commit, configuration)
+        if attempt_path.exists() and not force:
+            previous = read_json(attempt_path)
+            self.rows.append({**previous, "status": f"already attempted ({previous['status']})"})
+            return 0 if previous.get("complete") is True else 1
+        git(self.source, "checkout", "--quiet", "--detach", commit)
+        if candidate and not force and configuration is not None:
+            tree = git(self.source, "rev-parse", f"{commit}^{{tree}}")
+            reused_candidate = candidate_for(self.store, current, tree, configuration)
+            from_current = current.get("source_tree") == tree and current.get("check_key") == configuration
+            if from_current or reused_candidate is not None:
+                evidence = current if from_current else reused_candidate
+                assert evidence is not None
+                result = {
+                    "commit": commit,
+                    "status": "reused current result" if from_current else "reused candidate result",
+                    "complete": True,
+                    "run_id": evidence.get("evidence_run_id", evidence["run_id"]),
+                }
+                write_json(attempt_path, result)
+                self.rows.append(result)
+                return 0
+        if not candidate and not force:
+            reused = inherit(self.store, self.source, commit, configuration)
+            if reused is not None:
+                result = {
+                    "commit": commit,
+                    "status": "inherited PR result" if reused["reuse_kind"] == "candidate" else "reused current result",
+                    "complete": True,
+                    "run_id": reused["evidence_run_id"],
+                }
+                write_json(attempt_path, result)
+                self.rows.append(result)
+                return 0
+        result = {"commit": commit, "status": "incomplete", "complete": False}
+        write_json(attempt_path, result)
+        code, receipt = self._invoke(candidate=candidate)
+        result.update({"run_id": receipt.get("run_id"), "exit_code": code})
+        if code == 0:
+            if receipt.get("complete") is not True or receipt.get("candidate") is not candidate:
+                raise CIError("incremental command did not return a completed result receipt")
+            snapshot = self.store.snapshot(receipt["snapshot"])
+            if snapshot["source_commit"] != commit or snapshot["check_key"] != configuration:
+                raise CIError("completed result does not match this task's source/configuration")
+            result.update({"status": "candidate checked" if candidate else "checked", "complete": True})
+        else:
+            result["status"] = "failed"
+        write_json(attempt_path, result)
+        self.rows.append(result)
+        if code in {129, 130, 143}:
+            raise CIError("CI execution was interrupted; remaining updates were not started")
+        return code
+
+    def _branch_tip(self, branch: str, fallback: str) -> str:
+        for ref in (f"refs/remotes/input/origin/{branch}", f"refs/remotes/input/heads/{branch}"):
+            try:
+                return git(self.source, "rev-parse", "--verify", f"{ref}^{{commit}}")
+            except CIError:
+                continue
+        return fallback
+
+    def process(self, event: Event, *, force: bool = False, revision: str | None = None) -> int:
+        with self.prepared(event):
+            current = self.store.current()
+            if event.kind in {"pr", "candidate"}:
+                if event.kind == "pr":
+                    base = self._branch_tip(event.branch, current["source_commit"])
+                    git(self.source, "checkout", "--quiet", "--detach", base)
+                    try:
+                        git(
+                            self.source,
+                            "merge",
+                            "--no-ff",
+                            "--no-edit",
+                            "-m",
+                            "Specula CI merge candidate",
+                            event.target,
+                        )
+                    except CIError:
+                        with contextlib.suppress(CIError):
+                            git(self.source, "merge", "--abort")
+                        raise
+                    target = git(self.source, "rev-parse", "HEAD")
+                else:
+                    target = event.target
+                return self.check(event, target, candidate=True, force=force)
+            cursor_path = self.directory / "cursor.json"
+            cursor = read_json(cursor_path)["commit"] if cursor_path.exists() else current["source_commit"]
+            with contextlib.suppress(CIError):
+                git(self.source, "merge-base", "--is-ancestor", cursor, current["source_commit"])
+                cursor = current["source_commit"]
+            if event.kind in {"schedule", "workflow_dispatch"}:
+                target = self._branch_tip(event.branch, event.target)
+                if revision:
+                    requested = git(self.source, "rev-parse", "--verify", f"{revision}^{{commit}}")
+                    git(self.source, "merge-base", "--is-ancestor", requested, target)
+                    target = requested
+                dispatch_code = self.check(event, target, candidate=False, force=force)
+                if dispatch_code == 0:
+                    write_json(cursor_path, {"commit": target})
+                return dispatch_code
+            try:
+                git(self.source, "merge-base", "--is-ancestor", cursor, event.target)
+            except CIError:
+                git(self.source, "merge-base", "--is-ancestor", event.target, cursor)
+                previous = self._attempt_path(event, event.target, self.configuration(current))
+                if previous.exists():
+                    result = read_json(previous)
+                    self.rows.append({**result, "status": f"already attempted ({result['status']})"})
+                    return 0 if result.get("complete") is True else 1
+                self.rows.append(
+                    {
+                        "commit": event.target,
+                        "status": "superseded by a newer branch event; no new check",
+                        "complete": False,
+                    }
+                )
+                return 0
+            commits = git(
+                self.source, "rev-list", "--reverse", "--first-parent", f"{cursor}..{event.target}"
+            ).splitlines()
+            if not commits:
+                return self.check(event, event.target, candidate=False)
+            # A rebased PR can create several mainline SHAs even though its
+            # final merged tree was already checked. Inherit that group before
+            # advancing through intermediate commits invalidates its baseline.
+            if len(commits) > 1 and event.before == cursor:
+                configuration = self.configuration(current)
+                tree = git(self.source, "rev-parse", f"{event.target}^{{tree}}")
+                ready = candidate_for(self.store, current, tree, configuration)
+                if ready is not None and is_merged_pr(event):
+                    inherited = inherit(self.store, self.source, event.target, configuration)
+                    assert inherited is not None
+                    self.rows.append(
+                        {
+                            "commit": event.target,
+                            "status": "inherited PR result (final merged tree)",
+                            "complete": True,
+                            "run_id": inherited["evidence_run_id"],
+                            "commit_group": commits,
+                        }
+                    )
+                    write_json(cursor_path, {"commit": event.target})
+                    return 0
+            failures = 0
+            for commit in commits:
+                if self.check(event, commit, candidate=False):
+                    failures += 1
+                write_json(cursor_path, {"commit": commit})
+            return 1 if failures else 0
+
+    def report(self, error: str | None = None) -> None:
+        self.reports.mkdir(parents=True, exist_ok=False)
+        lines = ["# Specula CI", "", "| Source commit | Result | Specula run |", "|---|---|---|"]
+        for row in self.rows:
+            lines.append(
+                f"| {html.escape(str(row['commit']))} | {html.escape(str(row['status']))} | {html.escape(str(row.get('run_id') or '-'))} |"
+            )
+            if row.get("commit_group"):
+                lines.append(
+                    f"\nThis PR's {len(row['commit_group'])} mainline commits were adopted as one checked update; intermediate commits were not separately checked.\n"
+                )
+            run_id = row.get("run_id")
+            if not isinstance(run_id, str) or not _valid_run_id(run_id):
+                continue
+            run = self.store.path(f"runs/{run_id}")
+            try:
+                target = read_json(run / "ci-input.json")["target"].split("|", 1)[0].strip()
+            except (OSError, ValueError, CIError):
+                continue
+            work = run / target / ".specula-output"
+            destination = self.reports / run_id
+            destination.mkdir(exist_ok=True)
+            for relative in (
+                "ci-report.md",
+                "summary.md",
+                "confirmed-bugs.md",
+                "spec/changelog.md",
+                "spec/bug-report.md",
+            ):
+                if ci_init._regular_file(work, relative):
+                    path = destination / relative
+                    path.parent.mkdir(exist_ok=True)
+                    shutil.copy2(work / relative, path)
+            for filename in ("source.diff", "model.diff"):
+                if ci_init._regular_file(run, filename):
+                    shutil.copy2(run / filename, destination / filename)
+        if error:
+            lines += ["", f"Error: {html.escape(error)}"]
+        lines += [
+            "",
+            "Reused/inherited rows launch no additional Agent; their usage summaries belong to the original run.",
+            "Reports describe actual coverage; completion is not a proof of safety.",
+            "",
+        ]
+        content = "\n".join(lines)
+        (self.reports / "summary.md").write_text(content)
+        summary = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary:
+            with Path(summary).open("a") as stream:
+                stream.write(content)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="specula ci", description="Handle a GitHub event using the incremental CI workflow"
+    )
+    parser.add_argument("--ci-dir", required=True, type=Path)
+    parser.add_argument("--artifact", required=True, type=Path)
+    parser.add_argument("--reports-dir", required=True, type=Path)
+    parser.add_argument("--event-name", default=os.environ.get("GITHUB_EVENT_NAME"))
+    parser.add_argument("--event-path", type=Path, default=os.environ.get("GITHUB_EVENT_PATH"))
+    parser.add_argument("--force", action="store_true", help="Explicitly rerun a manual task")
+    parser.add_argument("--branch", help="Target branch for scheduled or manual checks")
+    parser.add_argument("--revision", help="Specific revision on the branch for a manual dispatch")
+    args, options = parser.parse_known_args(argv)
+    runner = GitHubCI(args.ci_dir, args.artifact, args.reports_dir, options)
+    error: str | None = None
+    code = 1
+    report_safe = False
+    try:
+        runner.validate_reports()
+        report_safe = True
+        if not args.event_name or args.event_path is None:
+            raise CIError("GITHUB_EVENT_NAME and GITHUB_EVENT_PATH are required")
+        payload = read_json(args.event_path)
+        event = Event.parse(args.event_name, payload, dict(os.environ))
+        if args.branch and event is not None:
+            if args.event_name not in {"schedule", "workflow_dispatch"} and args.branch != event.branch:
+                raise CIError("configured branch does not match the source event")
+            event = Event(event.repository, args.branch, event.kind, event.target, event.before, event.pr_number)
+        if args.force and args.event_name != "workflow_dispatch":
+            raise CIError("--force is only available for an explicit manual dispatch")
+        if args.revision and (args.event_name != "workflow_dispatch" or args.revision.startswith("-")):
+            raise CIError("--revision requires a manual dispatch and a valid Git revision")
+        if event is None:
+            print("Event skipped: no authorized source update to execute")
+            runner.rows.append(
+                {"commit": "-", "status": "skipped (external fork or irrelevant event)", "complete": False}
+            )
+            code = 0
+        else:
+            code = runner.process(event, force=args.force, revision=args.revision)
+    except (OSError, ValueError, CIError, ci_init.CIInitError) as exc:
+        error = str(exc)
+        print(f"ERROR: {error}", file=sys.stderr)
+    finally:
+        try:
+            if report_safe:
+                runner.report(error)
+        except (OSError, ValueError, CIError) as exc:
+            print(f"ERROR: could not publish CI report: {exc}", file=sys.stderr)
+            code = 1
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -1510,6 +1510,7 @@ class Phase:
         # hook-capable adapters arm the completion gate. Per-launch env copy,
         # not os.environ: targets differ under --max-parallel.
         env = os.environ.copy()
+        env.pop("SPECULA_CI_BORROW_LEASE", None)
         for key in (RESOURCE_INVOCATION_ENV, RESOURCE_ROOT_ENV, RESOURCE_PHASE_ENV):
             env.pop(key, None)
         env["SPECULA_PHASE"] = self.key
@@ -1734,6 +1735,7 @@ def run_agent_blocking(
         log_file.with_suffix(".usage.json"),
     )
     env = os.environ.copy()
+    env.pop("SPECULA_CI_BORROW_LEASE", None)
     for key in (RESOURCE_INVOCATION_ENV, RESOURCE_ROOT_ENV, RESOURCE_PHASE_ENV):
         env.pop(key, None)
     env["SPECULA_PHASE"] = phase_key if stop_gate else f"{phase_key}_turn"

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -161,6 +161,7 @@ Options:
                          (one target, full pipeline, isolated output; registration is not verification)
   --ci-dir=PATH          Persistent project directory shared by initialization and incremental runs
   --incremental          Run one Agent through the incremental-modeling skill using --ci-dir
+  --ci-candidate         Save an incremental result without updating the branch's current model
   --revision=REF         Verify that the supplied CI source is checked out at this revision
   --keep-original        Work in a full private copy and write a reviewable changes.patch
   --tlc-memory-limit=SIZE
@@ -2972,9 +2973,9 @@ class Pipeline:
         pass_fds: tuple[int, ...] = ()
         if self._run_lock_fd is not None:
             env[resumelib.RUN_LOCK_FD_ENV] = str(self._run_lock_fd)
-            pass_fds = inherited_run_lock_fds(env)
         else:
             env.pop(resumelib.RUN_LOCK_FD_ENV, None)
+        pass_fds = inherited_run_lock_fds(env)
         if self._resource_phase_key is not None and self._resource_invocation_id is not None:
             resource_root = Path(os.path.abspath(self.run_dir if self.run_dir is not None else _logical_cwd()))
             env[RESOURCE_ROOT_ENV] = str(resource_root)

--- a/tests/e2e/test_github_ci.py
+++ b/tests/e2e/test_github_ci.py
@@ -27,12 +27,6 @@ class GitHubEvents(unittest.TestCase):
         self.source = self.fixture.source
         self.fixture.git("branch", "-M", "trunk")
         self.fixture.initialize()
-        self.bin = self.fixture.work / "bin"
-        self.bin.mkdir()
-        self.gh = self.bin / "gh"
-        self.gh.write_text('#!/bin/sh\ncat "$0.response"\n')
-        self.gh.chmod(0o755)
-        Path(str(self.gh) + ".response").write_text("")
 
     def calls(self) -> int:
         return Path(str(self.fixture.adapter) + ".phases").read_text().splitlines().count("incremental")
@@ -60,7 +54,6 @@ class GitHubEvents(unittest.TestCase):
                 "HOME": str(self.fixture.work),
             }
         )
-        environment["PATH"] = str(self.bin) + os.pathsep + environment.get("PATH", "")
         result = subprocess.run(
             [
                 sys.executable,
@@ -137,7 +130,7 @@ class GitHubEvents(unittest.TestCase):
         self.squash()
         pushed, reports = self.push()
         self.assertEqual(pushed.returncode, 0, pushed.stdout + pushed.stderr)
-        self.assertEqual(self.calls(), 3)
+        self.assertEqual(self.calls(), 2)
         self.assertNotIn("inherited PR result", (reports / "summary.md").read_text())
 
     def test_changed_configuration_does_not_reuse_pr_result(self) -> None:
@@ -165,14 +158,11 @@ class GitHubEvents(unittest.TestCase):
         )
         self.fixture.git("update-ref", "refs/heads/trunk", rebased_second)
         self.fixture.git("checkout", "-q", "--detach", rebased_second)
-        Path(str(self.gh) + ".response").write_text(
-            json.dumps({"merged_at": "2026-09-06", "merge_commit_sha": rebased_second, "branch": "trunk"}) + "\n"
-        )
         result, reports = self.event("push", {"ref": "refs/heads/trunk", "before": base, "after": rebased_second})
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertEqual(self.calls(), 1)
         self.assertEqual(CIStore(self.ci).current()["source_commit"], rebased_second)
-        self.assertIn("intermediate commits were not separately checked", (reports / "summary.md").read_text())
+        self.assertIn("inherited PR result", (reports / "summary.md").read_text())
 
     def test_duplicate_pr_event_reuses_the_same_checked_tree(self) -> None:
         self.prepare_pr()
@@ -207,19 +197,133 @@ class GitHubEvents(unittest.TestCase):
         ).stdout.strip()
         self.assertEqual(actual, self.fixture.git("rev-parse", "trunk"))
 
-    def test_push_covers_all_new_mainline_commits_and_old_events_do_not_regress(self) -> None:
+    def test_push_checks_cumulative_diff_and_old_events_do_not_regress(self) -> None:
         self.fixture.change_source("B\n")
         earlier = self.fixture.git("rev-parse", "HEAD")
+        (self.source / "another-module.txt").write_text("C addition\n")
         self.fixture.change_source("C\n")
         latest = self.fixture.git("rev-parse", "HEAD")
         result, _ = self.push()
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertEqual(self.calls(), 2)
+        self.assertEqual(self.calls(), 1)
+        diff = (self.fixture.latest() / "source.diff").read_text()
+        self.assertIn("-initial\n+C", diff)
+        self.assertIn("+C addition", diff)
         for target in (latest, earlier):
-            result, _ = self.push(target)
+            result, reports = self.push(target)
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertEqual(self.calls(), 2)
+        self.assertIn("cumulative update", (reports / "summary.md").read_text())
+        self.assertIn("no separate check for this event", (reports / "summary.md").read_text())
+        self.assertEqual(self.calls(), 1)
         self.assertEqual(CIStore(self.ci).current()["source_commit"], latest)
+        result, _ = self.event("workflow_dispatch", {}, f"--revision={earlier}", "--force")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("cannot move it backward", result.stderr)
+        self.assertEqual(self.calls(), 1)
+        self.assertEqual(CIStore(self.ci).current()["source_commit"], latest)
+
+    def test_schedule_includes_intermediate_changes_before_their_push_event(self) -> None:
+        self.fixture.change_source("B change\n")
+        earlier = self.fixture.git("rev-parse", "HEAD")
+        (self.source / "another-module.txt").write_text("C addition\n")
+        self.fixture.commit("C")
+        latest = self.fixture.git("rev-parse", "HEAD")
+        result, _ = self.event("schedule", {})
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        diff = (self.fixture.latest() / "source.diff").read_text()
+        self.assertIn("-initial\n+B change", diff)
+        self.assertIn("+C addition", diff)
+        result, reports = self.push(earlier)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("cumulative update", (reports / "summary.md").read_text())
+        self.assertEqual(self.calls(), 1)
+        self.assertEqual(CIStore(self.ci).current()["source_commit"], latest)
+
+    def test_clean_pr_cannot_reuse_a_dirty_initialization(self) -> None:
+        self.ci = self.fixture.ci = self.fixture.work / "dirty-ci"
+        (self.source / "logic.txt").write_text("uncommitted initialization\n")
+        result = self.fixture.run_ci(
+            "--ci-init",
+            "--agent=fake",
+            "--model=fixture-model",
+            "--effort=high",
+            f"--artifact={self.source}",
+            "footest",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(CIStore(self.ci).current()["dirty"])
+        (self.source / "logic.txt").write_text("initial\n")
+        self.fixture.git("checkout", "-qb", "feature")
+        self.fixture.git("commit", "--allow-empty", "-qm", "same committed tree")
+        self.fixture.git("checkout", "-q", "trunk")
+        result, reports = self.open_pr()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(self.calls(), 1)
+        self.assertNotIn("reused current result", (reports / "summary.md").read_text())
+        self.assertIn("-uncommitted initialization\n+initial", (self.fixture.latest() / "source.diff").read_text())
+        result, reports = self.open_pr()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("reused candidate result", (reports / "summary.md").read_text())
+        self.assertEqual(self.calls(), 1)
+
+    def check_manual_resume(self, *, candidate: bool) -> None:
+        if candidate:
+            self.prepare_pr()
+        else:
+            self.fixture.change_source("B\n")
+        event = self.open_pr if candidate else self.push
+        original = (self.ci / "current").resolve()
+        fail = Path(str(self.fixture.adapter) + ".fail")
+        fail.touch()
+        result, _ = event()
+        self.assertNotEqual(result.returncode, 0)
+        run = self.fixture.latest()
+        self.assertEqual((self.ci / "current").resolve(), original)
+        fail.unlink()
+        result = self.fixture.run_ci(f"--run-id={run.name}")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        resumed = (self.ci / "current").resolve()
+        self.assertEqual(resumed == original, candidate)
+        result, reports = event()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(self.calls(), 2)  # Failed call + native resume; event adds no Agent call.
+        self.assertEqual((self.ci / "current").resolve(), resumed)
+        self.assertIn("reused", (reports / "summary.md").read_text())
+        attempts = list((self.ci / ".github-ci/attempts").glob("*.json"))
+        self.assertEqual(len(attempts), 1)
+        attempt = json.loads(attempts[0].read_text())
+        self.assertTrue(attempt["complete"])
+        self.assertEqual(attempt["run_id"], run.name)
+
+    def test_branch_manual_resume_reconciles_failed_attempt(self) -> None:
+        self.check_manual_resume(candidate=False)
+
+    def test_pr_manual_resume_reconciles_failed_attempt(self) -> None:
+        self.check_manual_resume(candidate=True)
+
+    def test_failed_update_is_included_in_the_next_successful_cumulative_diff(self) -> None:
+        self.fixture.change_source("B change\n")
+        earlier = self.fixture.git("rev-parse", "HEAD")
+        original = (self.ci / "current").resolve()
+        fail = Path(str(self.fixture.adapter) + ".fail")
+        fail.touch()
+        result, _ = self.push()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual((self.ci / "current").resolve(), original)
+        fail.unlink()
+        (self.source / "another-module.txt").write_text("C addition\n")
+        self.fixture.commit("C")
+        result, _ = self.push()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        diff = (self.fixture.latest() / "source.diff").read_text()
+        self.assertIn("-initial\n+B change", diff)
+        self.assertIn("+C addition", diff)
+        latest = (self.ci / "current").resolve()
+        result, reports = self.push(earlier)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("no separate check for this event", (reports / "summary.md").read_text())
+        self.assertEqual((self.ci / "current").resolve(), latest)
+        self.assertEqual(self.calls(), 2)
 
     def test_failure_is_not_retried_by_schedule_but_manual_force_can_rerun(self) -> None:
         self.fixture.change_source("B\n")
@@ -229,6 +333,10 @@ class GitHubEvents(unittest.TestCase):
         result, _ = self.push()
         self.assertNotEqual(result.returncode, 0)
         self.assertEqual((self.ci / "current").resolve(), previous)
+        # A stray completion file is not a successfully published result.
+        (self.fixture.latest() / "ci-result.json").write_text(
+            json.dumps({"complete": True, "candidate": False, "snapshot": previous.relative_to(self.ci).as_posix()})
+        )
         fail.unlink()
         for name, payload in (
             ("push", {"ref": "refs/heads/trunk", "after": self.fixture.git("rev-parse", "HEAD")}),

--- a/tests/e2e/test_github_ci.py
+++ b/tests/e2e/test_github_ci.py
@@ -1,0 +1,275 @@
+"""Real event-to-CLI wiring with fixture Agent calls; no LLM or TLC execution."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+
+import test_cli_pipeline as base_fixtures
+import test_incremental_ci as incremental_fixtures
+
+from specula.ci_store import CIStore
+
+
+class GitHubEvents(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = incremental_fixtures.IncrementalCLI()
+        self.fixture.setUp()
+        self.addCleanup(self.fixture.helper.doCleanups)
+        self.root = self.fixture.root
+        self.ci = self.fixture.ci
+        self.source = self.fixture.source
+        self.fixture.git("branch", "-M", "trunk")
+        self.fixture.initialize()
+        self.bin = self.fixture.work / "bin"
+        self.bin.mkdir()
+        self.gh = self.bin / "gh"
+        self.gh.write_text('#!/bin/sh\ncat "$0.response"\n')
+        self.gh.chmod(0o755)
+        Path(str(self.gh) + ".response").write_text("")
+
+    def calls(self) -> int:
+        return Path(str(self.fixture.adapter) + ".phases").read_text().splitlines().count("incremental")
+
+    def event(
+        self, name: str, payload: dict[str, Any], *options: str, model: str = "fixture-model"
+    ) -> tuple[subprocess.CompletedProcess[str], Path]:
+        request = self.fixture.work / f"event-{secrets.token_hex(4)}.json"
+        request.write_text(json.dumps({"repository": {"full_name": "example/project"}, **payload}))
+        reports = self.fixture.work / f"reports-{secrets.token_hex(4)}"
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in base_fixtures._VOLATILE
+            and key
+            not in {"SPECULA_CI_RECEIPT", "SPECULA_CI_BORROW_LEASE", "SPECULA_CI_EVENT_LOCK_FD", "SPECULA_CI_LOCK_FD"}
+        }
+        environment.update(
+            {
+                "GITHUB_REPOSITORY": "example/project",
+                "GITHUB_EVENT_NAME": name,
+                "GITHUB_EVENT_PATH": str(request),
+                "GITHUB_REF": "refs/heads/trunk",
+                "GITHUB_SHA": self.fixture.git("rev-parse", "HEAD"),
+                "HOME": str(self.fixture.work),
+            }
+        )
+        environment["PATH"] = str(self.bin) + os.pathsep + environment.get("PATH", "")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(self.root / "src/specula/cli.py"),
+                "ci",
+                f"--ci-dir={self.ci}",
+                f"--artifact={self.source}",
+                f"--reports-dir={reports}",
+                "--agent=fake",
+                f"--model={model}",
+                "--effort=high",
+                *options,
+            ],
+            env=environment,
+            cwd=self.fixture.work,
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+        return result, reports
+
+    def push(self, target: str | None = None, **kwargs: Any) -> tuple[subprocess.CompletedProcess[str], Path]:
+        return self.event(
+            "push", {"ref": "refs/heads/trunk", "after": target or self.fixture.git("rev-parse", "HEAD")}, **kwargs
+        )
+
+    def open_pr(self, **kwargs: Any) -> tuple[subprocess.CompletedProcess[str], Path]:
+        head = self.fixture.git("rev-parse", "feature")
+        return self.event(
+            "pull_request_target",
+            {
+                "number": 7,
+                "action": "synchronize",
+                "pull_request": {
+                    "head": {"sha": head, "repo": {"full_name": "example/project"}},
+                    "base": {"ref": "trunk", "sha": self.fixture.git("rev-parse", "trunk")},
+                },
+            },
+            **kwargs,
+        )
+
+    def prepare_pr(self) -> None:
+        self.fixture.git("checkout", "-qb", "feature")
+        self.fixture.change_source("PR change\n")
+        self.fixture.git("checkout", "-q", "trunk")
+
+    def squash(self) -> str:
+        self.fixture.git("merge", "--squash", "feature")
+        self.fixture.git("commit", "-qm", "Squashed feature")
+        return self.fixture.git("rev-parse", "HEAD")
+
+    def test_pr_result_is_inherited_after_squash_without_another_agent(self) -> None:
+        self.prepare_pr()
+        previous = (self.ci / "current").resolve()
+        checked, _ = self.open_pr()
+        self.assertEqual(checked.returncode, 0, checked.stdout + checked.stderr)
+        self.assertEqual(self.calls(), 1)
+        self.assertEqual((self.ci / "current").resolve(), previous)
+        merged = self.squash()
+        pushed, reports = self.push()
+        self.assertEqual(pushed.returncode, 0, pushed.stdout + pushed.stderr)
+        self.assertEqual(self.calls(), 1)
+        self.assertEqual(CIStore(self.ci).current()["source_commit"], merged)
+        self.assertIn("inherited PR result", (reports / "summary.md").read_text())
+        self.assertTrue(list(reports.glob("*/summary.md")))
+        self.assertFalse(list(reports.rglob("*.resume.json")))
+
+    def test_changed_merge_content_requires_new_checks(self) -> None:
+        self.prepare_pr()
+        checked, _ = self.open_pr()
+        self.assertEqual(checked.returncode, 0, checked.stdout + checked.stderr)
+        (self.source / "another-module.txt").write_text("new context\n")
+        self.fixture.commit("other mainline update")
+        self.squash()
+        pushed, reports = self.push()
+        self.assertEqual(pushed.returncode, 0, pushed.stdout + pushed.stderr)
+        self.assertEqual(self.calls(), 3)
+        self.assertNotIn("inherited PR result", (reports / "summary.md").read_text())
+
+    def test_changed_configuration_does_not_reuse_pr_result(self) -> None:
+        self.prepare_pr()
+        checked, _ = self.open_pr()
+        self.assertEqual(checked.returncode, 0, checked.stdout + checked.stderr)
+        self.squash()
+        pushed, _ = self.push(model="different-model")
+        self.assertEqual(pushed.returncode, 0, pushed.stdout + pushed.stderr)
+        self.assertEqual(self.calls(), 2)
+
+    def test_multi_commit_rebase_merge_inherits_the_final_pr_model(self) -> None:
+        base = self.fixture.git("rev-parse", "trunk")
+        self.fixture.git("checkout", "-qb", "feature")
+        self.fixture.change_source("first PR commit\n")
+        first = self.fixture.git("rev-parse", "HEAD")
+        self.fixture.change_source("second PR commit\n")
+        second = self.fixture.git("rev-parse", "HEAD")
+        self.fixture.git("checkout", "-q", "trunk")
+        result, _ = self.open_pr()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        rebased_first = self.fixture.git("commit-tree", f"{first}^{{tree}}", "-p", base, "-m", "rebased first")
+        rebased_second = self.fixture.git(
+            "commit-tree", f"{second}^{{tree}}", "-p", rebased_first, "-m", "rebased second"
+        )
+        self.fixture.git("update-ref", "refs/heads/trunk", rebased_second)
+        self.fixture.git("checkout", "-q", "--detach", rebased_second)
+        Path(str(self.gh) + ".response").write_text(
+            json.dumps({"merged_at": "2026-09-06", "merge_commit_sha": rebased_second, "branch": "trunk"}) + "\n"
+        )
+        result, reports = self.event("push", {"ref": "refs/heads/trunk", "before": base, "after": rebased_second})
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(self.calls(), 1)
+        self.assertEqual(CIStore(self.ci).current()["source_commit"], rebased_second)
+        self.assertIn("intermediate commits were not separately checked", (reports / "summary.md").read_text())
+
+    def test_duplicate_pr_event_reuses_the_same_checked_tree(self) -> None:
+        self.prepare_pr()
+        for _ in range(2):
+            result, _ = self.open_pr()
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(self.calls(), 1)
+
+    def test_merge_queue_reuses_a_matching_pr_candidate(self) -> None:
+        self.prepare_pr()
+        result, _ = self.open_pr()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        base = self.fixture.git("rev-parse", "trunk")
+        head = self.fixture.git("rev-parse", "feature")
+        group = self.fixture.git("commit-tree", f"{head}^{{tree}}", "-p", base, "-p", head, "-m", "merge group")
+        self.fixture.git("update-ref", "refs/heads/queue", group)
+        result, reports = self.event(
+            "merge_group",
+            {"action": "checks_requested", "merge_group": {"base_ref": "refs/heads/trunk", "head_sha": group}},
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(self.calls(), 1)
+        self.assertIn("reused candidate result", (reports / "summary.md").read_text())
+
+    def test_pr_check_restores_the_canonical_branch_checkout(self) -> None:
+        self.prepare_pr()
+        result, _ = self.open_pr()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        source = self.ci / ".github-ci/source"
+        actual = subprocess.run(
+            ["git", "-C", str(source), "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+        ).stdout.strip()
+        self.assertEqual(actual, self.fixture.git("rev-parse", "trunk"))
+
+    def test_push_covers_all_new_mainline_commits_and_old_events_do_not_regress(self) -> None:
+        self.fixture.change_source("B\n")
+        earlier = self.fixture.git("rev-parse", "HEAD")
+        self.fixture.change_source("C\n")
+        latest = self.fixture.git("rev-parse", "HEAD")
+        result, _ = self.push()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(self.calls(), 2)
+        for target in (latest, earlier):
+            result, _ = self.push(target)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(self.calls(), 2)
+        self.assertEqual(CIStore(self.ci).current()["source_commit"], latest)
+
+    def test_failure_is_not_retried_by_schedule_but_manual_force_can_rerun(self) -> None:
+        self.fixture.change_source("B\n")
+        previous = (self.ci / "current").resolve()
+        fail = Path(str(self.fixture.adapter) + ".fail")
+        fail.touch()
+        result, _ = self.push()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual((self.ci / "current").resolve(), previous)
+        fail.unlink()
+        for name, payload in (
+            ("push", {"ref": "refs/heads/trunk", "after": self.fixture.git("rev-parse", "HEAD")}),
+            ("schedule", {}),
+        ):
+            result, _ = self.event(name, payload)
+            self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.calls(), 1)
+        result, _ = self.event("workflow_dispatch", {}, "--force")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(self.calls(), 2)
+
+    def test_external_fork_is_skipped_without_running_or_changing_ci_state(self) -> None:
+        before = set(self.ci.iterdir())
+        result, reports = self.event(
+            "pull_request_target",
+            {
+                "number": 9,
+                "action": "opened",
+                "pull_request": {
+                    "head": {"sha": "a" * 40, "repo": {"full_name": "external/project"}},
+                    "base": {"ref": "trunk"},
+                },
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(self.calls(), 0)
+        self.assertEqual(set(self.ci.iterdir()), before)
+        self.assertTrue((reports / "summary.md").is_file())
+
+    def test_schedule_and_manual_dispatch_reuse_completed_current_result(self) -> None:
+        self.fixture.change_source("B\n")
+        for name in ("schedule", "workflow_dispatch", "schedule"):
+            result, _ = self.event(name, {})
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(self.calls(), 1)
+
+    def test_manual_revision_selects_a_specific_new_commit(self) -> None:
+        self.fixture.change_source("B\n")
+        selected = self.fixture.git("rev-parse", "HEAD")
+        self.fixture.change_source("C\n")
+        result, _ = self.event("workflow_dispatch", {}, f"--revision={selected}")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(CIStore(self.ci).current()["source_commit"], selected)

--- a/tests/e2e/test_incremental_ci.py
+++ b/tests/e2e/test_incremental_ci.py
@@ -125,6 +125,24 @@ class IncrementalCLI(unittest.TestCase):
         self.assertEqual(usage["phases"]["incremental"]["total_tokens"], 150)
         self.assertTrue(usage["phases"]["incremental"]["usage_incomplete"])
 
+    def test_candidate_resume_cannot_update_the_current_model(self) -> None:
+        self.initialize()
+        previous = (self.ci / "current").resolve()
+        self.change_source("candidate source\n")
+        flag = Path(str(self.adapter) + ".fail")
+        flag.touch()
+        first = self.run_ci("--incremental", "--ci-candidate", "--agent=fake", "--model=fixture-model")
+        self.assertEqual(first.returncode, 9, first.stdout + first.stderr)
+        run = self.latest()
+        flag.unlink()
+        result = self.run_ci(f"--run-id={run.name}")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual((self.ci / "current").resolve(), previous)
+        receipt = json.loads((run / "ci-result.json").read_text())
+        self.assertTrue(receipt["candidate"])
+        self.assertTrue(receipt["complete"])
+        self.assertTrue((self.ci / receipt["snapshot"] / "model/spec/base.tla").is_file())
+
     def test_no_model_change_still_advances_source_version(self) -> None:
         self.initialize()
         original = (self.ci / "current/model/spec/base.tla").read_bytes()

--- a/tests/unit/test_ci_inheritance.py
+++ b/tests/unit/test_ci_inheritance.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import test_ci_store as fixtures
 
-from specula.ci_inheritance import inherit, register_candidate
+from specula.ci_inheritance import inherit, matches_source, register_candidate
 from specula.ci_store import CIError, git
 from specula.github_ci import Event, GitHubCI
 
@@ -70,6 +70,16 @@ class InheritanceTests(unittest.TestCase):
         self.assertIsNone(inherit(self.store, self.merged, self.merge_commit, "b" * 64))
         self.assertIsNone(inherit(self.store, self.merged, self.merge_commit, None))
         self.assertEqual(self.store.current_token(), self.initial)
+
+    def test_reuse_requires_both_clean_identity_and_matching_frozen_source(self) -> None:
+        candidate = self.store.snapshot(self.token)
+        tree = candidate["source_tree"]
+        self.assertTrue(matches_source(self.store, candidate, tree, "a" * 64))
+        self.assertFalse(matches_source(self.store, {**candidate, "dirty": True}, tree, "a" * 64))
+        self.assertFalse(matches_source(self.store, candidate, tree, "b" * 64))
+        original = self.store.current()
+        claimed = {**original, "source_tree": tree, "check_key": "a" * 64}
+        self.assertFalse(matches_source(self.store, claimed, tree, "a" * 64))
 
     def test_advanced_model_baseline_cannot_be_overwritten_by_old_candidate(self) -> None:
         self.store.publish(self.fixture.run_dir, self.fixture.work, {**self.fixture.inputs, "previous": self.initial})

--- a/tests/unit/test_ci_inheritance.py
+++ b/tests/unit/test_ci_inheritance.py
@@ -1,0 +1,140 @@
+"""Candidate inheritance and event safety without invoking an Agent."""
+
+from __future__ import annotations
+
+import shutil
+import unittest
+from pathlib import Path
+
+import test_ci_store as fixtures
+
+from specula.ci_inheritance import inherit, register_candidate
+from specula.ci_store import CIError, git
+from specula.github_ci import Event, GitHubCI
+
+
+class InheritanceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = fixtures.StoreTests()
+        self.fixture.setUp()
+        self.addCleanup(self.fixture.doCleanups)
+        self.store = self.fixture.store
+        self.store.publish(self.fixture.run_dir, self.fixture.work, self.fixture.inputs)
+        self.initial = self.store.current_token()
+        self.candidate_run = self.fixture.root / "runs/candidate"
+        self.candidate_work = self.candidate_run / "project/.specula-output"
+        self.candidate_source = self.candidate_run / "ci-source"
+        shutil.copytree(self.fixture.work, self.candidate_work)
+        shutil.copytree(self.fixture.source, self.candidate_source)
+        (self.candidate_source / "code").write_text("updated source\n")
+        git(self.candidate_source, "add", ".")
+        git(self.candidate_source, "commit", "--quiet", "-m", "candidate")
+        candidate_commit = git(self.candidate_source, "rev-parse", "HEAD")
+        self.inputs = {
+            **self.fixture.inputs,
+            "previous": self.initial,
+            "source": "runs/candidate/ci-source",
+            "source_commit": candidate_commit,
+            "snapshot_commit": candidate_commit,
+            "check_key": "a" * 64,
+        }
+        candidate = self.store.publish(self.candidate_run, self.candidate_work, self.inputs, advance=False)
+        self.token = candidate.relative_to(self.fixture.root).as_posix()
+        register_candidate(self.store, self.token)
+        self.merged = self.fixture.root / "merged"
+        shutil.copytree(self.candidate_source, self.merged)
+        original_commit = self.fixture.inputs["source_commit"]
+        assert isinstance(original_commit, str)
+        self.merge_commit = git(
+            self.merged,
+            "commit-tree",
+            f"{candidate_commit}^{{tree}}",
+            "-p",
+            original_commit,
+            "-m",
+            "squash result",
+        )
+        git(self.merged, "checkout", "--quiet", "--detach", self.merge_commit)
+
+    def test_candidate_is_read_only_until_matching_merge(self) -> None:
+        self.assertEqual(self.store.current_token(), self.initial)
+        self.assertNotEqual(self.merge_commit, self.inputs["source_commit"])
+        inherited = inherit(self.store, self.merged, self.merge_commit, "a" * 64)
+        assert inherited is not None
+        self.assertEqual(inherited["source_commit"], self.merge_commit)
+        self.assertEqual(inherited["checked_source_commit"], self.inputs["source_commit"])
+        self.assertEqual(inherited["evidence_run_id"], "candidate")
+        self.assertNotEqual(self.store.current_token(), self.initial)
+
+    def test_different_configuration_cannot_inherit(self) -> None:
+        self.assertIsNone(inherit(self.store, self.merged, self.merge_commit, "b" * 64))
+        self.assertIsNone(inherit(self.store, self.merged, self.merge_commit, None))
+        self.assertEqual(self.store.current_token(), self.initial)
+
+    def test_advanced_model_baseline_cannot_be_overwritten_by_old_candidate(self) -> None:
+        self.store.publish(self.fixture.run_dir, self.fixture.work, {**self.fixture.inputs, "previous": self.initial})
+        advanced = self.store.current_token()
+        self.assertIsNone(inherit(self.store, self.merged, self.merge_commit, "a" * 64))
+        self.assertEqual(self.store.current_token(), advanced)
+
+    def test_changed_merged_tree_cannot_inherit(self) -> None:
+        (self.merged / "new-module").write_text("untested interaction")
+        git(self.merged, "add", ".")
+        git(self.merged, "commit", "--quiet", "-m", "changed merge")
+        commit = git(self.merged, "rev-parse", "HEAD")
+        self.assertIsNone(inherit(self.store, self.merged, commit, "a" * 64))
+        self.assertEqual(self.store.current_token(), self.initial)
+
+    def test_modified_candidate_assets_are_rejected(self) -> None:
+        (self.fixture.root / self.token / "model/spec/base.tla").write_text("unverified modification")
+        with self.assertRaises(CIError):
+            inherit(self.store, self.merged, self.merge_commit, "a" * 64)
+        self.assertEqual(self.store.current_token(), self.initial)
+
+    def test_repeated_inheritance_does_not_replace_current_again(self) -> None:
+        inherit(self.store, self.merged, self.merge_commit, "a" * 64)
+        published = self.store.current_token()
+        reused = inherit(self.store, self.merged, self.merge_commit, "a" * 64)
+        assert reused is not None
+        self.assertEqual(reused["reuse_kind"], "current")
+        self.assertEqual(self.store.current_token(), published)
+
+
+class EventTests(unittest.TestCase):
+    def test_configured_branch_is_not_hardcoded_to_main(self) -> None:
+        event = Event.parse(
+            "push",
+            {"repository": {"full_name": "owner/repo"}, "ref": "refs/heads/release/v2", "after": "a" * 40},
+            {"GITHUB_REPOSITORY": "owner/repo"},
+        )
+        assert event is not None
+        self.assertEqual(event.branch, "release/v2")
+
+    def test_cross_repository_events_are_rejected(self) -> None:
+        with self.assertRaises(CIError):
+            Event.parse("push", {"repository": {"full_name": "elsewhere/repo"}}, {"GITHUB_REPOSITORY": "owner/repo"})
+
+    def test_deleted_pr_heads_and_external_forks_are_not_executed(self) -> None:
+        for head in ({"repo": None}, {"repo": {"full_name": "fork/repo"}}):
+            with self.subTest(head=head):
+                self.assertIsNone(
+                    Event.parse(
+                        "pull_request_target",
+                        {"repository": {"full_name": "owner/repo"}, "pull_request": {"head": head}},
+                        {"GITHUB_REPOSITORY": "owner/repo"},
+                    )
+                )
+
+    def test_tag_push_and_malformed_sha_are_rejected(self) -> None:
+        for ref, revision in (("refs/tags/v1", "a" * 40), ("refs/heads/trunk", "--config=bad")):
+            with self.subTest(ref=ref), self.assertRaises(CIError):
+                Event.parse(
+                    "push",
+                    {"repository": {"full_name": "owner/repo"}, "ref": ref, "after": revision},
+                    {"GITHUB_REPOSITORY": "owner/repo"},
+                )
+
+    def test_report_export_cannot_overwrite_ci_storage(self) -> None:
+        runner = GitHubCI(Path("/tmp/project-ci"), Path("/tmp/project-code"), Path("/tmp/project-ci/current"), [])
+        with self.assertRaises(CIError):
+            runner.validate_reports()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -22,7 +22,7 @@ from specula import cli
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# captured from the bash dispatcher (git history: `specula` pre-cutover)
+# Public help retains the dispatcher layout as commands are added.
 BASH_HELP = """\
 usage: specula <command> [options] "name|github|lang|reference" [...]
 
@@ -30,6 +30,7 @@ A framework for finding deep bugs in system code using TLA+.
 
 commands:
   run       Run the full pipeline (all phases: analysis -> classification)
+  ci        Handle a GitHub event using a persistent CI model
   batch     Batch-run the pipeline over a task queue (workers, quota gate, retries)
   analyze   Phase 1 - static code analysis -> modeling brief
   specgen   Phase 2 - generate TLA+ specs from the modeling brief


### PR DESCRIPTION
## Summary

- Add a configurable GitHub Actions template for pushes, same-repository PRs, merge queues, manual runs, and optional schedules.
- Add `specula ci` as an event adapter around the existing incremental workflow. Serialize shared state, retain individual outcomes, and leave failed tasks for explicit recovery.
- Save PR results as candidates. Reuse a completed result at merge when the frozen source snapshot, model baseline, and check configuration match, including rewritten commit SHAs. Native resume results take precedence over stale failed attempts.
- Export job summaries and report bundles without exporting source checkouts, credentials, or native conversation files.

PR checks cover the final proposed merged tree. Push and scheduled checks process the cumulative diff from the last successful model baseline to their target, potentially including several commits in one run. Matching PR results can be inherited after merge. Intermediate versions are not separately verified within a cumulative check, and delayed earlier events never move the model backward.

## Setup

Initialize a persistent CI directory, configure a dedicated Linux runner, and copy `examples/ci/specula-ci.yml` into the target repository. Set `SPECULA_CI_DIR` and an explicit `SPECULA_MODEL`, then choose branch filters and optional scheduling in the workflow. The template uses a trusted Specula installation and excludes external-fork PRs before runner assignment.

## Validation

- Full Python suite: 1391 passed, 647 subtests passed.
- Strict mypy, pinned Ruff check/format, shell syntax, and Actionlint validation pass.
- Event-to-CLI tests cover inheritance without another Agent call, dirty-source rejection, changed merge inputs, duplicate events, cumulative push/schedule diffs, failed-update recovery, branch/candidate native resume, manual force, and external-fork exclusion.

Tests use deterministic adapters; no live LLM/TLC project run or customer-runner deployment was performed. Completion remains the existing workflow's reported outcome, not independent semantic grading. User-supplied model/harness initialization remains outside this PR.
