### PR TITLE
Support BYOM for CI initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Added `specula run --byom=PATH` for continuing Phase 2 onward from user-provided model, instrumentation, harness, or trace artifacts, with a final modification report for each target.
+- Added BYOM support to CI initialization, reusing supplied verification assets through the standard workflow before publishing a persistent CI baseline.
 
 ## [1.1.0] - 2026-08-13
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -119,12 +119,7 @@ specula run \
 
 Quote the target descriptor because `|` has special meaning in the shell. Its fields identify the output name, GitHub repository, primary language, and reference algorithm or design document.
 
-For more consistent scope across repeated runs and to focus resources on your
-highest-priority modules and scenarios, we recommend starting from the
-[modeling guidance template](./modeling-guidance-template.md) and passing your
-edited file to a single-target run. See the
-[completed SONiC linkmgrd example](./modeling-guidance-example.md) for a
-concrete configuration:
+For more consistent scope across repeated runs and to focus resources on your highest-priority modules and scenarios, we recommend starting from the [modeling guidance template](./modeling-guidance-template.md) and passing your edited file to a single-target run. See the [completed SONiC linkmgrd example](./modeling-guidance-example.md) for a concrete configuration:
 
 ```bash
 specula run \
@@ -133,8 +128,7 @@ specula run \
   "cometbft|cometbft/cometbft|Go|Tendermint BFT"
 ```
 
-Guidance is optional. Without it, Specula determines the modeling scope
-automatically.
+Guidance is optional. Without it, Specula determines the modeling scope automatically.
 
 With the default isolated workspace, an external source checkout must be supplied with `--artifact`. Alternatively, Specula finds canonical checkouts under `case-studies/<name>/artifact/`.
 
@@ -153,15 +147,11 @@ Supported adapters are `claude-code` (default), `codex`, `copilot-cli`, `opencod
 
 ## Add Specula to CI
 
-Specula maintains a reference model and harness that evolve with your project's
-code. Choose a persistent CI directory outside the source checkout, and use the
-same directory for initialization and subsequent checks.
+Specula maintains a reference model and harness that evolve with your project's code. Choose a persistent CI directory outside the source checkout, and use the same directory for initialization and subsequent checks.
 
 ### Initialize once
 
-Initialization runs the full Specula workflow, focusing on the depth of the core
-logic and its interactions. Optional `--guidance` supplies your modeling scope
-and priorities.
+Initialization runs the full Specula workflow, focusing on the depth of the core logic and its interactions. Optional `--guidance` supplies your modeling scope and priorities.
 
 ```bash
 specula run --ci-init --ci-dir=/work/project-ci \
@@ -169,10 +159,7 @@ specula run --ci-init --ci-dir=/work/project-ci \
   "name|owner/repository|language|reference"
 ```
 
-For a long-lived CI baseline, we recommend initializing from source as above.
-A model from an ordinary one-shot run may focus on a few scenarios and carry
-coverage gaps into later checks; CI initialization focuses on reusable core logic
-and interactions. Regenerating a model does not guarantee better coverage.
+For a long-lived CI baseline, we recommend initializing from source as above. A model from an ordinary one-shot run may focus on a few scenarios and carry coverage gaps into later checks; CI initialization focuses on reusable core logic and interactions. Regenerating a model does not guarantee better coverage.
 
 To reuse an existing model or verification assets, add [BYOM](#bring-your-own-model-byom):
 
@@ -183,20 +170,9 @@ specula run --ci-init --ci-dir=/work/project-ci \
   "name|owner/repository|language|reference"
 ```
 
-The Agent organizes supplied assets and completes missing or incompatible parts,
-preserving the model's scope unless you request an expansion in your guidance.
-It may adapt workspace copies of an older model and harness to the supplied source.
-Usable traces are reused by default, followed by the standard BYOM validation,
-confirmation, and repair workflow. Prior logs alone do not complete initialization.
-Review `byom-modification-report.md` in the target's output for adaptations and
-remaining gaps. Successful completion publishes the baseline for subsequent checks;
-registration is not a proof of safety.
+The Agent organizes supplied assets and completes missing or incompatible parts, preserving the model's scope unless you request an expansion in your guidance. It may adapt workspace copies of an older model and harness to the supplied source. Usable traces are reused by default, followed by the standard BYOM validation, confirmation, and repair workflow. Prior logs alone do not complete initialization. Review `byom-modification-report.md` in the target's output for adaptations and remaining gaps. Successful completion publishes the baseline for subsequent checks; registration is not a proof of safety.
 
-Keep the original BYOM files available and unchanged until initialization and any
-resume finish. BYOM stores their path, not an input snapshot. To change the input,
-start a new initialization run; use a new CI directory if one is already initialized.
-`--byom` cannot be combined with `--incremental` or `--skip-*` options. CI initialization
-supports one target and requires isolated output.
+Keep the original BYOM files available and unchanged until initialization and any resume finish. BYOM stores their path, not an input snapshot. To change the input, start a new initialization run; use a new CI directory if one is already initialized. `--byom` cannot be combined with `--incremental` or `--skip-*` options. CI initialization supports one target and requires isolated output.
 
 ### Check updates
 
@@ -206,62 +182,33 @@ For each update, check out the target commit in the source repository and run:
 specula run --incremental --ci-dir=/work/project-ci
 ```
 
-Specula computes the changes since the current model's source version, then
-runs one Agent through the incremental-modeling workflow using the existing
-model and harness. The repository path and user guidance are reused. Use the
-ordinary `--agent`, `--model`, and `--effort` options to select the Agent.
+Specula computes the changes since the current model's source version, then runs one Agent through the incremental-modeling workflow using the existing model and harness. The repository path and user guidance are reused. Use the ordinary `--agent`, `--model`, and `--effort` options to select the Agent.
 
-Completed runs update `current/model/` in the CI directory. Reports, diffs, logs,
-and resource usage are saved under `runs/<run-id>/` in the same directory.
+Completed runs update `current/model/` in the CI directory. Reports, diffs, logs, and resource usage are saved under `runs/<run-id>/` in the same directory.
 
 ### Resume an interrupted run
 
-Incomplete runs leave the current model unchanged. Resume the original Agent
-conversation and working directory with:
+Incomplete runs leave the current model unchanged. Resume the original Agent conversation and working directory with:
 
 ```bash
 specula run --ci-dir=/work/project-ci --run-id=<run-id>
 ```
 
-For BYOM initialization, the same resume command restores the original BYOM path;
-you do not need to repeat `--ci-init` or `--byom`. Persistent CI does not support
-`--fresh-context`. To start over, rerun the initialization or incremental command
-without `--run-id`. Run checks sharing a CI directory one at a time.
+For BYOM initialization, the same resume command restores the original BYOM path; you do not need to repeat `--ci-init` or `--byom`. Persistent CI does not support `--fresh-context`. To start over, rerun the initialization or incremental command without `--run-id`. Run checks sharing a CI directory one at a time.
 
 ### Run automatically with GitHub Actions
 
-Install Specula, the selected agent, and the project's build dependencies under
-the account running a dedicated Linux runner labeled `specula`. Initialize the
-CI directory under that same account so later runs can reuse its files and
-Agent sessions.
+Install Specula, the selected agent, and the project's build dependencies under the account running a dedicated Linux runner labeled `specula`. Initialize the CI directory under that same account so later runs can reuse its files and Agent sessions.
 
-Copy the [workflow template](../examples/ci/specula-ci.yml) into your project's
-`.github/workflows/specula-ci.yml`. Set the repository variables
-`SPECULA_CI_DIR` and `SPECULA_MODEL`; optionally set `SPECULA_AGENT` and
-`SPECULA_EFFORT`. Edit the branch filters to suit your repository. Each
-independently evolving branch needs its own initialized CI directory.
+Copy the [workflow template](../examples/ci/specula-ci.yml) into your project's `.github/workflows/specula-ci.yml`. Set the repository variables `SPECULA_CI_DIR` and `SPECULA_MODEL`; optionally set `SPECULA_AGENT` and `SPECULA_EFFORT`. Edit the branch filters to suit your repository. Each independently evolving branch needs its own initialized CI directory.
 
-Each push checks the cumulative diff from the last successful model baseline to
-the pushed version. One check may include several commits; intermediate versions
-are not checked separately. Scheduled checks use the latest branch version.
-Once the model reaches that version, delayed events for earlier commits do not
-repeat the work or move the model backward.
+Each push checks the cumulative diff from the last successful model baseline to the pushed version. One check may include several commits; intermediate versions are not checked separately. Scheduled checks use the latest branch version. Once the model reaches that version, delayed events for earlier commits do not repeat the work or move the model backward.
 
-Same-repository PRs check the proposed merged code without changing the branch's
-current model. When the code is merged, matching completed results are inherited
-without another Agent run, including squash and rebase merges.
-Changes to the code, model baseline, or check configuration require a new check.
-External-fork PRs do not run automatically on the runner.
+Same-repository PRs check the proposed merged code without changing the branch's current model. When the code is merged, matching completed results are inherited without another Agent run, including squash and rebase merges. Changes to the code, model baseline, or check configuration require a new check. External-fork PRs do not run automatically on the runner.
 
-Manual runs are available in the Actions tab. Uncomment `schedule` to enable
-cron; use `SPECULA_CI_BRANCH` to select a non-default branch for scheduled runs.
-Change `SPECULA_CI_ENVIRONMENT` when updating the runner's toolchain or external
-configuration so older check results are not reused under a different setup.
+Manual runs are available in the Actions tab. Uncomment `schedule` to enable cron; use `SPECULA_CI_BRANCH` to select a non-default branch for scheduled runs. Change `SPECULA_CI_ENVIRONMENT` when updating the runner's toolchain or external configuration so older check results are not reused under a different setup.
 
-The Actions summary lists each revision's outcome, with downloadable reports
-and usage summaries. Full working files and conversation state stay in the CI
-directory. Failed checks are reported, not automatically retried; use the
-existing resume command or request an explicit manual rerun.
+The Actions summary lists each revision's outcome, with downloadable reports and usage summaries. Full working files and conversation state stay in the CI directory. Failed checks are reported, not automatically retried; use the existing resume command or request an explicit manual rerun.
 
 ## Bring Your Own Model (BYOM)
 
@@ -411,10 +358,7 @@ If an agent call is interrupted, attach to the same run. Specula restores omitte
 specula run --run-id=my-run
 ```
 
-When a run was created with `--guidance`, an omitted flag on resume reuses the
-same absolute path and reads its current contents. You may edit that file
-between invocations, but resuming with a different guidance path is rejected,
-including with `--fresh-context`.
+When a run was created with `--guidance`, an omitted flag on resume reuses the same absolute path and reads its current contents. You may edit that file between invocations, but resuming with a different guidance path is rejected, including with `--fresh-context`.
 
 After the resumed phase finishes, later phases follow the skip options on the current command.
 
@@ -507,9 +451,7 @@ specula run [options] "name|owner/repository|language|reference"
 
 `--byom` is supported only by `specula run`. It conflicts with `--no-isolate`, `--skip-analysis`, `--skip-specgen`, `--skip-harness`, `--skip-validate`, `--skip-confirmation`, `--skip-classification`, and `--skip-repair-loop`.
 
-When an interactive `specula run` has no `--guidance`, Specula asks before
-continuing. Non-interactive and batch runs print a warning and continue without
-waiting for input, so unattended jobs are not blocked.
+When an interactive `specula run` has no `--guidance`, Specula asks before continuing. Non-interactive and batch runs print a warning and continue without waiting for input, so unattended jobs are not blocked.
 
 Use command-specific help for the authoritative option list:
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -169,6 +169,35 @@ specula run --ci-init --ci-dir=/work/project-ci \
   "name|owner/repository|language|reference"
 ```
 
+For a long-lived CI baseline, we recommend initializing from source as above.
+A model from an ordinary one-shot run may focus on a few scenarios and carry
+coverage gaps into later checks; CI initialization focuses on reusable core logic
+and interactions. Regenerating a model does not guarantee better coverage.
+
+To reuse an existing model or verification assets, add [BYOM](#bring-your-own-model-byom):
+
+```bash
+specula run --ci-init --ci-dir=/work/project-ci \
+  --byom=/work/existing-model-or-assets --artifact=/work/project \
+  --guidance=/work/project-guidance.md \
+  "name|owner/repository|language|reference"
+```
+
+The Agent organizes supplied assets and completes missing or incompatible parts,
+preserving the model's scope unless you request an expansion in your guidance.
+It may adapt workspace copies of an older model and harness to the supplied source.
+Usable traces are reused by default, followed by the standard BYOM validation,
+confirmation, and repair workflow. Prior logs alone do not complete initialization.
+Review `byom-modification-report.md` in the target's output for adaptations and
+remaining gaps. Successful completion publishes the baseline for subsequent checks;
+registration is not a proof of safety.
+
+Keep the original BYOM files available and unchanged until initialization and any
+resume finish. BYOM stores their path, not an input snapshot. To change the input,
+start a new initialization run; use a new CI directory if one is already initialized.
+`--byom` cannot be combined with `--incremental` or `--skip-*` options. CI initialization
+supports one target and requires isolated output.
+
 ### Check updates
 
 For each update, check out the target commit in the source repository and run:
@@ -194,8 +223,10 @@ conversation and working directory with:
 specula run --ci-dir=/work/project-ci --run-id=<run-id>
 ```
 
-To start over, rerun the incremental command without `--run-id`. Run checks
-sharing a CI directory one at a time.
+For BYOM initialization, the same resume command restores the original BYOM path;
+you do not need to repeat `--ci-init` or `--byom`. Persistent CI does not support
+`--fresh-context`. To start over, rerun the initialization or incremental command
+without `--run-id`. Run checks sharing a CI directory one at a time.
 
 ### Run automatically with GitHub Actions
 
@@ -251,7 +282,7 @@ BYOM skips the full code-analysis phase. Its Phase 2 and Phase 2.5 agents inspec
 
 Specula does not modify the original BYOM path. Later phases may modify the adopted workspace copies under their normal validation and repair rules. At the end of each target run, `byom-modification-report.md` summarizes which supplied assets were reused or modified, what Specula added, and why. The report is an agent-produced comparison, not a mechanically complete patch.
 
-BYOM requires the default isolated layout and conflicts with `--no-isolate` and every `--skip-*` option. Other `specula run` options retain their normal behavior. A resumed run reuses its stored absolute BYOM path; use `--fresh-context` to select a different path.
+BYOM requires the default isolated layout and conflicts with `--no-isolate` and every `--skip-*` option. A resumed run reuses its stored absolute BYOM path; keep the original files available and unchanged until the run and any resume finish. Ordinary runs can use `--fresh-context` to select a different path. For persistent CI, use [BYOM initialization](#initialize-once); `--incremental` does not accept `--byom`, and changing the initialization input requires a new run.
 
 ### Hybrid agent configuration
 

--- a/src/specula/ci_workflow.py
+++ b/src/specula/ci_workflow.py
@@ -15,6 +15,7 @@ from specula import ci_init, resumelib
 from specula.ci_identity import check_key
 from specula.ci_inheritance import register_candidate
 from specula.ci_store import CIError, CIStore, freeze_source, git, read_json, write_json
+from specula.output_index import BYOM_REPORT_FILENAME
 from specula.pipelinelib import Pipeline, _valid_run_id
 from specula.snapshotlib import load_sources
 
@@ -68,8 +69,8 @@ class CIPipeline(Pipeline):
         if (self.ci_init and self.incremental) or not (self.ci_init or self.incremental or self._run_id_given):
             print("ERROR: choose --ci-init, --incremental, or --run-id with --ci-dir", file=sys.stderr)
             return 1
-        if not self.isolate or self.byom_path is not None or len(self.targets) != 1:
-            print("ERROR: persistent CI requires one target, isolated output, and no --byom", file=sys.stderr)
+        if not self.isolate or len(self.targets) != 1:
+            print("ERROR: persistent CI requires one target and isolated output", file=sys.stderr)
             return 1
         if any(arg.startswith("--skip-") for arg in argv) or self._enable_reviews_given:
             print("ERROR: CI runs the complete workflow; skip and review flags are not supported", file=sys.stderr)
@@ -89,6 +90,12 @@ class CIPipeline(Pipeline):
         self._isolate_explicit = True
         self.store = CIStore(self.ci_dir)
         return None
+
+    def _byom_option_error(self) -> str | None:
+        error = super()._byom_option_error()
+        if error is None and self.byom_path is not None and self.incremental:
+            return "--byom cannot be used with --incremental; initialize a new CI directory with --ci-init"
+        return error
 
     def run_storage_root(self) -> Path:
         assert self.ci_dir is not None
@@ -121,6 +128,8 @@ class CIPipeline(Pipeline):
         self.candidate = candidate
         self.revision = raw.get("revision")
         super()._restore_resume_configuration(raw, allow_overrides=allow_overrides)
+        if self.ci_init == self.incremental:
+            raise resumelib.ResumeError("invalid stored CI run mode; expected initialization or incremental checking")
         if self.incremental:
             self.skip_classification = True
 
@@ -251,7 +260,7 @@ class CIPipeline(Pipeline):
             ci_init._copy_assets(Path(current["model_path"]), work)
             # Prior run summaries remain available in old_model; they are not
             # this run's findings, completion evidence, or resource history.
-            for filename in ("summary.md", ".summary-findings.md", "ci-report.md"):
+            for filename in ("summary.md", ".summary-findings.md", "ci-report.md", BYOM_REPORT_FILENAME):
                 (work / filename).unlink(missing_ok=True)
         write_json(record, inputs)
         self.inputs = inputs

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -158,7 +158,7 @@ Options:
   --byom=PATH            Use user-provided model artifacts and run Phase 2 onward
   --guidance=PATH        Target-specific modeling guidance (single-target runs only)
   --ci-init              Build and register an initial CI baseline with core-depth guidance
-                         (one target, full pipeline, isolated output; registration is not verification)
+                         (one target, isolated output; accepts --byom; registration is not verification)
   --ci-dir=PATH          Persistent project directory shared by initialization and incremental runs
   --incremental          Run one Agent through the incremental-modeling skill using --ci-dir
   --ci-candidate         Save an incremental result without updating the branch's current model
@@ -705,10 +705,8 @@ class Pipeline:
         if not self.ci_init:
             return None
         conflicts = [flag for flag in BYOM_CONFLICTING_FLAGS if flag in self.argv]
-        if self.byom_path is not None:
-            conflicts.append("--byom")
         if conflicts:
-            return f"--ci-init conflicts with {', '.join(conflicts)}; initialization requests the full pipeline"
+            return f"--ci-init conflicts with {', '.join(conflicts)}; initialization does not allow phase skips"
         if len(self.targets) != 1:
             return "--ci-init supports exactly one target per run"
         if not self.isolate:
@@ -1075,9 +1073,7 @@ class Pipeline:
             if not allow_overrides and (
                 stored_byom is None or self.byom_path is None or self.byom_path != Path(stored_byom)
             ):
-                raise resumelib.ResumeError(
-                    "--byom differs from this run; pass --fresh-context to use another input path"
-                )
+                raise resumelib.ResumeError("--byom differs from this run; start a new run to use another input path")
         elif stored_byom is not None:
             try:
                 self.byom_path = self._normalize_byom_path(stored_byom)

--- a/src/specula/prompts/ci-initialization.md
+++ b/src/specula/prompts/ci-initialization.md
@@ -19,3 +19,12 @@ Produce reusable properties, scenarios, instrumentation, and harness assets thro
 the existing workflow. Distinguish observed and checked behavior from unresolved
 questions and budget-limited exploration. Finding a real implementation bug does not
 by itself invalidate a faithful model; finishing the workflow is not a proof of safety.
+
+When using BYOM, follow the existing BYOM workflow and preserve the supplied model's
+scope unless the user explicitly requests an expansion. Reuse usable assets and fill
+missing or incompatible responsibilities within that scope. The supplied source is
+the initialization target: assess model and harness correspondence to that version,
+and use the normal validation and repair workflow to adapt workspace copies as needed.
+Report unresolved correspondence and coverage gaps rather than claiming adaptation
+is complete. Existing logs do not replace this run's validation. Describe adaptations
+in the normal BYOM modification report.

--- a/src/specula/prompts/ci-initialization.md
+++ b/src/specula/prompts/ci-initialization.md
@@ -1,30 +1,11 @@
 ## CI Initialization Guidance
 
-This run establishes a reusable modeling and verification baseline for future
-incremental checks. Run the normal Specula workflow; this guidance supplements,
-and does not replace, each phase's methodology.
+This run establishes a reusable modeling and verification baseline for future incremental checks. Run the normal Specula workflow; this guidance supplements, and does not replace, each phase's methodology.
 
-Respect the user's explicit priorities, scope, and exclusions. Within that scope,
-prioritize semantic depth in the core logic over breadth across peripheral features.
-Investigate the core state transitions and the interactions on which their correctness
-depends, including relevant failure, concurrency, and recovery paths. Let implementation
-evidence determine which mechanisms matter; do not add mechanisms merely to fill a list.
+Respect the user's explicit priorities, scope, and exclusions. Within that scope, prioritize semantic depth in the core logic over breadth across peripheral features. Investigate the core state transitions and the interactions on which their correctness depends, including relevant failure, concurrency, and recovery paths. Let implementation evidence determine which mechanisms matter; do not add mechanisms merely to fill a list.
 
-Build a coherent reference covering that core, rather than a collection of isolated
-models for a few known bugs. Add detail where it can expose meaningful interactions,
-not to meet a model-size or line-count target. Keep important assumptions and remaining
-coverage gaps visible so later updates can revisit them.
+Build a coherent reference covering that core, rather than a collection of isolated models for a few known bugs. Add detail where it can expose meaningful interactions, not to meet a model-size or line-count target. Keep important assumptions and remaining coverage gaps visible so later updates can revisit them.
 
-Produce reusable properties, scenarios, instrumentation, and harness assets through
-the existing workflow. Distinguish observed and checked behavior from unresolved
-questions and budget-limited exploration. Finding a real implementation bug does not
-by itself invalidate a faithful model; finishing the workflow is not a proof of safety.
+Produce reusable properties, scenarios, instrumentation, and harness assets through the existing workflow. Distinguish observed and checked behavior from unresolved questions and budget-limited exploration. Finding a real implementation bug does not by itself invalidate a faithful model; finishing the workflow is not a proof of safety.
 
-When using BYOM, follow the existing BYOM workflow and preserve the supplied model's
-scope unless the user explicitly requests an expansion. Reuse usable assets and fill
-missing or incompatible responsibilities within that scope. The supplied source is
-the initialization target: assess model and harness correspondence to that version,
-and use the normal validation and repair workflow to adapt workspace copies as needed.
-Report unresolved correspondence and coverage gaps rather than claiming adaptation
-is complete. Existing logs do not replace this run's validation. Describe adaptations
-in the normal BYOM modification report.
+When using BYOM, follow the existing BYOM workflow and preserve the supplied model's scope unless the user explicitly requests an expansion. Reuse usable assets and fill missing or incompatible responsibilities within that scope. The supplied source is the initialization target: assess model and harness correspondence to that version, and use the normal validation and repair workflow to adapt workspace copies as needed. Report unresolved correspondence and coverage gaps rather than claiming adaptation is complete. Existing logs do not replace this run's validation. Describe adaptations in the normal BYOM modification report.

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -208,20 +208,29 @@ class CliE2E(unittest.TestCase):
             "esac; done\n"
             'printf "%s\\n" "$SPECULA_PHASE" >> "$0.phases"\n'
             'cp "$prompt" "$0.$SPECULA_PHASE.prompt"\n'
+            'printf "%s\\n" "${SPECULA_BYOM_PATH-}" > "$0.$SPECULA_PHASE.byom"\n'
             'case "$SPECULA_PHASE" in\n'
             "  code_analysis)\n"
             '    printf "# Fixture modeling brief\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
             "    ;;\n"
             "  spec_generation)\n"
             '    mkdir -p "$SPECULA_WORK_DIR/spec"\n'
+            '    if [ -n "${SPECULA_BYOM_PATH-}" ]; then\n'
+            '      printf "# Adopted fixture scope\\n" > "$SPECULA_WORK_DIR/modeling-brief.md"\n'
+            '      if [ -d "$SPECULA_BYOM_PATH" ]; then\n'
+            '        cp -R "$SPECULA_BYOM_PATH/." "$SPECULA_WORK_DIR/"\n'
+            "      else\n"
+            '        cp "$SPECULA_BYOM_PATH" "$SPECULA_WORK_DIR/spec/base.tla"\n'
+            "      fi\n"
+            "    fi\n"
             "    for file in base.tla MC.tla Trace.tla instrumentation-spec.md; do\n"
-            '      printf "fixture model\\n" > "$SPECULA_WORK_DIR/spec/$file"\n'
+            '      if [ ! -f "$SPECULA_WORK_DIR/spec/$file" ]; then printf "fixture model\\n" > "$SPECULA_WORK_DIR/spec/$file"; fi\n'
             "    done\n"
             "    ;;\n"
             "  harness_generation)\n"
             '    mkdir -p "$SPECULA_WORK_DIR/harness" "$SPECULA_WORK_DIR/traces"\n'
-            '    printf "#!/bin/sh\\n" > "$SPECULA_WORK_DIR/harness/run.sh"\n'
-            '    printf \'{"event":"fixture"}\\n\' > "$SPECULA_WORK_DIR/traces/fixture.ndjson"\n'
+            '    if [ ! -f "$SPECULA_WORK_DIR/harness/run.sh" ]; then printf "#!/bin/sh\\n" > "$SPECULA_WORK_DIR/harness/run.sh"; fi\n'
+            '    if [ -z "$(ls -A "$SPECULA_WORK_DIR/traces")" ]; then printf \'{"event":"fixture"}\\n\' > "$SPECULA_WORK_DIR/traces/fixture.ndjson"; fi\n'
             "    ;;\n"
             "  spec_validation)\n"
             '    printf x >> "$0.validation-count"\n'
@@ -241,6 +250,9 @@ class CliE2E(unittest.TestCase):
             "  bug_classification)\n"
             '    printf "# Severity Classification\\n\\n## Summary\\n\\n## Per-entry classification\\n" > "$SPECULA_WORK_DIR/bug-severity.md"\n'
             '    printf "No impact-bearing findings were recorded.\\n\\n## Findings\\n\\n- Other dispositions: 0.\\n\\n## Validation limits\\n\\nFixture only; no semantic validation was performed.\\n" > "$SPECULA_WORK_DIR/.summary-findings.md"\n'
+            '    if [ -n "${SPECULA_BYOM_PATH-}" ] && [ ! -f "$0.omit-byom-report" ]; then\n'
+            '      printf "# BYOM Modification Report\\nSupplied assets copied; missing fixture assets added. No semantic verification performed.\\n" > "$SPECULA_WORK_DIR/byom-modification-report.md"\n'
+            "    fi\n"
             "    ;;\n"
             "  *) exit 97 ;;\n"
             "esac\n"

--- a/tests/e2e/test_incremental_ci.py
+++ b/tests/e2e/test_incremental_ci.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import test_cli_pipeline as fixtures
 
-from specula.ci_store import CIStore
+from specula.ci_store import CIStore, asset_hashes
 
 
 class IncrementalCLI(unittest.TestCase):
@@ -76,6 +76,187 @@ class IncrementalCLI(unittest.TestCase):
 
     def latest(self) -> Path:
         return (self.ci / "runs/latest").resolve()
+
+    def supplied_model(self) -> Path:
+        model = self.work / "Supplied.tla"
+        model.write_text("---- MODULE Supplied ----\nSuppliedInvariant == TRUE\n====\n")
+        return model
+
+    def test_byom_model_initialization_then_incremental_update(self) -> None:
+        supplied = self.supplied_model()
+        original = supplied.read_bytes()
+        guidance = self.work / "guidance.md"
+        guidance.write_text("Preserve the supplied election scope.\n")
+        result = self.run_ci(
+            "--ci-init",
+            "--agent=fake",
+            f"--artifact={self.source}",
+            f"--byom={supplied}",
+            f"--guidance={guidance}",
+            "footest",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        run = self.latest()
+        old = (self.ci / "current").resolve()
+        self.assertEqual((old / "model/spec/base.tla").read_bytes(), original)
+        self.assertTrue((old / "model/harness/run.sh").is_file())
+        self.assertTrue((old / "model/byom-modification-report.md").is_file())
+        self.assertEqual(CIStore(self.ci).current()["source_commit"], self.initial_sha)
+        phases = Path(f"{self.adapter}.phases").read_text().splitlines()
+        self.assertEqual(
+            phases,
+            [
+                "spec_generation",
+                "harness_generation",
+                "spec_validation",
+                "bug_confirmation_turn",
+                "bug_classification",
+            ],
+        )
+        for phase in ("spec_generation", "harness_generation"):
+            prompt = Path(f"{self.adapter}.{phase}.prompt").read_text()
+            self.assertIn("# BYOM Phase", prompt)
+            self.assertIn("## CI Initialization Guidance", prompt)
+            self.assertIn(guidance.read_text(), prompt)
+        self.assertIn("SKIPPED (BYOM)", (run / "pipeline-summary.md").read_text())
+        self.assertIn(
+            "[BYOM modification report](byom-modification-report.md)",
+            (run / "footest/.specula-output/index.md").read_text(),
+        )
+        self.assertEqual(supplied.read_bytes(), original)
+        self.assertEqual(self.git("status", "--porcelain"), "")
+
+        self.change_source("updated\n")
+        result = self.run_ci("--incremental", "--agent=fake")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(CIStore(self.ci).current()["source_commit"], self.git("rev-parse", "HEAD"))
+        self.assertEqual((old / "model/spec/base.tla").read_bytes(), original)
+        self.assertEqual((self.ci / "current/model/spec/base.tla").read_text(), "updated fixture model\n")
+        self.assertTrue((old / "model/byom-modification-report.md").is_file())
+        self.assertFalse((self.ci / "current/model/byom-modification-report.md").exists())
+        self.assertNotIn("BYOM modification report", (self.latest() / "footest/.specula-output/index.md").read_text())
+        self.assertIn("SuppliedInvariant", (self.latest() / "model.diff").read_text())
+        self.assertEqual(Path(f"{self.adapter}.incremental.byom").read_text().strip(), "")
+        prompt = Path(f"{self.adapter}.incremental.prompt").read_text()
+        self.assertIn(guidance.read_text(), prompt)
+        self.assertNotIn("## CI Initialization Guidance", prompt)
+        self.assertEqual(supplied.read_bytes(), original)
+
+    def test_byom_bundle_is_adopted_and_still_validated(self) -> None:
+        supplied = self.work / "bundle"
+        assets = {
+            "modeling-brief.md": "# Supplied scope\n",
+            "spec/base.tla": "supplied reference\n",
+            "spec/MC.tla": "supplied MC wrapper\n",
+            "spec/MC.cfg": "supplied MC config\n",
+            "spec/Trace.tla": "supplied Trace wrapper\n",
+            "spec/Trace.cfg": "supplied Trace config\n",
+            "spec/instrumentation-spec.md": "supplied mapping\n",
+            "harness/run.sh": "#!/bin/sh\n# Supplied harness\nexit 0\n",
+            "traces/retained.ndjson": '{"event":"retained"}\n',
+            "spec/old-validation.log": "Prior evidence only.\n",
+        }
+        for name, content in assets.items():
+            path = supplied / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+        (supplied / "harness/run.sh").chmod(0o755)
+        before = asset_hashes(supplied)
+        result = self.run_ci("--ci-init", "--agent=fake", f"--artifact={self.source}", f"--byom={supplied}", "footest")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        for name, content in assets.items():
+            self.assertEqual((self.ci / "current/model" / name).read_text(), content)
+        self.assertEqual(asset_hashes(supplied), before)
+        self.assertEqual(Path(f"{self.adapter}.validation-count").read_text(), "x")
+        self.assertEqual(self.git("status", "--porcelain"), "")
+
+    def test_byom_initialization_failure_and_resume_preserve_inputs(self) -> None:
+        supplied = self.supplied_model()
+        original = supplied.read_bytes()
+        self.adapter = self.helper._ci_init_adapter(self.root, interrupt_validation=True)
+        first = self.run_ci("--ci-init", "--agent=fake", f"--artifact={self.source}", f"--byom={supplied}", "footest")
+        self.assertEqual(first.returncode, 9, first.stdout + first.stderr)
+        run = self.latest()
+        self.assertFalse((self.ci / "current").is_symlink())
+        self.assertFalse((run / "ci-result.json").exists())
+        baseline = (run / "ci-baseline.json").read_bytes()
+        self.assertEqual(json.loads(baseline)["validation_status"], "UNVERIFIED")
+        phases_before = Path(f"{self.adapter}.phases").read_bytes()
+
+        replacement = self.work / "replacement.tla"
+        replacement.write_text("another input\n")
+        rejected = self.run_ci(f"--run-id={run.name}", f"--byom={replacement}")
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("--byom differs", rejected.stderr)
+        self.assertIn("start a new run", rejected.stderr)
+        self.assertEqual(Path(f"{self.adapter}.phases").read_bytes(), phases_before)
+        supplied.rename(self.work / "saved.tla")
+        rejected = self.run_ci(f"--run-id={run.name}")
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("BYOM input is unavailable", rejected.stderr)
+        self.assertEqual(Path(f"{self.adapter}.phases").read_bytes(), phases_before)
+        (self.work / "saved.tla").rename(supplied)
+
+        self.change_source("later source\n")
+        resumed = self.run_ci(f"--run-id={run.name}")
+        self.assertEqual(resumed.returncode, 0, resumed.stdout + resumed.stderr)
+        self.assertEqual(self.latest(), run)
+        self.assertEqual((run / "ci-baseline.json").read_bytes(), baseline)
+        self.assertEqual(CIStore(self.ci).current()["source_commit"], self.initial_sha)
+        self.assertEqual((self.ci / "current/model/spec/base.tla").read_bytes(), original)
+        self.assertEqual(supplied.read_bytes(), original)
+        self.assertEqual(Path(f"{self.adapter}.spec_validation.byom").read_text().strip(), str(supplied))
+        self.assertIn("exact session", Path(f"{self.adapter}.spec_validation.prompt").read_text())
+        phases = Path(f"{self.adapter}.phases").read_text().splitlines()
+        self.assertNotIn("code_analysis", phases)
+        self.assertEqual(phases.count("spec_generation"), 1)
+        self.assertEqual(phases.count("harness_generation"), 1)
+        self.assertEqual(phases.count("spec_validation"), 2)
+        self.assertTrue((self.ci / "current/model/byom-modification-report.md").is_file())
+        self.assertEqual(self.git("status", "--porcelain"), "")
+
+    def test_byom_dry_run_and_invalid_modes_do_not_publish(self) -> None:
+        supplied = self.supplied_model()
+        result = self.run_ci("--ci-init", "--dry-run", f"--artifact={self.source}", f"--byom={supplied}", "footest")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertFalse((self.ci / "current").is_symlink())
+        self.assertFalse(Path(f"{self.adapter}.phases").exists())
+        runs = set((self.ci / "runs").iterdir())
+        for flags in (
+            ["--incremental"],
+            ["--ci-init", "--ci-candidate"],
+            ["--ci-init", "--skip-validate"],
+            ["--ci-init", "--no-isolate"],
+            ["--ci-init", "--enable-reviews"],
+            ["--ci-init", "--run-id=missing"],
+        ):
+            with self.subTest(flags=flags):
+                rejected = self.run_ci(*flags, f"--byom={supplied}", "footest")
+                self.assertNotEqual(rejected.returncode, 0)
+                self.assertEqual(set((self.ci / "runs").iterdir()), runs)
+                self.assertFalse((self.ci / "current").is_symlink())
+                self.assertFalse(Path(f"{self.adapter}.phases").exists())
+        self.assertEqual(self.git("status", "--porcelain"), "")
+
+    def test_byom_cannot_overwrite_an_initialized_ci_directory(self) -> None:
+        self.initialize()
+        old = (self.ci / "current").resolve()
+        before = asset_hashes(old)
+        phases = Path(f"{self.adapter}.phases").read_bytes()
+        result = self.run_ci("--ci-init", f"--byom={self.supplied_model()}", "footest")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("already initialized", result.stderr)
+        self.assertEqual((self.ci / "current").resolve(), old)
+        self.assertEqual(asset_hashes(old), before)
+        self.assertEqual(Path(f"{self.adapter}.phases").read_bytes(), phases)
+
+    def test_missing_byom_report_prevents_publication(self) -> None:
+        supplied = self.supplied_model()
+        Path(f"{self.adapter}.omit-byom-report").touch()
+        result = self.run_ci("--ci-init", "--agent=fake", f"--artifact={self.source}", f"--byom={supplied}", "footest")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.ci / "current").is_symlink())
+        self.assertFalse((self.latest() / "ci-result.json").exists())
 
     def test_initialization_then_single_agent_incremental_update(self) -> None:
         self.initialize()

--- a/tests/unit/test_ci_init.py
+++ b/tests/unit/test_ci_init.py
@@ -15,6 +15,7 @@ from unittest import mock
 
 from specula import ci_init, resumelib
 from specula import pipelinelib as pl
+from specula.ci_workflow import CIPipeline
 
 
 class TestCIInit(unittest.TestCase):
@@ -149,14 +150,65 @@ class TestCIInit(unittest.TestCase):
         target.symlink_to(outside, target_is_directory=True)
         self.assertIsNone(self.register())
 
-    def test_ci_mode_rejects_skips_byom_and_multiple_targets(self) -> None:
+    def test_ci_mode_rejects_skips_and_multiple_targets_with_or_without_byom(self) -> None:
         provided = self.root / "model.tla"
         provided.write_text("provided")
         invalid = [[flag, "project"] for flag in pl.BYOM_CONFLICTING_FLAGS]
-        invalid += [[f"--byom={provided}", "project"], ["a", "b"], ["--no-isolate", "project"]]
-        for args in invalid:
-            with self.subTest(args=args), contextlib.redirect_stderr(io.StringIO()):
-                self.assertEqual(pl.Pipeline().parse_args(["--ci-init", *args]), 1)
+        invalid += [["a", "b"], ["--no-isolate", "project"]]
+        for byom in ([], [f"--byom={provided}"]):
+            for args in invalid:
+                with self.subTest(args=args, byom=byom), contextlib.redirect_stderr(io.StringIO()):
+                    self.assertEqual(pl.Pipeline().parse_args(["--ci-init", *byom, *args]), 1)
+
+    def test_ci_byom_file_and_directory_restore_without_repeating_flags(self) -> None:
+        model = self.root / "model.tla"
+        model.write_text("provided")
+        bundle = self.root / "bundle"
+        bundle.mkdir()
+        for persistent in (False, True):
+            for provided in (model, bundle):
+                with self.subTest(persistent=persistent, provided=provided):
+                    initial = CIPipeline() if persistent else pl.Pipeline()
+                    storage = [f"--ci-dir={self.root / 'ci'}"] if persistent else []
+                    self.assertIsNone(initial.parse_args([*storage, "--ci-init", f"--byom={provided}", "project"]))
+                    resumed = CIPipeline() if persistent else pl.Pipeline()
+                    self.assertIsNone(resumed.parse_args([*storage, "--run-id=existing"]))
+                    resumed._restore_resume_configuration(initial._resume_configuration_document())
+                    self.assertTrue(resumed.ci_init)
+                    self.assertEqual(resumed.byom_path, provided)
+                    self.assertTrue(resumed.skip_analysis)
+                    self.assertFalse(resumed.skip_specgen)
+                    self.assertFalse(resumed.skip_harness)
+                    self.assertFalse(resumed.skip_validation)
+
+    def test_incremental_byom_is_rejected_on_parse_and_configuration_restore(self) -> None:
+        provided = self.root / "model.tla"
+        provided.write_text("provided")
+        storage = [f"--ci-dir={self.root / 'ci'}"]
+        for flags in (["--incremental"], ["--incremental", "--run-id=existing"]):
+            with self.subTest(flags=flags), contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(CIPipeline().parse_args([*storage, *flags, f"--byom={provided}"]), 1)
+        initial = CIPipeline()
+        self.assertIsNone(initial.parse_args([*storage, "--incremental", "project"]))
+        stored = initial._resume_configuration_document()
+        stored["byom"] = str(provided)
+        resumed = CIPipeline()
+        self.assertIsNone(resumed.parse_args([*storage, "--run-id=existing"]))
+        with self.assertRaisesRegex(resumelib.ResumeError, "--byom cannot be used with --incremental"):
+            resumed._restore_resume_configuration(stored)
+        self.assertFalse((self.root / "ci").exists())
+
+    def test_ci_resume_requires_exactly_one_stored_workflow_mode(self) -> None:
+        storage = [f"--ci-dir={self.root / 'ci'}"]
+        initial = CIPipeline()
+        self.assertIsNone(initial.parse_args([*storage, "--ci-init", "project"]))
+        for enabled in (False, True):
+            stored = initial._resume_configuration_document()
+            stored.update(ci_init=enabled, incremental=enabled)
+            resumed = CIPipeline()
+            self.assertIsNone(resumed.parse_args([*storage, "--run-id=existing"]))
+            with self.subTest(enabled=enabled), self.assertRaisesRegex(resumelib.ResumeError, "CI run mode"):
+                resumed._restore_resume_configuration(stored)
 
     def test_ci_mode_restores_on_resume_and_rejects_explicit_skip(self) -> None:
         initial = pl.Pipeline()


### PR DESCRIPTION
Projects with existing TLA+ assets can now initialize Specula CI with `specula run --ci-init --byom=PATH --ci-dir=PATH`. Initialization reuses the ordinary BYOM agents and prompts to adopt and complete the supplied assets, runs the standard verification workflow, and publishes through the existing CI store.

CI guidance preserves the supplied scope unless the user requests expansion and allows adapting workspace copies to the supplied source revision. Resume retains the existing path-based BYOM behavior. Incremental runs still reject `--byom`, including after configuration restoration, and the initialization modification report stays with its original run. Usage documentation covers initialization, input preservation, recovery, and the recommendation to build a fresh CI baseline when practical.

Validation:

- GitHub CI on `e65c7758` passed all checks: 1,399 tests passed, 1 skipped, and 669 subtests passed under Python 3.10 ([run](https://github.com/specula-org/Specula/actions/runs/34187544620)). Local Python 3.14 testing passed 1,400 tests and 669 subtests, with the two relevant resume tests rerun after the final error-message change.
- Public CLI tests cover model-only and complete-bundle adoption, initialization followed by an incremental update, failure and native-session resume, missing/replaced inputs, invalid options, existing baseline protection, and missing modification reports.
- Ruff lint/format, mypy, shell syntax, tracked symlinks, 64 invariant-tool tests, and trace-debugger basic tests passed.

CLI tests use a deterministic adapter; no LLM or TLC acceptance experiment was run. Ready for manual acceptance and review as a draft.
