### PR TITLE
Add native context compaction to incremental CI

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -186,15 +186,6 @@ Specula computes the changes since the current model's source version, then runs
 
 Completed runs update `current/model/` in the CI directory. Reports, diffs, logs, and resource usage are saved under `runs/<run-id>/` in the same directory.
 
-After `specula setup`, incremental runs can request native context compaction.
-The agent saves a short `.context-control/ci-context.md` handoff before pausing, then continues
-the same conversation. Compaction failures do not stop CI. Initialization and
-ordinary one-shot runs are unchanged.
-Copilot compaction requires Python 3.11+ for its SDK. Native compaction receipts
-and per-turn usage remain in the run's `.context-control/` directory.
-When a backend omits compaction usage, the cost total is marked incomplete;
-the recorded per-turn costs remain available.
-
 ### Resume an interrupted run
 
 Incomplete runs leave the current model unchanged. Resume the original Agent conversation and working directory with:

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -186,6 +186,15 @@ Specula computes the changes since the current model's source version, then runs
 
 Completed runs update `current/model/` in the CI directory. Reports, diffs, logs, and resource usage are saved under `runs/<run-id>/` in the same directory.
 
+After `specula setup`, incremental runs can request native context compaction.
+The agent saves a short `.context-control/ci-context.md` handoff before pausing, then continues
+the same conversation. Compaction failures do not stop CI. Initialization and
+ordinary one-shot runs are unchanged.
+Copilot compaction requires Python 3.11+ for its SDK. Native compaction receipts
+and per-turn usage remain in the run's `.context-control/` directory.
+When a backend omits compaction usage, the cost total is marked incomplete;
+the recorded per-turn costs remain available.
+
 ### Resume an interrupted run
 
 Incomplete runs leave the current model unchanged. Resume the original Agent conversation and working directory with:

--- a/scripts/infra/setup.sh
+++ b/scripts/infra/setup.sh
@@ -356,6 +356,14 @@ setup_python_tool_env \
   "$INV_CHECKING_TOOL_VENV" \
   "$INV_CHECKING_TOOL_PYTHON"
 
+# Registered per CI invocation, not in the user's global Agent configuration.
+setup_python_tool_env \
+  "CI context control" \
+  "$PROJECT_ROOT/tools/context_control" \
+  "$PROJECT_ROOT/tools/context_control/.venv" \
+  "$PROJECT_ROOT/tools/context_control/.venv/bin/python" \
+  "$PROJECT_ROOT/tools/context_control/requirements.txt"
+
 # ─── Skills directory check ──────────────────────────────────────────────────
 
 if [[ ! -d "$SKILLS_SOURCE" ]]; then
@@ -469,6 +477,19 @@ fi
 echo ""
 
 # ─── Done ────────────────────────────────────────────────────────────────────
+
+for agent in opencode pi; do
+  if command_exists "$agent" && ask_yn "Install Specula skills for $agent?"; then
+    case "$agent" in
+      opencode) setup_skills "${XDG_CONFIG_HOME:-$HOME/.config}/opencode/skills" "$SKILLS_SOURCE" ;;
+      pi) setup_skills "${PI_CODING_AGENT_DIR:-$HOME/.pi/agent}/skills" "$SKILLS_SOURCE" ;;
+    esac
+  fi
+done
+print_status "CI context tools are registered automatically for incremental runs."
+if command_exists copilot && ! "$PROJECT_ROOT/tools/context_control/.venv/bin/python" -c 'import copilot' >/dev/null 2>&1; then
+  print_warning "Copilot context compaction needs Python 3.11+; other CI functionality remains available."
+fi
 
 if [[ "$SKILL_SETUP_INCOMPLETE" == true ]]; then
   print_warning "Setup completed with an incomplete Specula skill installation."

--- a/scripts/launch/adapters/codex.sh
+++ b/scripts/launch/adapters/codex.sh
@@ -427,6 +427,9 @@ run_codex() {
   cmd+=(codex exec --dangerously-bypass-approvals-and-sandbox --output-last-message "$last_message_file")
   # Keep one large tool result from jumping past Codex's auto-compaction point.
   cmd+=(-c "tool_output_token_limit=10000")
+  if [[ "${SPECULA_PHASE:-}" == "incremental" && -n "${SPECULA_CONTEXT_CODEX_CONFIG:-}" ]]; then
+    cmd+=(-c "mcp_servers.specula_context=$SPECULA_CONTEXT_CODEX_CONFIG")
+  fi
   # Model / reasoning effort (additive — empty leaves codex config.toml default).
   [[ -n "$MODEL" ]] && cmd+=(-m "$MODEL")
   [[ -n "$EFFORT" ]] && cmd+=(-c "model_reasoning_effort=$EFFORT")

--- a/scripts/launch/adapters/copilot-cli.sh
+++ b/scripts/launch/adapters/copilot-cli.sh
@@ -165,6 +165,9 @@ fi
 # Keep the scripting channel free of version-specific stats footers. Provider
 # diagnostics still go to stderr, which is captured below for policy recovery.
 CMD=(copilot -p "$PROMPT" --allow-all --autopilot --silent)
+if [[ "${SPECULA_PHASE:-}" == "incremental" && -n "${SPECULA_CONTEXT_MCP_JSON:-}" ]]; then
+  CMD+=(--additional-mcp-config "$SPECULA_CONTEXT_MCP_JSON")
+fi
 
 if [[ -n "$RESUME_SESSION_ID" ]]; then
   if [[ ! "$RESUME_SESSION_ID" =~ ^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$ ]]; then

--- a/skills/incremental-modeling/guide.md
+++ b/skills/incremental-modeling/guide.md
@@ -4,6 +4,29 @@ Treat the prior Specula run as semantic evidence and the new source as the imple
 
 The workflow has four parts under `references/`: `generation/`, `validation/`, `model-checking/`, and `reproduction/`. Execute them in that order.
 
+## Preserve Context Across Long CI Runs
+
+At a major stage transition or after a coherent batch of analysis/repairs, consider
+`request_context_compaction` if earlier exploration is making the conversation
+large. Before requesting it, update the actual artifacts and write a short
+`.context-control/ci-context.md` in the working directory. This is run-local
+working memory, not a reusable baseline result. Preserve current source/model identity,
+important modeling decisions and evidence paths, valid versus invalidated checks,
+unresolved counterexamples, pending work, and the next step. Review that handoff
+yourself; do not replace it with a copied transcript or a rigid change contract.
+
+Collect outstanding tool results before yielding; native terminal handles may
+not survive the pause. Keep durable commands/logs for any externally managed work.
+Call the tool with the handoff path and follow its yield instruction. This is an
+internal pause, not CI completion: do not finalize reports or emit the CI completion
+marker. The controller compacts and resumes the same native conversation.
+
+After continuation, read the handoff first and reopen evidence as needed, not all
+historical logs. Keep unresolved or invalidated work pending. If the tool is absent,
+or compaction fails, continue the existing task without repeatedly requesting it.
+This optional CI capability does not apply to initialization or ordinary one-shot
+runs and does not change any verification or reproduction requirement below.
+
 ## Inputs
 
 Require:

--- a/skills/incremental-modeling/guide.md
+++ b/skills/incremental-modeling/guide.md
@@ -6,14 +6,21 @@ The workflow has four parts under `references/`: `generation/`, `validation/`, `
 
 ## Preserve Context Across Long CI Runs
 
-At a major stage transition or after a coherent batch of analysis/repairs, consider
-`request_context_compaction` if earlier exploration is making the conversation
-large. Before requesting it, update the actual artifacts and write a short
+Consider `request_context_compaction` when a coherent unit of analysis or repair
+has reached a stable stopping point, its essential state can be handed off briefly,
+and there has been substantive progress since the previous compaction. Do not wait
+for a full context window or compact at every stage by default. Do not interrupt an
+active derivation or counterexample diagnosis to compact; when repeated attempts
+make no progress, diagnose the stall rather than using compaction as a reset.
+
+Before requesting it, update the actual artifacts and write a short
 `.context-control/ci-context.md` in the working directory. This is run-local
 working memory, not a reusable baseline result. Preserve current source/model identity,
-important modeling decisions and evidence paths, valid versus invalidated checks,
-unresolved counterexamples, pending work, and the next step. Review that handoff
-yourself; do not replace it with a copied transcript or a rigid change contract.
+important modeling decisions and evidence paths, key failed approaches and their
+reasons, valid versus invalidated checks, unresolved counterexamples, pending work,
+and the next step. Remove repetitive exploration, not uncertain items: retain their
+unresolved or unverified status. Review that handoff yourself; do not replace it
+with a copied transcript or a rigid change contract.
 
 Collect outstanding tool results before yielding; native terminal handles may
 not survive the pause. Keep durable commands/logs for any externally managed work.
@@ -26,6 +33,8 @@ historical logs. Keep unresolved or invalidated work pending. If the tool is abs
 or compaction fails, continue the existing task without repeatedly requesting it.
 This optional CI capability does not apply to initialization or ordinary one-shot
 runs and does not change any verification or reproduction requirement below.
+
+Timing guidance adapted from [SelfCompact](https://arxiv.org/html/2606.23525v2#S3).
 
 ## Inputs
 

--- a/src/specula/adapters/claude_code.py
+++ b/src/specula/adapters/claude_code.py
@@ -486,6 +486,8 @@ def main(argv: list[str]) -> int:
         streaming = bool(stream_activity_log)
         output_format = "stream-json" if streaming else "json"
         cmd = ["claude", "--print", "--dangerously-skip-permissions", "--output-format", output_format]
+        if os.environ.get("SPECULA_PHASE") == "incremental" and os.environ.get("SPECULA_CONTEXT_MCP_CONFIG"):
+            cmd += ["--mcp-config", os.environ["SPECULA_CONTEXT_MCP_CONFIG"]]
         if resume_session_id:
             cmd += ["--resume", resume_session_id]
         if streaming:

--- a/src/specula/adapters/opencode.py
+++ b/src/specula/adapters/opencode.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -149,6 +150,24 @@ def main(argv: list[str]) -> int:
     if options.effort:
         command += ["--variant", options.effort]
     child_env = os.environ.copy()
+    context_config = child_env.get("SPECULA_CONTEXT_MCP_JSON")
+    if child_env.get("SPECULA_PHASE") == "incremental" and context_config:
+        # Newer OpenCode releases renamed the non-interactive approval flag.
+        try:
+            help_result = subprocess.run(["opencode", "run", "--help"], capture_output=True, text=True, timeout=10)
+            if help_result.returncode == 0 and "--auto" in help_result.stdout + help_result.stderr:
+                command[command.index("--dangerously-skip-permissions")] = "--auto"
+        except (OSError, subprocess.TimeoutExpired):
+            pass  # Keep the existing adapter behavior if help is unavailable.
+        entry = json.loads(context_config)["mcpServers"]["specula_context"]
+        config = json.loads(child_env.get("OPENCODE_CONFIG_CONTENT") or "{}")
+        config.setdefault("mcp", {})["specula_context"] = {
+            "type": "local",
+            "command": [entry["command"], *entry["args"]],
+            "environment": entry["env"],
+            "enabled": True,
+        }
+        child_env["OPENCODE_CONFIG_CONTENT"] = json.dumps(config)
     child_env["OPENCODE_FAKE_VCS"] = "git"
     _allow_external_directories(child_env)
     return run_json_cli("opencode", command, options, child_env=child_env)

--- a/src/specula/adapters/pi.py
+++ b/src/specula/adapters/pi.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 if __package__:
     from .utils.json_cli import AdapterArgumentError, parse_options, run_json_cli
@@ -61,6 +62,8 @@ def main(argv: list[str]) -> int:
         return 1
 
     command = ["pi", "--print", "--mode", "json"]
+    if os.environ.get("SPECULA_PHASE") == "incremental" and os.environ.get("SPECULA_CONTEXT_REQUEST"):
+        command += ["--extension", str(Path(__file__).resolve().parents[3] / "tools/context_control/pi-extension.js")]
     if options.resume_state is None:
         # Preserve the standalone adapter's historical ephemeral behavior.
         command.append("--no-session")

--- a/src/specula/adapters/utils/event_stream.py
+++ b/src/specula/adapters/utils/event_stream.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 import re
 import sys
 from collections.abc import Callable, Iterable
@@ -116,6 +117,14 @@ def _claude_events(record: object, concise: bool) -> list[_LogEvent]:
 def _copilot_events(record: object, concise: bool) -> list[_LogEvent]:
     if not isinstance(record, dict):
         return []
+    if (
+        record.get("type") == "session.task_complete"
+        and os.environ.get("SPECULA_PHASE") == "incremental"
+        and os.environ.get("SPECULA_CONTEXT_REQUEST")
+    ):
+        data = record.get("data")
+        if isinstance(data, dict) and data.get("success") is True and isinstance(data.get("summary"), str):
+            return [_text_event(data["summary"], concise)]
     data = record.get("data")
     if record.get("type") == "session.error":
         if not isinstance(data, dict):

--- a/src/specula/context_control.py
+++ b/src/specula/context_control.py
@@ -1,0 +1,80 @@
+"""A CI-scoped request to compact an existing native Agent conversation."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from pathlib import Path
+from typing import Any
+
+REQUEST_ENV = "SPECULA_CONTEXT_REQUEST"
+TOKEN_ENV = "SPECULA_CONTEXT_TOKEN"
+PYTHON_ENV = "SPECULA_CONTEXT_PYTHON"
+MCP_ENV = "SPECULA_CONTEXT_MCP_CONFIG"
+YIELD_PREFIX = "SPECULA_CONTEXT_YIELD"
+TOOL_NAME = "request_context_compaction"
+TOOL_DESCRIPTION = (
+    "Request native context compaction after saving and reviewing a Markdown handoff. "
+    "Use between completed work batches, after collecting outstanding tool results. "
+    "The request is not CI completion. Follow the returned continuation instructions."
+)
+
+
+def write_json(path: Path, value: Any) -> None:
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    try:
+        with temporary.open("x", encoding="utf-8") as stream:
+            json.dump(value, stream, ensure_ascii=False, indent=2)
+            stream.write("\n")
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def request_compaction(handoff_path: str) -> dict[str, str]:
+    """Bind a request to this invocation; do not judge the handoff's semantics."""
+    raw = os.environ.get(REQUEST_ENV)
+    token = os.environ.get(TOKEN_ENV)
+    work = os.environ.get("SPECULA_WORK_DIR")
+    if os.environ.get("SPECULA_PHASE") != "incremental" or not raw or not token or not work:
+        raise ValueError("Context compaction is available only inside an incremental CI run.")
+    root = Path(work).resolve()
+    path = Path(handoff_path)
+    path = (path if path.is_absolute() else root / path).resolve()
+    if not path.is_relative_to(root) or not path.is_file() or path.stat().st_size == 0:
+        raise ValueError("Save a nonempty handoff file inside the CI working directory first.")
+    request = Path(raw)
+    if not request.parent.is_dir():
+        raise ValueError("The CI context controller is no longer available.")
+    write_json(request, {"token": token, "handoff_path": str(path)})
+    yield_instruction = f"end this turn with exactly: {YIELD_PREFIX} {token}"
+    if os.environ.get("SPECULA_CONTEXT_AGENT") == "copilot-cli":
+        yield_instruction = (
+            f"call the native task_complete tool with summary exactly '{YIELD_PREFIX} {token}'. "
+            "This completes only this internal invocation so autopilot stops; the controller will resume the CI task."
+        )
+    return {
+        "status": "requested",
+        "instruction": (
+            "The controller will compact this same conversation after you yield. "
+            "Do not write final CI reports or claim completion. Once outstanding tool results "
+            f"are collected, {yield_instruction}"
+        ),
+    }
+
+
+def mcp_config(python: Path, server: Path, env: dict[str, str]) -> dict[str, Any]:
+    return {
+        "mcpServers": {
+            "specula_context": {
+                "command": str(python),
+                "args": [str(server)],
+                "env": {
+                    key: env[key]
+                    for key in (REQUEST_ENV, TOKEN_ENV, "SPECULA_WORK_DIR", "SPECULA_PHASE", "SPECULA_CONTEXT_AGENT")
+                    if key in env
+                },
+            }
+        }
+    }

--- a/src/specula/context_runner.py
+++ b/src/specula/context_runner.py
@@ -1,0 +1,220 @@
+"""Continue one incremental conversation across explicitly requested compactions."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from specula.adapters.utils.usage import UsageTotals, accumulate_usage
+from specula.context_control import MCP_ENV, PYTHON_ENV, REQUEST_ENV, TOKEN_ENV, YIELD_PREFIX, mcp_config, write_json
+from specula.resource_summary import UsageRecord, _claude_usage, _normalized_usage, _parse_usage_file
+from specula.resumelib import inherited_run_lock_fds
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def tool_environment(directory: Path, work: Path, python: Path, agent: str = "") -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            REQUEST_ENV: str(directory / "request.json"),
+            TOKEN_ENV: secrets.token_hex(16),
+            PYTHON_ENV: str(python),
+            "SPECULA_WORK_DIR": str(work),
+            "SPECULA_CONTEXT_AGENT": agent,
+        }
+    )
+    # Native MCP servers may be launched with a restricted inherited environment.
+    config = mcp_config(python, ROOT / "tools/context_control/mcp_server.py", env)
+    write_json(directory / "mcp.json", config)
+    env[MCP_ENV] = str(directory / "mcp.json")
+    env["SPECULA_CONTEXT_MCP_JSON"] = json.dumps(config)
+    entry = config["mcpServers"]["specula_context"]
+    values = ", ".join(json.dumps(k) + "=" + json.dumps(v) for k, v in entry["env"].items())
+    env["SPECULA_CONTEXT_CODEX_CONFIG"] = (
+        "{command=" + json.dumps(entry["command"]) + ",args=" + json.dumps(entry["args"]) + ",env={" + values + "}}"
+    )
+    return env
+
+
+def compaction_usage(agent: str, receipt: dict[str, Any]) -> UsageRecord | None:
+    if agent == "claude-code" and isinstance(receipt.get("usage_payload"), dict):
+        payload = receipt["usage_payload"]
+        return _claude_usage({**payload, "model_usage": payload.get("modelUsage", {})})
+    totals = UsageTotals()
+    if agent == "pi" and isinstance(receipt.get("pi_usage"), dict):
+        accumulate_usage(
+            "pi", {"type": "message_end", "message": {"role": "assistant", "usage": receipt["pi_usage"]}}, totals
+        )
+    elif agent == "opencode" and isinstance(receipt.get("opencode_usage"), list):
+        for info in receipt["opencode_usage"]:
+            accumulate_usage("opencode", {"type": "step_finish", "part": info}, totals)
+    else:
+        return None
+    return _normalized_usage(totals.as_payload(agent), dict(totals.as_usage()))
+
+
+def publish_usage(path: Path, agent: str, session_id: str | None, records: list[UsageRecord | None]) -> None:
+    observed = [record for record in records if record is not None]
+    if not observed:
+        return
+    complete = all(record is not None and record.complete for record in records)
+    cost_known = all(record is not None and record.cost_usd is not None for record in records)
+    tokens_known = all(record is not None and record.total_tokens is not None for record in records)
+    write_json(
+        path,
+        {
+            "agent": agent,
+            "session_id": session_id,
+            "total_cost_usd": sum(r.cost_usd or 0 for r in observed) if cost_known else None,
+            "usage": {
+                "total_tokens": sum(r.total_tokens or 0 for r in observed) if tokens_known else None,
+                "cached_input_tokens": sum(r.cached_input_tokens or 0 for r in observed) if tokens_known else None,
+            },
+            "usage_complete": complete,
+            "observed_cost_usd": sum(r.cost_usd or 0 for r in observed)
+            if any(r.cost_usd is not None for r in observed)
+            else None,
+            "observed_usage": {
+                "total_tokens": sum(r.total_tokens or 0 for r in observed),
+                "cached_input_tokens": sum(r.cached_input_tokens or 0 for r in observed),
+            },
+            "usage_scope": "CI invocation including context compaction"
+            if complete
+            else "partial; inspect context compaction receipts",
+        },
+    )
+
+
+def run(adapter: Path, arguments: list[str]) -> int:
+    options = dict(arg[2:].split("=", 1) for arg in arguments if arg.startswith("--") and "=" in arg)
+    if os.environ.get("SPECULA_PHASE") != "incremental":
+        return subprocess.call([str(adapter), *arguments], pass_fds=inherited_run_lock_fds())
+    python = ROOT / "tools/context_control/.venv/bin/python"
+    if not python.is_file():
+        print("WARNING: context tool is not installed; run specula setup to enable CI compaction.", flush=True)
+        return subprocess.call([str(adapter), *arguments], pass_fds=inherited_run_lock_fds())
+    work = Path(os.environ["SPECULA_WORK_DIR"]).resolve()
+    log = Path(options["log"])
+    resume = Path(options["resume-state"])
+    usage = log.with_suffix(".usage.json")
+    control = work / ".context-control"
+    try:
+        control.mkdir(exist_ok=True)
+        directory = Path(tempfile.mkdtemp(prefix="invocation-", dir=control))
+        env = tool_environment(directory, work, python, adapter.stem)
+    except OSError as exc:
+        print(f"WARNING: context tool unavailable ({exc}); continuing without compaction.", flush=True)
+        return subprocess.call([str(adapter), *arguments], pass_fds=inherited_run_lock_fds())
+    records: list[UsageRecord | None] = []
+    call_arguments = list(arguments)
+    round_number = 0
+    session_id: str | None = None
+    compacted = False
+    codex_compaction_unpriced = False
+    try:
+        while True:
+            request = Path(env[REQUEST_ENV])
+            request.unlink(missing_ok=True)
+            rc = subprocess.call([str(adapter), *call_arguments], env=env, pass_fds=inherited_run_lock_fds())
+            if usage.is_file():
+                shutil.copy2(usage, directory / f"turn-{round_number + 1}.usage.json")
+            record = _parse_usage_file(work, usage)
+            # Codex's collector reads the whole native session, including prior
+            # turns. Other CLI adapters report the current invocation's usage.
+            if adapter.stem == "codex":
+                records = [record]
+            else:
+                records.append(record)
+            if rc != 0 or not request.is_file():
+                return rc
+            response = log.with_suffix(".last-message.txt") if adapter.stem == "codex" else log
+            expected = f"{YIELD_PREFIX} {env[TOKEN_ENV]}"
+            if response.read_text(errors="replace").strip().splitlines()[-1:] != [expected]:
+                return rc  # Never reinterpret an ordinary final response as a yield.
+            pending = json.loads(request.read_text())
+            if pending.get("token") != env[TOKEN_ENV]:
+                return 1
+            state = json.loads(resume.read_text())
+            if state.get("adapter") != adapter.stem or not state.get("session_id"):
+                raise ValueError("Compaction requires the exact persisted native session")
+            if session_id is not None and session_id != state["session_id"]:
+                raise ValueError("Native conversation changed during compaction")
+            session_id = state["session_id"]
+            round_number += 1
+            archive = directory / str(round_number)
+            archive.mkdir()
+            for suffix in (".log", ".last-message.txt", ".activity.jsonl", ".raw.json", ".usage.json"):
+                source = log.with_suffix(suffix)
+                if source.is_file():
+                    shutil.copy2(source, archive / source.name)
+            shutil.copy2(request, archive / "request.json")
+            receipt_path = archive / "compaction.json"
+            print(f"Context compaction: {adapter.stem}, same session {session_id}", flush=True)
+            helper_env = {**env, "SPECULA_PHASE": "context_compaction"}
+            helper_env.pop(REQUEST_ENV, None)
+            try:
+                with (archive / "control.log").open("w") as output:
+                    subprocess.call(
+                        [
+                            str(python),
+                            str(ROOT / "tools/context_control/compact.py"),
+                            str(resume),
+                            str(receipt_path),
+                            options.get("claude-alias", ""),
+                        ],
+                        env=helper_env,
+                        stdout=output,
+                        stderr=subprocess.STDOUT,
+                        pass_fds=inherited_run_lock_fds(),
+                    )
+            except OSError as exc:
+                write_json(receipt_path, {"status": "failed", "error": str(exc)})
+            try:
+                receipt = json.loads(receipt_path.read_text())
+            except (OSError, ValueError):
+                receipt = {"status": "failed", "error": "Native compactor returned no receipt"}
+            if adapter.stem != "codex":
+                records.append(compaction_usage(adapter.stem, receipt))
+            else:
+                codex_compaction_unpriced = True
+            compacted = True
+            status = receipt.get("status", "failed")
+            print(f"Context compaction {status}; continuing the same CI conversation.", flush=True)
+            if status == "failed" and receipt.get("error"):
+                print("Compaction note: " + str(receipt["error"]).replace("\n", " ")[:240], flush=True)
+            prompt = directory / "continue.md"
+            prompt.write_text(
+                f"Continue the same incremental CI task. Context compaction {status}. "
+                f"First read the saved handoff at {pending['handoff_path']}; then open only evidence needed for the next work. "
+                "Keep unresolved counterexamples, invalidated results and pending checks pending. "
+                "This was an internal pause, not finalization or a new run. "
+                "If compaction failed, continue without repeatedly retrying it. Finish the existing workflow.\n"
+            )
+            call_arguments = [arg for arg in arguments if not arg.startswith(("--prompt=", "--prompt-file="))]
+            call_arguments.append(f"--prompt-file={prompt}")
+    finally:
+        if compacted:
+            publish_usage(usage, adapter.stem, session_id, records + ([None] if codex_compaction_unpriced else []))
+
+
+def main() -> int:
+    try:
+        return run(Path(sys.argv[1]), sys.argv[2:])
+    except (OSError, ValueError, KeyError) as exc:
+        print(f"ERROR: CI context continuation: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/specula/native_compaction.py
+++ b/src/specula/native_compaction.py
@@ -1,0 +1,317 @@
+"""Native compaction between CLI turns; never edit or replace session history."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import importlib
+import json
+import os
+import secrets
+import shutil
+import signal
+import socket
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+from specula.context_control import write_json
+
+
+@contextlib.asynccontextmanager
+async def process(argv: list[str], log: Path, env: dict[str, str] | None = None) -> AsyncIterator[Any]:
+    with log.open("ab") as errors:
+        child = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=errors,
+            env=env,
+            limit=64 * 1024 * 1024,
+        )
+        try:
+            yield child
+        finally:
+            if child.stdin:
+                child.stdin.close()
+            if child.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    child.terminate()
+                try:
+                    await asyncio.wait_for(child.wait(), 5)
+                except asyncio.TimeoutError:
+                    with contextlib.suppress(ProcessLookupError):
+                        child.kill()
+                    await child.wait()
+
+
+class Lines:
+    def __init__(self, child: Any) -> None:
+        self.child = child
+        self.number = 0
+        self.events: list[dict[str, Any]] = []
+
+    async def send(self, value: dict[str, Any]) -> None:
+        self.child.stdin.write((json.dumps(value) + "\n").encode())
+        await self.child.stdin.drain()
+
+    async def receive(self) -> dict[str, Any]:
+        while line := await self.child.stdout.readline():
+            try:
+                event = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(event, dict):
+                return event
+        raise RuntimeError("Native compaction process exited before a completion response")
+
+    async def call(self, method: str, params: dict[str, Any], *, pi: bool = False) -> dict[str, Any]:
+        self.number += 1
+        key = str(self.number)
+        await self.send(
+            {"id": key, "type": method, **params} if pi else {"id": key, "method": method, "params": params}
+        )
+        while True:
+            event = await self.receive()
+            if event.get("id") == key and ("result" in event or "error" in event or pi):
+                if event.get("error") or event.get("success") is False:
+                    raise RuntimeError(str(event.get("error", "Native compaction request failed")))
+                result = event.get("data", {}) if pi else event.get("result", {})
+                if not isinstance(result, dict):
+                    raise RuntimeError("Native control returned an invalid response")
+                return result
+            if "method" in event and "id" in event:
+                # Compaction must not execute user tools or approve new work.
+                await self.send({"id": event["id"], "error": {"code": -32601, "message": "No tools during compaction"}})
+            else:
+                self.events.append(event)
+
+
+async def codex(state: dict[str, Any], log: Path) -> dict[str, Any]:
+    argv = ["codex", "app-server"]
+    if state.get("effort"):
+        argv += ["-c", "model_reasoning_effort=" + json.dumps(state["effort"])]
+    async with process(argv, log) as child:
+        rpc = Lines(child)
+        await rpc.call("initialize", {"clientInfo": {"name": "specula", "version": "1"}})
+        await rpc.send({"method": "initialized", "params": {}})
+        params = {"threadId": state["session_id"], "cwd": state["cwd"]}
+        if state.get("model"):
+            params["model"] = state["model"]
+        resumed = await rpc.call("thread/resume", params)
+        if resumed.get("thread", {}).get("id") != state["session_id"]:
+            raise RuntimeError("Codex resumed a different conversation")
+        rpc.events.clear()
+        await rpc.call("thread/compact/start", {"threadId": state["session_id"]})
+        compacted = False
+        while True:
+            event = rpc.events.pop(0) if rpc.events else await rpc.receive()
+            p = event.get("params", {})
+            if p.get("threadId") != state["session_id"]:
+                continue
+            if event.get("method") == "item/completed" and p.get("item", {}).get("type") == "contextCompaction":
+                compacted = True
+            if event.get("method") == "turn/completed":
+                if not compacted or p.get("turn", {}).get("status") != "completed":
+                    raise RuntimeError("Codex compaction did not complete")
+                return {
+                    "status": "completed",
+                    "evidence": event,
+                    "usage_warning": "Codex compaction reports context size, not billable compaction usage.",
+                }
+
+
+async def claude(state: dict[str, Any], log: Path, alias: str) -> dict[str, Any]:
+    env = os.environ.copy()
+    for key in ("CLAUDECODE", "CLAUDE_CODE_SSE_PORT", "CLAUDE_CODE_ENTRYPOINT"):
+        env.pop(key, None)
+    env["CLAUDE_CONFIG_DIR"] = str(Path.home() / f".{alias or 'claude'}")
+    argv = ["claude", "--print", "--resume", state["session_id"], "--output-format", "stream-json", "--verbose"]
+    if state.get("model"):
+        argv += ["--model", state["model"]]
+    if state.get("effort"):
+        argv += ["--effort", state["effort"]]
+    async with process(argv, log, env) as child:
+        child.stdin.write(b"/compact\n")
+        await child.stdin.drain()
+        child.stdin.close()
+        rpc = Lines(child)
+        boundary = None
+        while True:
+            event = await rpc.receive()
+            if event.get("session_id") not in (None, state["session_id"]):
+                raise RuntimeError("Claude compaction changed session identity")
+            if event.get("type") == "system" and event.get("subtype") == "compact_boundary":
+                boundary = event
+            if event.get("type") == "result":
+                if event.get("is_error") or event.get("subtype") != "success":
+                    raise RuntimeError("Claude compaction failed: " + str(event.get("result", event.get("errors", ""))))
+                return {
+                    "status": "completed" if boundary else "skipped",
+                    "evidence": boundary or event,
+                    "usage_payload": event,
+                }
+
+
+async def pi(state: dict[str, Any], log: Path) -> dict[str, Any]:
+    argv = ["pi", "--mode", "rpc", "--session", state["session_id"]]
+    if state.get("model"):
+        argv += ["--model", state["model"]]
+    if state.get("effort"):
+        argv += ["--thinking", state["effort"]]
+    async with process(argv, log) as child:
+        rpc = Lines(child)
+        current = await rpc.call("get_state", {}, pi=True)
+        if current.get("sessionId") != state["session_id"]:
+            raise RuntimeError("Pi resumed a different conversation")
+        result = await rpc.call("compact", {}, pi=True)
+        if not result.get("summary") or not result.get("firstKeptEntryId"):
+            raise RuntimeError("Pi returned no compaction result")
+        return {"status": "completed", "evidence": result, "pi_usage": result.get("usage")}
+
+
+async def copilot(state: dict[str, Any], log: Path) -> dict[str, Any]:
+    # Installed by tools/context_control/requirements.txt, not needed by other paths.
+    sdk = importlib.import_module("copilot")
+    client: Any = sdk.CopilotClient(
+        connection=sdk.RuntimeConnection.for_stdio(path=shutil.which("copilot") or "copilot"),
+        working_directory=state["cwd"],
+        log_level="error",
+    )
+    events: list[dict[str, Any]] = []
+    try:
+        await client.start()
+        session = await client.resume_session(
+            state["session_id"],
+            model=state.get("model") or None,
+            reasoning_effort=state.get("effort") or None,
+            working_directory=state["cwd"],
+        )
+        session.on(lambda event: events.append(event.to_dict()) if "compaction" in str(event.type).lower() else None)
+        try:
+            result = await session.rpc.history.compact()
+            evidence = result.to_dict()
+        except Exception as exc:
+            return {"status": "failed", "error": f"{type(exc).__name__}: {exc}", "events": events}
+        return {
+            "status": "completed" if evidence.get("success") is True else "failed",
+            "evidence": evidence,
+            "events": events,
+        }
+    finally:
+        await client.force_stop()
+
+
+async def opencode(state: dict[str, Any], log: Path) -> dict[str, Any]:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    password = secrets.token_urlsafe(24)
+    env = {
+        **os.environ,
+        "OPENCODE_SERVER_PASSWORD": password,
+        "OPENCODE_SERVER_USERNAME": "opencode",
+        "OPENCODE_FAKE_VCS": "git",
+    }
+    auth = base64.b64encode(f"opencode:{password}".encode()).decode()
+    base = f"http://127.0.0.1:{port}"
+
+    def request(path: str, body: Any = None) -> Any:
+        req = urllib.request.Request(
+            base + path,
+            headers={
+                "Authorization": "Basic " + auth,
+                "Content-Type": "application/json",
+                "x-opencode-directory": state["cwd"],
+            },
+            data=json.dumps(body).encode() if body is not None else None,
+        )
+        with log.open("a") as stream:
+            stream.write(f"OpenCode control: {path}\n")
+        with urllib.request.urlopen(req, timeout=180 if path.endswith("/summarize") else 10) as response:
+            return json.loads(response.read() or b"null")
+
+    async with process(["opencode", "serve", "--hostname", "127.0.0.1", "--port", str(port)], log, env) as child:
+        # Drain the server banner so its stdout can never fill while serving HTTP.
+        drain = asyncio.create_task(child.stdout.read())
+        try:
+            for _ in range(100):
+                try:
+                    await asyncio.to_thread(request, "/global/health")
+                    break
+                except (OSError, urllib.error.URLError):
+                    if child.returncode is not None:
+                        raise RuntimeError("OpenCode server exited") from None
+                    await asyncio.sleep(0.1)
+            else:
+                raise RuntimeError("OpenCode server did not become ready")
+            prefix = "/session/" + state["session_id"]
+            current = await asyncio.to_thread(request, prefix)
+            if current.get("id") != state["session_id"]:
+                raise RuntimeError("OpenCode resumed a different conversation")
+            before = await asyncio.to_thread(request, prefix + "/message")
+            model = state.get("model", "")
+            if not model or "/" not in model:
+                assistants = [m["info"] for m in before if m.get("info", {}).get("role") == "assistant"]
+                if not assistants:
+                    raise RuntimeError("OpenCode has no previous model to compact with")
+                provider, model_id = assistants[-1]["providerID"], assistants[-1]["modelID"]
+            else:
+                provider, model_id = model.split("/", 1)
+            known = {m["info"]["id"] for m in before}
+            await asyncio.to_thread(request, prefix + "/summarize", {"providerID": provider, "modelID": model_id})
+            after = await asyncio.to_thread(request, prefix + "/message")
+            added = [m["info"] for m in after if m["info"]["id"] not in known and m["info"].get("role") == "assistant"]
+            completed = [
+                m for m in added if m.get("summary") and not m.get("error") and m.get("time", {}).get("completed")
+            ]
+            if not completed:
+                raise RuntimeError("OpenCode produced no completed compaction checkpoint")
+            return {"status": "completed", "evidence": completed, "opencode_usage": added}
+        finally:
+            drain.cancel()
+
+
+async def compact(state: dict[str, Any], log: Path, alias: str = "") -> dict[str, Any]:
+    if not state.get("session_id") or not state.get("cwd"):
+        raise ValueError("An existing native session is required")
+    agent = state["adapter"]
+    if agent == "claude-code":
+        return await claude(state, log, alias)
+    functions = {"codex": codex, "pi": pi, "opencode": opencode, "copilot-cli": copilot}
+    if agent not in functions:
+        raise ValueError(f"Native compaction is not available for {agent}")
+    return await functions[agent](state, log)
+
+
+async def managed_compact(state: dict[str, Any], log: Path, alias: str) -> dict[str, Any]:
+    task = asyncio.current_task()
+    assert task is not None
+    loop = asyncio.get_running_loop()
+    loop.add_signal_handler(signal.SIGTERM, task.cancel)
+    try:
+        return await asyncio.wait_for(compact(state, log, alias), 300)
+    except asyncio.CancelledError:
+        return {"status": "failed", "error": "Compaction interrupted"}
+    finally:
+        loop.remove_signal_handler(signal.SIGTERM)
+
+
+def main() -> int:
+    state_file, receipt_file, alias = sys.argv[1:4]
+    receipt = Path(receipt_file)
+    try:
+        state = json.loads(Path(state_file).read_text())
+        result = asyncio.run(managed_compact(state, receipt.with_suffix(".log"), alias))
+    except Exception as exc:
+        result = {"status": "failed", "error": f"{type(exc).__name__}: {exc}"}
+    write_json(receipt, result)
+    return 0  # The caller continues the existing conversation even on failure.
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -1565,17 +1565,20 @@ class Phase:
                 attempt=invocation_attempt,
                 archived_usage_path=archived_attempts.get(usage_path),
             )
+            command = [
+                str(adapter),
+                f"--prompt-file={files['prompt']}",
+                f"--max-turns={max_turns}",
+                f"--claude-alias={claude_alias}",
+                *_model_effort_argv(adapter, self._model, self._effort),
+                f"--log={files['log']}",
+                f"--resume-state={resume_state}",
+                "--background",
+            ]
+            if self.key == "incremental":
+                command = [sys.executable, str(SCRIPT_DIR / "context_runner.py"), *command]
             proc = subprocess.Popen(
-                [
-                    str(adapter),
-                    f"--prompt-file={files['prompt']}",
-                    f"--max-turns={max_turns}",
-                    f"--claude-alias={claude_alias}",
-                    *_model_effort_argv(adapter, self._model, self._effort),
-                    f"--log={files['log']}",
-                    f"--resume-state={resume_state}",
-                    "--background",
-                ],
+                command,
                 env=env,
                 cwd=launch_cwd,
                 start_new_session=True,

--- a/src/specula/prompts/incremental.md
+++ b/src/specula/prompts/incremental.md
@@ -5,6 +5,12 @@ workflow in one continuous session: generation, trace validation, model checking
 and reproduction when an actual counterexample requires it. Apply the referenced
 Specula methods. You own the analysis, planning, repairs, and verification loop.
 
+For long conversations, follow the skill's context-preservation guidance. The
+`request_context_compaction` tool can yield an internal turn after you save a
+handoff; the controller resumes this same session. Such a yield is not completion
+of the workflow and does not require final reports. Compaction is optional; failure
+does not prevent continuing the task.
+
 ## Inputs
 
 - Original source update (before instrumentation): {{source_diff}}

--- a/tests/e2e/test_incremental_ci.py
+++ b/tests/e2e/test_incremental_ci.py
@@ -6,7 +6,9 @@ The fixture does not perform semantic verification or call an LLM.
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
+import sys
 import unittest
 from pathlib import Path
 
@@ -73,6 +75,44 @@ class IncrementalCLI(unittest.TestCase):
     def change_source(self, text: str) -> None:
         (self.source / "logic.txt").write_text(text)
         self.commit("update")
+
+    def test_compaction_yield_does_not_publish_and_failure_continues(self) -> None:
+        self.initialize()
+        previous = (self.ci / "current").resolve()
+        original_assets = asset_hashes(previous)
+        tool = self.root / "tools/context_control"
+        (tool / ".venv/bin").mkdir(parents=True)
+        (tool / ".venv/bin/python").symlink_to(sys.executable)
+        shutil.copy2(fixtures.REAL_ROOT / "tools/context_control/compact.py", tool / "compact.py")
+        # The real controller calls the native compactor, which reports that
+        # this fixture-only backend has no native compaction API.
+        script = self.adapter.read_text().replace(
+            "  incremental)\n",
+            "  incremental)\n"
+            '    if [ ! -f "$0.context-yielded" ]; then\n'
+            f'      test "$(readlink -f "{self.ci}/current")" = "{previous}"\n'
+            '      printf "Pending fixture check; no semantic verification performed.\\n" > "$SPECULA_WORK_DIR/ci-context.md"\n'
+            '      python3 -c \'import json,os,sys; from pathlib import Path; sys.path.insert(0,os.environ["SPECULA_ROOT"]+"/src"); '
+            "from specula.context_control import request_compaction; "
+            'Path(sys.argv[1]).write_text(json.dumps({"adapter":"fake","session_id":"fixture-context-session","cwd":os.getcwd()})); '
+            'request_compaction("ci-context.md")\' "$resume"\n'
+            '      printf "SPECULA_CONTEXT_YIELD %s\\n" "$SPECULA_CONTEXT_TOKEN" > "$log"\n'
+            '      touch "$0.context-yielded"\n'
+            "      exit 0\n"
+            "    fi\n",
+        )
+        self.adapter.write_text(script)
+        self.change_source("changed\n")
+        result = self.run_ci("--incremental", "--agent=fake")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Context compaction failed; continuing", result.stdout)
+        self.assertNotEqual((self.ci / "current").resolve(), previous)
+        self.assertEqual(asset_hashes(previous), original_assets)
+        state = json.loads(Path(f"{self.adapter}.resumed").read_text())
+        self.assertEqual(state["session_id"], "fixture-context-session")
+        work = self.latest() / "footest/.specula-output"
+        self.assertEqual(len(list(work.glob(".context-control/*/1/compaction.json"))), 1)
+        self.assertFalse((self.ci / "current/model/.context-control").exists())
 
     def latest(self) -> Path:
         return (self.ci / "runs/latest").resolve()

--- a/tests/unit/test_context_control.py
+++ b/tests/unit/test_context_control.py
@@ -1,0 +1,383 @@
+"""CI context requests and native completion protocols; no paid model calls."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from specula import context_control as control
+from specula import context_runner as runner
+from specula import native_compaction as native
+from specula.adapters.utils import event_stream
+
+
+def configure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.setenv("SPECULA_PHASE", "incremental")
+    monkeypatch.setenv("SPECULA_WORK_DIR", str(work))
+    monkeypatch.setenv(control.REQUEST_ENV, str(tmp_path / "request.json"))
+    monkeypatch.setenv(control.TOKEN_ENV, "this-invocation")
+    return work
+
+
+def test_request_requires_saved_handoff_but_not_a_semantic_schema(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    work = configure(monkeypatch, tmp_path)
+    with pytest.raises(ValueError, match="handoff"):
+        control.request_compaction("missing.md")
+    (work / "handoff.md").write_text("Pending counterexample. Final regression has not run.\n")
+    result = control.request_compaction("handoff.md")
+    assert result["status"] == "requested"
+    assert control.YIELD_PREFIX in result["instruction"]
+    saved = json.loads((tmp_path / "request.json").read_text())
+    assert saved == {"token": "this-invocation", "handoff_path": str(work / "handoff.md")}
+    outside = tmp_path / "outside.md"
+    outside.write_text("unrelated")
+    with pytest.raises(ValueError):
+        control.request_compaction(str(outside))
+    monkeypatch.setenv("SPECULA_PHASE", "code_analysis")
+    with pytest.raises(ValueError, match="incremental"):
+        control.request_compaction("handoff.md")
+
+
+def test_request_keeps_two_invocations_separate(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    work = configure(monkeypatch, tmp_path)
+    (work / "handoff.md").write_text("important")
+    for name in ("first", "second"):
+        directory = tmp_path / name
+        directory.mkdir()
+        env = runner.tool_environment(directory, work, Path(sys.executable))
+        with monkeypatch.context() as scoped:
+            for key, value in env.items():
+                scoped.setenv(key, value)
+            control.request_compaction("handoff.md")
+        assert json.loads((directory / "request.json").read_text())["token"] == env[control.TOKEN_ENV]
+    assert (tmp_path / "first/request.json").read_text() != (tmp_path / "second/request.json").read_text()
+
+
+@pytest.mark.asyncio
+async def test_mcp_discovery_and_real_tool_call(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    work = configure(monkeypatch, tmp_path)
+    (work / "handoff.md").write_text("Unresolved evidence stays unresolved.")
+    server = Path(control.__file__).resolve().parents[2] / "tools/context_control/mcp_server.py"
+    params = StdioServerParameters(command=sys.executable, args=[str(server)], env=dict(os.environ))
+    async with stdio_client(params) as (reader, writer), ClientSession(reader, writer) as session:
+        await session.initialize()
+        listed = await session.list_tools()
+        assert [tool.name for tool in listed.tools] == [control.TOOL_NAME]
+        result = await session.call_tool(control.TOOL_NAME, {"handoff_path": "handoff.md"})
+        assert not result.isError
+    assert json.loads((tmp_path / "request.json").read_text())["handoff_path"] == str(work / "handoff.md")
+
+
+@pytest.mark.parametrize("agent", ["codex", "claude-code", "pi", "opencode", "copilot-cli"])
+@pytest.mark.parametrize("outcome", ["completed", "failed"])
+@pytest.mark.parametrize("native_failure", [False, True])
+def test_internal_yield_compacts_and_continues_original_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    agent: str,
+    outcome: str,
+    native_failure: bool,
+) -> None:
+    work = configure(monkeypatch, tmp_path)
+    monkeypatch.setattr(runner, "ROOT", tmp_path)
+    monkeypatch.delenv("SPECULA_RUN_DIR", raising=False)
+    tool = tmp_path / "tools/context_control"
+    (tool / ".venv/bin").mkdir(parents=True)
+    (tool / ".venv/bin/python").symlink_to(sys.executable)
+    (tool / "compact.py").write_text(
+        "import json,sys\nfrom pathlib import Path\n"
+        "state=json.loads(Path(sys.argv[1]).read_text())\n"
+        "assert state['session_id']=='original-session'\n"
+        f"Path(sys.argv[2]).write_text(json.dumps({{'status':{outcome!r}, 'usage_in_native_session': True}}))\n"
+    )
+    real_src = Path(control.__file__).resolve().parents[1]
+    adapter = tmp_path / f"{agent}.sh"
+    adapter.write_text(
+        f"#!{sys.executable}\n"
+        "import json,os,sys\nfrom pathlib import Path\n"
+        f"sys.path.insert(0,{str(real_src)!r})\n"
+        "from specula.context_control import request_compaction\n"
+        "opts=dict(x[2:].split('=',1) for x in sys.argv[1:] if x.startswith('--') and '=' in x)\n"
+        "work=Path(os.environ['SPECULA_WORK_DIR']); log=Path(opts['log']); resume=Path(opts['resume-state'])\n"
+        "second=resume.exists()\n"
+        "if second:\n"
+        " assert json.loads(resume.read_text())['session_id']=='original-session'\n"
+        " assert 'First read the saved handoff' in Path(opts['prompt-file']).read_text()\n"
+        " assert (work/'ci-context.md').read_text()=='Unresolved cex: do not mark passed.'\n"
+        " response='SPECULA_INCREMENTAL_COMPLETE test-run'\n"
+        "else:\n"
+        f" resume.write_text(json.dumps({{'adapter':{agent!r},'session_id':'original-session','cwd':{str(tmp_path)!r}}}))\n"
+        " (work/'ci-context.md').write_text('Unresolved cex: do not mark passed.')\n"
+        " request_compaction('ci-context.md')\n"
+        " response='SPECULA_CONTEXT_YIELD '+os.environ['SPECULA_CONTEXT_TOKEN']\n"
+        "log.write_text(response+'\\n'); log.with_suffix('.last-message.txt').write_text(response+'\\n')\n"
+        f"log.with_suffix('.usage.json').write_text(json.dumps({{'agent':{agent!r},'session_id':'original-session','total_cost_usd':2.0 if second else 1.0,'usage':{{'total_tokens':200 if second else 100,'cached_input_tokens':20 if second else 10}}}}))\n"
+        f"raise SystemExit(9 if second and {native_failure!r} else 0)\n"
+    )
+    adapter.chmod(0o755)
+    prompt = work / "prompt.md"
+    prompt.write_text("Original task")
+    log = work / "incremental.log"
+    args = [f"--log={log}", f"--resume-state={work / 'incremental.resume.json'}", f"--prompt-file={prompt}"]
+    # A real execution failure still wins over a final-looking model response.
+    assert runner.run(adapter, args) == (9 if native_failure else 0)
+    assert log.read_text().strip() == "SPECULA_INCREMENTAL_COMPLETE test-run"
+    receipts = list(work.glob(".context-control/invocation-*/1/compaction.json"))
+    assert len(receipts) == 1
+    assert json.loads(receipts[0].read_text())["status"] == outcome
+    assert json.loads((work / "incremental.resume.json").read_text())["session_id"] == "original-session"
+    usage = json.loads(log.with_suffix(".usage.json").read_text())
+    if agent == "codex":
+        assert usage["observed_cost_usd"] == 2.0  # Not 1 + 2: native cumulative accounting.
+        assert usage["observed_usage"]["total_tokens"] == 200
+        assert usage["usage_complete"] is False  # Native compaction's billable usage is unavailable.
+    else:
+        assert usage["usage_complete"] is False  # The fixture did not provide compaction usage.
+        assert usage["total_cost_usd"] is None
+
+
+def test_accounting_includes_compaction_and_does_not_invent_missing_cost(tmp_path: Path) -> None:
+    receipt = {"pi_usage": {"input": 10, "output": 4, "cacheRead": 6, "cost": {"total": 0.2}}}
+    row = runner.compaction_usage("pi", receipt)
+    assert row is not None and row.total_tokens == 20 and row.cost_usd == 0.2
+    target = tmp_path / "usage.json"
+    runner.publish_usage(target, "pi", "id", [row, row])
+    assert json.loads(target.read_text())["total_cost_usd"] == 0.4
+    runner.publish_usage(target, "pi", "id", [row, None])
+    assert json.loads(target.read_text())["total_cost_usd"] is None
+    assert json.loads(target.read_text())["observed_cost_usd"] == 0.2
+    assert json.loads(target.read_text())["usage_complete"] is False
+
+
+def test_copilot_autopilot_yield_uses_successful_native_completion(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    work = configure(monkeypatch, tmp_path)
+    monkeypatch.setenv("SPECULA_CONTEXT_AGENT", "copilot-cli")
+    (work / "handoff.md").write_text("Pending")
+    result = control.request_compaction("handoff.md")
+    assert "task_complete" in result["instruction"]
+    record = {"type": "session.task_complete", "data": {"success": True, "summary": "SPECULA_CONTEXT_YIELD token"}}
+    assert event_stream._copilot_events(record, False)[0].text == "SPECULA_CONTEXT_YIELD token"
+    record["data"] = {"success": False, "summary": "SPECULA_CONTEXT_YIELD token"}
+    assert not event_stream._copilot_events(record, False)
+    monkeypatch.setenv("SPECULA_PHASE", "code_analysis")
+    record["data"] = {"success": True, "summary": "SPECULA_CONTEXT_YIELD token"}
+    assert not event_stream._copilot_events(record, False)
+
+
+class Input:
+    def __init__(self, output: asyncio.StreamReader, handler: Any) -> None:
+        self.output = output
+        self.handler = handler
+        self.messages: list[Any] = []
+
+    def write(self, raw: bytes) -> None:
+        message = json.loads(raw) if raw.lstrip().startswith(b"{") else raw.decode().strip()
+        self.messages.append(message)
+        for response in self.handler(message):
+            self.output.feed_data((json.dumps(response) + "\n").encode())
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def mock_process(monkeypatch: pytest.MonkeyPatch, handler: Any) -> tuple[list[list[str]], list[Input]]:
+    commands: list[list[str]] = []
+    inputs: list[Input] = []
+
+    @contextlib.asynccontextmanager
+    async def fake(argv: list[str], _log: Path, _env: Any = None) -> Any:
+        commands.append(argv)
+        output = asyncio.StreamReader()
+        stdin = Input(output, handler)
+        inputs.append(stdin)
+        yield SimpleNamespace(stdin=stdin, stdout=output, returncode=None)
+
+    monkeypatch.setattr(native, "process", fake)
+    return commands, inputs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("finished", [True, False])
+async def test_codex_requires_actual_compaction_completion(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    finished: bool,
+) -> None:
+    def handler(m: dict[str, Any]) -> list[dict[str, Any]]:
+        if m["method"] == "initialized":
+            return []
+        result = {"thread": {"id": "original"}} if m["method"] == "thread/resume" else {}
+        messages = [{"id": m["id"], "result": result}]
+        if m["method"] == "thread/compact/start":
+            if finished:
+                messages.append(
+                    {
+                        "method": "item/completed",
+                        "params": {"threadId": "original", "item": {"type": "contextCompaction"}},
+                    }
+                )
+            messages.append(
+                {"method": "turn/completed", "params": {"threadId": "original", "turn": {"status": "completed"}}}
+            )
+        return messages
+
+    _, inputs = mock_process(monkeypatch, handler)
+    state = {"session_id": "original", "cwd": str(tmp_path), "model": "selected-model", "effort": "high"}
+    if finished:
+        result = await native.codex(state, tmp_path / "log")
+        assert result["status"] == "completed"
+    else:
+        with pytest.raises(RuntimeError, match="did not complete"):
+            await native.codex(state, tmp_path / "log")
+    assert all(m.get("method") != "thread/start" for m in inputs[0].messages)
+    resume = next(m for m in inputs[0].messages if m.get("method") == "thread/resume")
+    assert resume["params"]["model"] == "selected-model"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", [True, False])
+async def test_claude_distinguishes_noop_from_completed_compaction(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    boundary: bool,
+) -> None:
+    def handler(_m: Any) -> list[dict[str, Any]]:
+        records = [{"type": "system", "subtype": "compact_boundary", "session_id": "original"}] if boundary else []
+        return records + [{"type": "result", "subtype": "success", "session_id": "original", "total_cost_usd": 0.1}]
+
+    commands, inputs = mock_process(monkeypatch, handler)
+    result = await native.claude({"session_id": "original"}, tmp_path / "log", "alias")
+    assert result["status"] == ("completed" if boundary else "skipped")
+    assert commands[0][commands[0].index("--resume") + 1] == "original"
+    assert inputs[0].messages == ["/compact"]
+
+
+@pytest.mark.asyncio
+async def test_pi_native_rpc_preserves_session_and_returns_compaction_usage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def handler(m: dict[str, Any]) -> list[dict[str, Any]]:
+        data = (
+            {"sessionId": "original"}
+            if m["type"] == "get_state"
+            else {
+                "summary": "Pending check remains pending",
+                "firstKeptEntryId": "entry",
+                "usage": {"input": 12},
+            }
+        )
+        return [{"id": m["id"], "type": "response", "command": m["type"], "success": True, "data": data}]
+
+    commands, inputs = mock_process(monkeypatch, handler)
+    result = await native.pi({"session_id": "original", "effort": "high"}, tmp_path / "log")
+    assert result["status"] == "completed" and result["pi_usage"] == {"input": 12}
+    assert [m["type"] for m in inputs[0].messages] == ["get_state", "compact"]
+    assert "original" in commands[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("success", [True, False])
+async def test_copilot_obeys_native_success_not_just_rpc_return(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    success: bool,
+) -> None:
+    session = SimpleNamespace(
+        on=lambda callback: None,
+        rpc=SimpleNamespace(
+            history=SimpleNamespace(
+                compact=AsyncMock(return_value=SimpleNamespace(to_dict=lambda: {"success": success}))
+            )
+        ),
+    )
+    client = SimpleNamespace(start=AsyncMock(), resume_session=AsyncMock(return_value=session), force_stop=AsyncMock())
+    sdk = SimpleNamespace(
+        CopilotClient=lambda **kwargs: client, RuntimeConnection=SimpleNamespace(for_stdio=lambda **kwargs: None)
+    )
+    monkeypatch.setattr(importlib, "import_module", lambda name: sdk)
+    result = await native.copilot({"session_id": "original", "cwd": str(tmp_path)}, tmp_path / "log")
+    assert result["status"] == ("completed" if success else "failed")
+    client.resume_session.assert_awaited_once_with(
+        "original", model=None, reasoning_effort=None, working_directory=str(tmp_path)
+    )
+    client.force_stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("checkpoint", [True, False])
+async def test_opencode_checks_new_native_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    checkpoint: bool,
+) -> None:
+    mock_process(monkeypatch, lambda _: [])
+    calls: list[Any] = []
+    count = 0
+
+    def urlopen(request: Any, timeout: int) -> Any:
+        nonlocal count
+        calls.append(request)
+        url = request.full_url
+        if url.endswith("/global/health"):
+            value: Any = {"healthy": True}
+        elif url.endswith("/session/original"):
+            value = {"id": "original"}
+        elif url.endswith("/summarize"):
+            assert json.loads(request.data) == {"providerID": "provider", "modelID": "model"}
+            value = True
+        else:
+            count += 1
+            value = [{"info": {"id": "old", "role": "assistant"}}]
+            if count > 1 and checkpoint:
+                value.append(
+                    {
+                        "info": {
+                            "id": "new",
+                            "role": "assistant",
+                            "summary": True,
+                            "time": {"completed": 1},
+                            "tokens": {},
+                            "cost": 0.1,
+                        }
+                    }
+                )
+        return contextlib.nullcontext(SimpleNamespace(read=lambda: json.dumps(value).encode()))
+
+    monkeypatch.setattr(urllib.request, "urlopen", urlopen)
+    if checkpoint:
+        result = await native.opencode(
+            {"session_id": "original", "model": "provider/model", "cwd": str(tmp_path)}, tmp_path / "log"
+        )
+        assert result["status"] == "completed"
+    else:
+        with pytest.raises(RuntimeError, match="checkpoint"):
+            await native.opencode(
+                {"session_id": "original", "model": "provider/model", "cwd": str(tmp_path)}, tmp_path / "log"
+            )
+    assert all("127.0.0.1" in c.full_url for c in calls)
+    assert all(c.get_header("Authorization") for c in calls)

--- a/tests/unit/test_setup_security.py
+++ b/tests/unit/test_setup_security.py
@@ -158,12 +158,16 @@ class TestSetupAgentDetection(unittest.TestCase):
             Path("tools/cfa"),
             Path("tools/spec_analyzer"),
             Path("tools/inv_checking_tool"),
+            Path("tools/context_control"),
             Path("skills"),
             Path("lib"),
         ):
             (root / relative).mkdir(parents=True)
         (root / "lib/tla2tools.jar").touch()
         (root / "lib/CommunityModules-deps.jar").touch()
+        shutil.copy2(
+            REPO_ROOT / "tools/context_control/requirements.txt", root / "tools/context_control/requirements.txt"
+        )
 
         home = root / "home"
         home.mkdir()
@@ -271,6 +275,16 @@ printf '\\n' >> "$FAKE_COMMAND_LOG"
         self.assertNotIn("claude\tmcp", commands)
         self.assertNotIn("codex\tmcp", commands)
         self.assertNotIn("copilot\tmcp", commands)
+
+    def test_opencode_and_pi_setup_include_context_dependencies_and_skills(self) -> None:
+        for agent, destination in (("opencode", ".config/opencode/skills"), ("pi", ".pi/agent/skills")):
+            with self.subTest(agent=agent), tempfile.TemporaryDirectory() as tmp:
+                result, commands = self.run_setup(Path(tmp), {agent}, "y\n")
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("tools/context_control/requirements.txt", commands)
+                self.assertIn("src/specula/skill_install.py", commands)
+                self.assertIn(destination, commands)
+                self.assertIn("registered automatically for incremental runs", result.stdout)
 
     def test_only_agents_on_path_are_prompted(self) -> None:
         for installed_agent in self.AGENT_PROMPTS:

--- a/tools/context_control/compact.py
+++ b/tools/context_control/compact.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Run the selected native compactor with the installed context-tool dependencies."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from specula.native_compaction import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/context_control/mcp_server.py
+++ b/tools/context_control/mcp_server.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Expose the CI context request without taking ownership of the native session."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from mcp.server.fastmcp import FastMCP
+
+from specula.context_control import TOOL_DESCRIPTION, request_compaction
+
+server = FastMCP("specula_context")
+
+
+@server.tool(description=TOOL_DESCRIPTION)
+def request_context_compaction(handoff_path: str) -> dict[str, str]:
+    return request_compaction(handoff_path)
+
+
+if __name__ == "__main__":
+    server.run()

--- a/tools/context_control/pi-extension.js
+++ b/tools/context_control/pi-extension.js
@@ -1,0 +1,23 @@
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export default function (pi) {
+  if (process.env.SPECULA_PHASE !== "incremental" || !process.env.SPECULA_CONTEXT_REQUEST) return;
+  pi.registerTool({
+    name: "request_context_compaction",
+    label: "Request context compaction",
+    description: "After saving a Markdown handoff and collecting outstanding tool results, request compaction of this CI conversation. Follow the returned yield instructions; this is not CI completion.",
+    parameters: {
+      type: "object",
+      properties: { handoff_path: { type: "string" } },
+      required: ["handoff_path"],
+      additionalProperties: false,
+    },
+    async execute(_id, params) {
+      const output = execFileSync(process.env.SPECULA_CONTEXT_PYTHON, [
+        fileURLToPath(new URL("request.py", import.meta.url)), params.handoff_path,
+      ], { encoding: "utf8" });
+      return { content: [{ type: "text", text: output }], details: {} };
+    },
+  });
+}

--- a/tools/context_control/request.py
+++ b/tools/context_control/request.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Pi's tool bridge to the same CI-scoped request handler as MCP."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from specula.context_control import request_compaction
+
+if __name__ == "__main__":
+    print(json.dumps(request_compaction(sys.argv[1])))

--- a/tools/context_control/requirements.txt
+++ b/tools/context_control/requirements.txt
@@ -1,0 +1,2 @@
+mcp>=1.28.1,<2
+github-copilot-sdk==1.0.13; python_version >= "3.11"


### PR DESCRIPTION
## Summary

- Add an incremental-CI-only context request tool, with MCP registration or a Pi extension supplied automatically per run.
- Save a short run-local handoff, yield an internal turn, compact the existing native conversation, and resume it without publishing a baseline at the yield boundary.
- Add native controls for Codex, Claude Code, OpenCode, Pi, and Copilot. Compaction failure continues the original conversation; ordinary execution failures remain failures.
- Integrate dependencies and skill discovery with setup, preserve per-turn evidence and usage, and mark unavailable compaction costs as incomplete.

Initialization, ordinary one-shot execution, and the existing verification/publication criteria are unchanged. This does not include the separate final-report workflow optimization.


## Current limitations

- Copilot's experimental manual-compaction API returned HTTP 400 (requested model not supported) for the available model configuration in the test account. Its native success path is covered by protocol fixtures, not claimed as a successful live compaction.
- Codex does not expose billable compaction usage through this control interface. Observed ordinary-turn usage is retained, but the combined cost is marked incomplete rather than treating compaction as free.
