### PR TITLE
Streamline incremental CI final reporting

### DIFF
--- a/skills/incremental-modeling/guide.md
+++ b/skills/incremental-modeling/guide.md
@@ -6,33 +6,13 @@ The workflow has four parts under `references/`: `generation/`, `validation/`, `
 
 ## Preserve Context Across Long CI Runs
 
-Consider `request_context_compaction` when a coherent unit of analysis or repair
-has reached a stable stopping point, its essential state can be handed off briefly,
-and there has been substantive progress since the previous compaction. Do not wait
-for a full context window or compact at every stage by default. Do not interrupt an
-active derivation or counterexample diagnosis to compact; when repeated attempts
-make no progress, diagnose the stall rather than using compaction as a reset.
+Consider `request_context_compaction` when a coherent unit of analysis or repair has reached a stable stopping point, its essential state can be handed off briefly, and there has been substantive progress since the previous compaction. Do not wait for a full context window or compact at every stage by default. Do not interrupt an active derivation or counterexample diagnosis to compact; when repeated attempts make no progress, diagnose the stall rather than using compaction as a reset.
 
-Before requesting it, update the actual artifacts and write a short
-`.context-control/ci-context.md` in the working directory. This is run-local
-working memory, not a reusable baseline result. Preserve current source/model identity,
-important modeling decisions and evidence paths, key failed approaches and their
-reasons, valid versus invalidated checks, unresolved counterexamples, pending work,
-and the next step. Remove repetitive exploration, not uncertain items: retain their
-unresolved or unverified status. Review that handoff yourself; do not replace it
-with a copied transcript or a rigid change contract.
+Before requesting it, update the actual artifacts and write a short `.context-control/ci-context.md` in the working directory. This is run-local working memory, not a reusable baseline result. Preserve current source/model identity, important modeling decisions and evidence paths, key failed approaches and their reasons, valid versus invalidated checks, unresolved counterexamples, pending work, and the next step. Remove repetitive exploration, not uncertain items: retain their unresolved or unverified status. Review that handoff yourself; do not replace it with a copied transcript or a rigid change contract.
 
-Collect outstanding tool results before yielding; native terminal handles may
-not survive the pause. Keep durable commands/logs for any externally managed work.
-Call the tool with the handoff path and follow its yield instruction. This is an
-internal pause, not CI completion: do not finalize reports or emit the CI completion
-marker. The controller compacts and resumes the same native conversation.
+Collect outstanding tool results before yielding; native terminal handles may not survive the pause. Keep durable commands/logs for any externally managed work. Call the tool with the handoff path and follow its yield instruction. This is an internal pause, not CI completion: do not finalize reports or emit the CI completion marker. The controller compacts and resumes the same native conversation.
 
-After continuation, read the handoff first and reopen evidence as needed, not all
-historical logs. Keep unresolved or invalidated work pending. If the tool is absent,
-or compaction fails, continue the existing task without repeatedly requesting it.
-This optional CI capability does not apply to initialization or ordinary one-shot
-runs and does not change any verification or reproduction requirement below.
+After continuation, read the handoff first and reopen evidence as needed, not all historical logs. Keep unresolved or invalidated work pending. If the tool is absent, or compaction fails, continue the existing task without repeatedly requesting it. This optional CI capability does not apply to initialization or ordinary one-shot runs and does not change any verification or reproduction requirement below.
 
 Timing guidance adapted from [SelfCompact](https://arxiv.org/html/2606.23525v2#S3).
 
@@ -136,34 +116,11 @@ When Part 3 produces an actual counterexample, enter through `references/reprodu
 
 ## Readiness and Final Reporting
 
-Keep required stage artifacts current as you work: decisions, checks, counterexamples,
-repairs, and reproduction outcomes belong in their existing records. Do not defer
-evidence until the end or repeatedly rewrite complete reports to finish a turn.
+Keep required stage evidence current. Before final reporting, briefly check readiness against the applicable completion rules in Parts 1–4 and the current artifacts; no separate checklist is needed.
 
-Before final reporting, briefly check the existing evidence yourself. Applicable
-trace validation, MC/simulation, and reproduction must have explicit outcomes; all
-started work must have been observed; no required work or counterexample disposition
-may remain unresolved. Evidence must apply to the final artifacts, with invalidated
-checks rerun where required. Use Part 3's budgeted completion rules: exhaustive
-exploration is not required, and a confirmed real code bug does not itself block
-completion. This is a reasoning step, not a separate checklist file or reviewer.
+If work remains, continue it. If blocked or interrupted, save a brief handoff instead of a final report. On resume, continue from saved progress and any partial report; recheck evidence invalidated by later changes.
 
-If work remains, continue the relevant phase before reporting. If genuinely blocked
-or interrupted, save brief progress, evidence paths, unresolved items, and the next
-step in the existing records or handoff, then explain the interruption briefly.
-Do not write a final CI report or claim completion merely to end the conversation.
-
-Once ready, write `ci-report.md` as the single human-facing wrap-up: modeling
-decision and changes, verification results, important findings, and limits, with
-links to existing evidence. A few lines suffice for an uneventful update. Preserve
-required stage reports and machine artifacts, but do not duplicate them or rebuild
-the one-shot reporting bundle. Leave resource summaries and cost calculation to
-the existing tools.
-
-Finalize once for the same candidate. On resume, continue valid completed work
-and any partial report in place. If later changes invalidate evidence or conclusions,
-complete the affected rechecks and update those conclusions before finishing;
-avoiding duplicate reporting must never preserve stale results.
+Once ready, write one short `ci-report.md` per candidate: results, important findings, limits, and evidence links. A few lines suffice for an uneventful update. Reference maintained stage records instead of rebuilding the one-shot reports; leave resource summaries and cost calculation to the existing tools.
 
 ## Current Stop Boundary
 

--- a/skills/incremental-modeling/guide.md
+++ b/skills/incremental-modeling/guide.md
@@ -134,6 +134,37 @@ Read `references/model-checking/01-update-focused-checking.md`. It reuses the in
 
 When Part 3 produces an actual counterexample, enter through `references/reproduction/01-confirm-counterexample.md`. That file adds only incremental provenance and old/new control guidance; the installed Specula **bug-confirmation** skill owns investigation, reproduction, verdicts, and repair requests.
 
+## Readiness and Final Reporting
+
+Keep required stage artifacts current as you work: decisions, checks, counterexamples,
+repairs, and reproduction outcomes belong in their existing records. Do not defer
+evidence until the end or repeatedly rewrite complete reports to finish a turn.
+
+Before final reporting, briefly check the existing evidence yourself. Applicable
+trace validation, MC/simulation, and reproduction must have explicit outcomes; all
+started work must have been observed; no required work or counterexample disposition
+may remain unresolved. Evidence must apply to the final artifacts, with invalidated
+checks rerun where required. Use Part 3's budgeted completion rules: exhaustive
+exploration is not required, and a confirmed real code bug does not itself block
+completion. This is a reasoning step, not a separate checklist file or reviewer.
+
+If work remains, continue the relevant phase before reporting. If genuinely blocked
+or interrupted, save brief progress, evidence paths, unresolved items, and the next
+step in the existing records or handoff, then explain the interruption briefly.
+Do not write a final CI report or claim completion merely to end the conversation.
+
+Once ready, write `ci-report.md` as the single human-facing wrap-up: modeling
+decision and changes, verification results, important findings, and limits, with
+links to existing evidence. A few lines suffice for an uneventful update. Preserve
+required stage reports and machine artifacts, but do not duplicate them or rebuild
+the one-shot reporting bundle. Leave resource summaries and cost calculation to
+the existing tools.
+
+Finalize once for the same candidate. On resume, continue valid completed work
+and any partial report in place. If later changes invalidate evidence or conclusions,
+complete the affected rechecks and update those conclusions before finishing;
+avoiding duplicate reporting must never preserve stale results.
+
 ## Current Stop Boundary
 
 Generation may run syntax and static configuration preflights only. Validation may build the reused harness, collect/replay traces, and run bounded local semantic diagnostics as described in Validation 3. Model-checking campaigns begin only after the initial validation gate; subsequent repairs use the local-feedback loop and final regression gate. Reproduction begins only with an actual counterexample.

--- a/src/specula/prompts/incremental.md
+++ b/src/specula/prompts/incremental.md
@@ -27,17 +27,21 @@ not automatic stage-completion or conversation-resume checkpoints.
 
 ## Finish
 
-Write a concise `{{work_dir}}/ci-report.md` explaining the modeling decision,
-model changes or repairs, trace validation, checking coverage, findings and
-reproduction outcomes, with paths to actual commands, logs, traces and reports.
-Distinguish limited exploration from unresolved required validation. A real code
-bug does not by itself invalidate a faithful model or prevent workflow completion.
+Follow the skill's Readiness and Final Reporting guidance. First briefly check
+readiness against the existing evidence; if required work remains, continue it
+before final reporting. This self-check does not need a separate file.
+
+Only once ready, write `{{work_dir}}/ci-report.md` as a short result summary with
+evidence links. A few lines suffice for an uneventful update. Reuse the maintained
+stage records rather than rewriting the one-shot reports; resource summaries and
+costs are handled by the existing tools.
 
 Only when the skill's applicable completion conditions are satisfied and all
 started work has been observed, end your final response with this exact line:
 
 SPECULA_INCREMENTAL_COMPLETE {{run_id}}
 
-If work remains unresolved or execution is interrupted, report what remains and
-do not emit that line. The current CI model will remain unchanged. On manual
-resume, continue this same conversation and workspace; do not restart completed work.
+If blocked or interrupted, save brief progress and the next step in the existing
+records or handoff, not a final CI report, and do not emit that line. The current
+CI model will remain unchanged. On manual resume, continue this same conversation
+and workspace, including any partial report; do not restart valid completed work.

--- a/src/specula/prompts/incremental.md
+++ b/src/specula/prompts/incremental.md
@@ -1,15 +1,8 @@
 # Incremental CI Task: {{target}}
 
-Read the installed Specula skill {{skill}} and its guide. Execute its complete
-workflow in one continuous session: generation, trace validation, model checking,
-and reproduction when an actual counterexample requires it. Apply the referenced
-Specula methods. You own the analysis, planning, repairs, and verification loop.
+Read the installed Specula skill {{skill}} and its guide. Execute its complete workflow in one continuous session: generation, trace validation, model checking, and reproduction when an actual counterexample requires it. Apply the referenced Specula methods. You own the analysis, planning, repairs, and verification loop.
 
-For long conversations, follow the skill's context-preservation guidance. The
-`request_context_compaction` tool can yield an internal turn after you save a
-handoff; the controller resumes this same session. Such a yield is not completion
-of the workflow and does not require final reports. Compaction is optional; failure
-does not prevent continuing the task.
+For long conversations, follow the skill's context-preservation guidance. The `request_context_compaction` tool can yield an internal turn after you save a handoff; the controller resumes this same session. Such a yield is not completion of the workflow and does not require final reports. Compaction is optional; failure does not prevent continuing the task.
 
 ## Inputs
 
@@ -19,29 +12,16 @@ does not prevent continuing the task.
 - Prior Specula artifacts: {{old_model}}
 - Working artifacts, initially copied from the prior model: {{work_dir}}
 
-Treat old source and artifacts as read-only evidence. Make all changes in the new
-source working copy and working artifacts. Rebase the existing harness onto the
-new source; do not include instrumentation changes in the source update itself.
-Keep the stage artifacts required by the skill as you work. They record evidence,
-not automatic stage-completion or conversation-resume checkpoints.
+Treat old source and artifacts as read-only evidence. Make all changes in the new source working copy and working artifacts. Rebase the existing harness onto the new source; do not include instrumentation changes in the source update itself. Keep the stage artifacts required by the skill as you work. They record evidence, not automatic stage-completion or conversation-resume checkpoints.
 
 ## Finish
 
-Follow the skill's Readiness and Final Reporting guidance. First briefly check
-readiness against the existing evidence; if required work remains, continue it
-before final reporting. This self-check does not need a separate file.
+Follow the skill's Readiness and Final Reporting guidance. First briefly check readiness against the existing evidence; if required work remains, continue it before final reporting. This self-check does not need a separate file.
 
-Only once ready, write `{{work_dir}}/ci-report.md` as a short result summary with
-evidence links. A few lines suffice for an uneventful update. Reuse the maintained
-stage records rather than rewriting the one-shot reports; resource summaries and
-costs are handled by the existing tools.
+Only once ready, write `{{work_dir}}/ci-report.md` as a short result summary with evidence links. A few lines suffice for an uneventful update. Reuse the maintained stage records rather than rewriting the one-shot reports; resource summaries and costs are handled by the existing tools.
 
-Only when the skill's applicable completion conditions are satisfied and all
-started work has been observed, end your final response with this exact line:
+Only when the skill's applicable completion conditions are satisfied and all started work has been observed, end your final response with this exact line:
 
 SPECULA_INCREMENTAL_COMPLETE {{run_id}}
 
-If blocked or interrupted, save brief progress and the next step in the existing
-records or handoff, not a final CI report, and do not emit that line. The current
-CI model will remain unchanged. On manual resume, continue this same conversation
-and workspace, including any partial report; do not restart valid completed work.
+If blocked or interrupted, save brief progress and the next step in the existing records or handoff, not a final CI report, and do not emit that line. The current CI model will remain unchanged. On manual resume, continue this same conversation and workspace, including any partial report; do not restart valid completed work.

--- a/tests/e2e/test_incremental_ci.py
+++ b/tests/e2e/test_incremental_ci.py
@@ -320,6 +320,32 @@ class IncrementalCLI(unittest.TestCase):
         self.assertEqual(usage["phases"]["incremental"]["cost_usd"], 0.01)
         self.assertTrue(usage["run_complete"])
 
+    def test_repair_can_finish_without_an_intermediate_ci_report(self) -> None:
+        self.initialize()
+        old = (self.ci / "current").resolve()
+        self.change_source("repair fixture\n")
+        # Simulate persisted repair evidence before the fixture's final model
+        # and report. This checks lifecycle compatibility, not Agent reasoning.
+        script = self.adapter.read_text().replace(
+            "  incremental)\n",
+            "  incremental)\n"
+            '    test ! -e "$SPECULA_WORK_DIR/ci-report.md" || exit 10\n'
+            '    printf "fixture model needing repair\\n" > "$SPECULA_WORK_DIR/spec/base.tla"\n'
+            '    printf "Fixture repair and recheck recorded; no semantic verification performed.\\n" > "$SPECULA_WORK_DIR/spec/changelog.md"\n'
+            '    test ! -e "$SPECULA_WORK_DIR/ci-report.md" || exit 10\n',
+        )
+        self.adapter.write_text(script)
+        result = self.run_ci("--incremental", "--agent=fake")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        model = self.ci / "current/model"
+        self.assertNotEqual((self.ci / "current").resolve(), old)
+        self.assertEqual((model / "spec/base.tla").read_text(), "updated fixture model\n")
+        self.assertIn("Fixture repair and recheck", (model / "spec/changelog.md").read_text())
+        self.assertTrue((model / "ci-report.md").is_file())
+        phases = Path(f"{self.adapter}.phases").read_text().splitlines()
+        self.assertEqual(phases.count("incremental"), 1)
+        self.assertEqual(phases[-1], "incremental")
+
     def test_failure_keeps_current_and_resume_uses_original_conversation_and_source(self) -> None:
         self.initialize()
         old = (self.ci / "current").resolve()
@@ -331,6 +357,10 @@ class IncrementalCLI(unittest.TestCase):
         self.assertEqual(first.returncode, 9, first.stdout + first.stderr)
         self.assertEqual((self.ci / "current").resolve(), old)
         run = self.latest()
+        work = run / "footest/.specula-output"
+        self.assertFalse((work / "ci-report.md").exists())
+        self.assertEqual((work / "spec/base.tla").read_text(), "unfinished edit\n")
+        self.assertFalse((run / "ci-result.json").exists())
         original_diff = (run / "source.diff").read_bytes()
         self.change_source("version C\n")
         flag.unlink()
@@ -339,6 +369,7 @@ class IncrementalCLI(unittest.TestCase):
         self.assertEqual(CIStore(self.ci).current()["source_commit"], sha_b)
         self.assertEqual((run / "source.diff").read_bytes(), original_diff)
         self.assertEqual(Path(str(self.adapter) + ".resumed").read_text(), "fixture-native-session\n")
+        self.assertEqual((self.ci / "current/model/ci-report.md").read_bytes(), (work / "ci-report.md").read_bytes())
         prompt = Path(str(self.adapter) + ".incremental.prompt").read_text()
         self.assertIn("exact session", prompt)
         self.assertNotIn("# Incremental CI Task", prompt)


### PR DESCRIPTION
## Summary

- Keep stage evidence current and check readiness before final reporting.
- Write one short `ci-report.md`; preserve progress on interruption and continue existing work on resume.
- Leave verification requirements, runtime gates, resource accounting, and Usage unchanged.