### PR TITLE
Fail CI on confirmed bugs while retaining valid models

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -186,6 +186,10 @@ Specula computes the changes since the current model's source version, then runs
 
 Completed runs update `current/model/` in the CI directory. Reports, diffs, logs, and resource usage are saved under `runs/<run-id>/` in the same directory.
 
+CI returns exit code `2` when the current confirmation results contain `REPRODUCED` or `ENV_LIMITED` bugs, regardless of whether the update introduced them. `MASKED` findings produce a warning and exit code `0`; completed checks without these findings also return `0`. Incomplete checks cannot pass. Inspect `ci-report.md` and `ci-verdict.json` for the incremental result and evidence. Initialization derives the same verdict from `confirmed-bugs.md`.
+
+Finding a bug does not invalidate the model: a completed check still advances the branch's model baseline even when CI fails. Each new incremental run reattempts confirmation/reproduction of unresolved prior findings on the current revision, including updates that do not change the model. Reports retain exploration limits; a passing check is not a proof of safety.
+
 ### Resume an interrupted run
 
 Incomplete runs leave the current model unchanged. Resume the original Agent conversation and working directory with:
@@ -202,9 +206,9 @@ Install Specula, the selected agent, and the project's build dependencies under 
 
 Copy the [workflow template](../examples/ci/specula-ci.yml) into your project's `.github/workflows/specula-ci.yml`. Set the repository variables `SPECULA_CI_DIR` and `SPECULA_MODEL`; optionally set `SPECULA_AGENT` and `SPECULA_EFFORT`. Edit the branch filters to suit your repository. Each independently evolving branch needs its own initialized CI directory.
 
-Each push checks the cumulative diff from the last successful model baseline to the pushed version. One check may include several commits; intermediate versions are not checked separately. Scheduled checks use the latest branch version. Once the model reaches that version, delayed events for earlier commits do not repeat the work or move the model backward.
+Each push checks the cumulative diff from the last completed model baseline to the pushed version. One check may include several commits; intermediate versions are not checked separately. Scheduled checks use the latest branch version. Once the model reaches that version, delayed events for earlier commits do not repeat the work or move the model backward.
 
-Same-repository PRs check the proposed merged code without changing the branch's current model. When the code is merged, matching completed results are inherited without another Agent run, including squash and rebase merges. Changes to the code, model baseline, or check configuration require a new check. External-fork PRs do not run automatically on the runner.
+Same-repository PRs check the proposed merged code without changing the branch's current model. When the code is merged, matching completed results are inherited without another Agent run, including squash and rebase merges. Reused results preserve their verdict, including failures and warnings. Changes to the code, model baseline, or check configuration require a new check. External-fork PRs do not run automatically on the runner.
 
 Manual runs are available in the Actions tab. Uncomment `schedule` to enable cron; use `SPECULA_CI_BRANCH` to select a non-default branch for scheduled runs. Change `SPECULA_CI_ENVIRONMENT` when updating the runner's toolchain or external configuration so older check results are not reused under a different setup.
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -188,7 +188,9 @@ Completed runs update `current/model/` in the CI directory. Reports, diffs, logs
 
 CI returns exit code `2` when the current confirmation results contain `REPRODUCED` or `ENV_LIMITED` bugs, regardless of whether the update introduced them. `MASKED` findings produce a warning and exit code `0`; completed checks without these findings also return `0`. Unfinished checks return a nonzero exit code. Inspect `ci-report.md` and `ci-verdict.json` for the incremental result and evidence. Initialization derives the same verdict from `confirmed-bugs.md`.
 
-Each new incremental run reattempts confirmation/reproduction of unresolved prior findings on the current revision, including updates that do not change the model.
+`NEEDS MORE INFO` and `DEFERRED` are stored as nonblocking information. A remaining `PENDING REPAIR` fails CI.
+
+Each new incremental run reattempts confirmation/reproduction of prior bug and warning findings on the current revision, including updates that do not change the model.
 
 ### Resume an interrupted run
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -159,7 +159,7 @@ specula run --ci-init --ci-dir=/work/project-ci \
   "name|owner/repository|language|reference"
 ```
 
-For a long-lived CI baseline, we recommend initializing from source as above. A model from an ordinary one-shot run may focus on a few scenarios and carry coverage gaps into later checks; CI initialization focuses on reusable core logic and interactions. Regenerating a model does not guarantee better coverage.
+For a long-lived CI baseline, we recommend initializing from source as above.
 
 To reuse an existing model or verification assets, add [BYOM](#bring-your-own-model-byom):
 
@@ -170,7 +170,7 @@ specula run --ci-init --ci-dir=/work/project-ci \
   "name|owner/repository|language|reference"
 ```
 
-The Agent organizes supplied assets and completes missing or incompatible parts, preserving the model's scope unless you request an expansion in your guidance. It may adapt workspace copies of an older model and harness to the supplied source. Usable traces are reused by default, followed by the standard BYOM validation, confirmation, and repair workflow. Prior logs alone do not complete initialization. Review `byom-modification-report.md` in the target's output for adaptations and remaining gaps. Successful completion publishes the baseline for subsequent checks; registration is not a proof of safety.
+The Agent organizes supplied assets and completes missing or incompatible parts, preserving the model's scope unless you request an expansion in your guidance. It may adapt workspace copies of an older model and harness to the supplied source. Usable traces are reused by default, followed by the standard BYOM validation, confirmation, and repair workflow. Review `byom-modification-report.md` in the target's output for adaptations and remaining gaps. Successful completion publishes the baseline for subsequent checks.
 
 Keep the original BYOM files available and unchanged until initialization and any resume finish. BYOM stores their path, not an input snapshot. To change the input, start a new initialization run; use a new CI directory if one is already initialized. `--byom` cannot be combined with `--incremental` or `--skip-*` options. CI initialization supports one target and requires isolated output.
 
@@ -186,9 +186,9 @@ Specula computes the changes since the current model's source version, then runs
 
 Completed runs update `current/model/` in the CI directory. Reports, diffs, logs, and resource usage are saved under `runs/<run-id>/` in the same directory.
 
-CI returns exit code `2` when the current confirmation results contain `REPRODUCED` or `ENV_LIMITED` bugs, regardless of whether the update introduced them. `MASKED` findings produce a warning and exit code `0`; completed checks without these findings also return `0`. Incomplete checks cannot pass. Inspect `ci-report.md` and `ci-verdict.json` for the incremental result and evidence. Initialization derives the same verdict from `confirmed-bugs.md`.
+CI returns exit code `2` when the current confirmation results contain `REPRODUCED` or `ENV_LIMITED` bugs, regardless of whether the update introduced them. `MASKED` findings produce a warning and exit code `0`; completed checks without these findings also return `0`. Unfinished checks return a nonzero exit code. Inspect `ci-report.md` and `ci-verdict.json` for the incremental result and evidence. Initialization derives the same verdict from `confirmed-bugs.md`.
 
-Finding a bug does not invalidate the model: a completed check still advances the branch's model baseline even when CI fails. Each new incremental run reattempts confirmation/reproduction of unresolved prior findings on the current revision, including updates that do not change the model. Reports retain exploration limits; a passing check is not a proof of safety.
+Each new incremental run reattempts confirmation/reproduction of unresolved prior findings on the current revision, including updates that do not change the model.
 
 ### Resume an interrupted run
 

--- a/skills/incremental-modeling/guide.md
+++ b/skills/incremental-modeling/guide.md
@@ -112,7 +112,7 @@ Read `references/model-checking/01-update-focused-checking.md`. It reuses the in
 
 ## Part 4: Reproduction
 
-When Part 3 produces an actual counterexample, enter through `references/reproduction/01-confirm-counterexample.md`. Also reattempt confirmation/reproduction of every unresolved prior finding against the current source on each new run, including `NO_MODEL_CHANGE`. Keep its ID; inspect prior reports even if they predate `ci-verdict.json`. The installed Specula **bug-confirmation** skill owns investigation, reproduction, verdicts, and repair requests.
+When Part 3 produces an actual counterexample, enter through `references/reproduction/01-confirm-counterexample.md`. Also reattempt confirmation/reproduction of prior `REPRODUCED`, `ENV_LIMITED`, and `MASKED` findings against the current source on each new run, including `NO_MODEL_CHANGE`. Keep its ID; inspect prior reports even if they predate `ci-verdict.json`. The installed Specula **bug-confirmation** skill owns investigation, reproduction, verdicts, and repair requests.
 
 ## Readiness and Final Reporting
 
@@ -136,12 +136,14 @@ Write `ci-verdict.json` alongside the report, using the run ID provided by the C
 }
 ```
 
-Include every finding investigated in this run and every unresolved prior finding, with unique, stable IDs. Use `"findings": []` only when both are empty. Evidence paths must name nonempty current confirmation records relative to the work directory, under `spec/`, `harness/`, or `traces/`, or a top-level Markdown file. Link the actual reproduction commands, observed outcomes, source revision, and any environment limits from that record; do not duplicate the evidence in the JSON.
+Include every finding investigated in this run and prior bug and warning findings, with unique, stable IDs. Use `"findings": []` only when both are empty. Evidence paths must name nonempty current confirmation records relative to the work directory, under `spec/`, `harness/`, or `traces/`, or a top-level Markdown file. Link the actual reproduction commands, observed outcomes, source revision, and any environment limits from that record; do not duplicate the evidence in the JSON.
 
 `REPRODUCED` and `ENV_LIMITED` fail CI, regardless of novelty, severity, or update attribution. `MASKED` produces a nonblocking warning. `FALSE POSITIVE` and `DROPPED` retain the main skill's meanings. Use `FIXED` for a prior defect whose repair is supported by current source analysis and a fresh reproduction/control attempt; explain why the previous trigger no longer harms. `FALSE POSITIVE`, `DROPPED`, and `FIXED` are nonblocking. Complete pending repairs and confirmation before final reporting.
+
+Store `NEEDS MORE INFO` and `DEFERRED` as nonblocking information in `ci-verdict.json`; no further processing is required. A remaining `PENDING REPAIR` means the workflow has not converged and fails CI.
 
 After completing the workflow, emit the completion marker. The controller publishes the model and computes the CI verdict from the recorded dispositions.
 
 ## Current Stop Boundary
 
-Generation may run syntax and static configuration preflights only. Validation may build the reused harness, collect/replay traces, and run bounded local semantic diagnostics as described in Validation 3. Model-checking campaigns begin only after the initial validation gate; subsequent repairs use the local-feedback loop and final regression gate. Reproduction handles actual counterexamples and rechecks unresolved prior findings.
+Generation may run syntax and static configuration preflights only. Validation may build the reused harness, collect/replay traces, and run bounded local semantic diagnostics as described in Validation 3. Model-checking campaigns begin only after the initial validation gate; subsequent repairs use the local-feedback loop and final regression gate. Reproduction handles actual counterexamples and rechecks prior bug and warning findings.

--- a/skills/incremental-modeling/guide.md
+++ b/skills/incremental-modeling/guide.md
@@ -112,7 +112,7 @@ Read `references/model-checking/01-update-focused-checking.md`. It reuses the in
 
 ## Part 4: Reproduction
 
-When Part 3 produces an actual counterexample, enter through `references/reproduction/01-confirm-counterexample.md`. Also reattempt confirmation/reproduction of every unresolved prior finding against the current source on each new run, including `NO_MODEL_CHANGE`. Keep its ID; inspect prior reports even if they predate `ci-verdict.json`. Prior conclusions do not replace current evidence. The installed Specula **bug-confirmation** skill owns investigation, reproduction, verdicts, and repair requests.
+When Part 3 produces an actual counterexample, enter through `references/reproduction/01-confirm-counterexample.md`. Also reattempt confirmation/reproduction of every unresolved prior finding against the current source on each new run, including `NO_MODEL_CHANGE`. Keep its ID; inspect prior reports even if they predate `ci-verdict.json`. The installed Specula **bug-confirmation** skill owns investigation, reproduction, verdicts, and repair requests.
 
 ## Readiness and Final Reporting
 
@@ -138,9 +138,9 @@ Write `ci-verdict.json` alongside the report, using the run ID provided by the C
 
 Include every finding investigated in this run and every unresolved prior finding, with unique, stable IDs. Use `"findings": []` only when both are empty. Evidence paths must name nonempty current confirmation records relative to the work directory, under `spec/`, `harness/`, or `traces/`, or a top-level Markdown file. Link the actual reproduction commands, observed outcomes, source revision, and any environment limits from that record; do not duplicate the evidence in the JSON.
 
-`REPRODUCED` and `ENV_LIMITED` fail CI, regardless of novelty, severity, or update attribution. `MASKED` produces a nonblocking warning. `FALSE POSITIVE` and `DROPPED` retain the main skill's meanings. Use `FIXED` only for a prior defect whose repair is supported by current source analysis and a fresh reproduction/control attempt; explain why the previous trigger no longer harms. Failure to trigger alone does not establish a fix. These dispositions do not fail CI. Pending repairs, insufficient information, and unfinished confirmation are incomplete work and cannot produce a passing result.
+`REPRODUCED` and `ENV_LIMITED` fail CI, regardless of novelty, severity, or update attribution. `MASKED` produces a nonblocking warning. `FALSE POSITIVE` and `DROPPED` retain the main skill's meanings. Use `FIXED` for a prior defect whose repair is supported by current source analysis and a fresh reproduction/control attempt; explain why the previous trigger no longer harms. `FALSE POSITIVE`, `DROPPED`, and `FIXED` are nonblocking. Complete pending repairs and confirmation before final reporting.
 
-A completed workflow with confirmed bugs still emits the completion marker and publishes its valid model under the usual branch/candidate rules. The controller computes the CI verdict from these dispositions; workflow completion does not imply CI success. Keep budget-limited exploration labeled as such; a passing verdict is not a proof of safety.
+After completing the workflow, emit the completion marker. The controller publishes the model and computes the CI verdict from the recorded dispositions.
 
 ## Current Stop Boundary
 

--- a/skills/incremental-modeling/guide.md
+++ b/skills/incremental-modeling/guide.md
@@ -112,7 +112,7 @@ Read `references/model-checking/01-update-focused-checking.md`. It reuses the in
 
 ## Part 4: Reproduction
 
-When Part 3 produces an actual counterexample, enter through `references/reproduction/01-confirm-counterexample.md`. That file adds only incremental provenance and old/new control guidance; the installed Specula **bug-confirmation** skill owns investigation, reproduction, verdicts, and repair requests.
+When Part 3 produces an actual counterexample, enter through `references/reproduction/01-confirm-counterexample.md`. Also reattempt confirmation/reproduction of every unresolved prior finding against the current source on each new run, including `NO_MODEL_CHANGE`. Keep its ID; inspect prior reports even if they predate `ci-verdict.json`. Prior conclusions do not replace current evidence. The installed Specula **bug-confirmation** skill owns investigation, reproduction, verdicts, and repair requests.
 
 ## Readiness and Final Reporting
 
@@ -122,6 +122,26 @@ If work remains, continue it. If blocked or interrupted, save a brief handoff in
 
 Once ready, write one short `ci-report.md` per candidate: results, important findings, limits, and evidence links. A few lines suffice for an uneventful update. Reference maintained stage records instead of rebuilding the one-shot reports; leave resource summaries and cost calculation to the existing tools.
 
+### CI Verdict
+
+Write `ci-verdict.json` alongside the report, using the run ID provided by the CI task:
+
+```json
+{
+  "version": 1,
+  "run_id": "<current-run-id>",
+  "findings": [
+    {"id": "MC-1", "status": "REPRODUCED", "evidence": "spec/reproduction-MC-1.md"}
+  ]
+}
+```
+
+Include every finding investigated in this run and every unresolved prior finding, with unique, stable IDs. Use `"findings": []` only when both are empty. Evidence paths must name nonempty current confirmation records relative to the work directory, under `spec/`, `harness/`, or `traces/`, or a top-level Markdown file. Link the actual reproduction commands, observed outcomes, source revision, and any environment limits from that record; do not duplicate the evidence in the JSON.
+
+`REPRODUCED` and `ENV_LIMITED` fail CI, regardless of novelty, severity, or update attribution. `MASKED` produces a nonblocking warning. `FALSE POSITIVE` and `DROPPED` retain the main skill's meanings. Use `FIXED` only for a prior defect whose repair is supported by current source analysis and a fresh reproduction/control attempt; explain why the previous trigger no longer harms. Failure to trigger alone does not establish a fix. These dispositions do not fail CI. Pending repairs, insufficient information, and unfinished confirmation are incomplete work and cannot produce a passing result.
+
+A completed workflow with confirmed bugs still emits the completion marker and publishes its valid model under the usual branch/candidate rules. The controller computes the CI verdict from these dispositions; workflow completion does not imply CI success. Keep budget-limited exploration labeled as such; a passing verdict is not a proof of safety.
+
 ## Current Stop Boundary
 
-Generation may run syntax and static configuration preflights only. Validation may build the reused harness, collect/replay traces, and run bounded local semantic diagnostics as described in Validation 3. Model-checking campaigns begin only after the initial validation gate; subsequent repairs use the local-feedback loop and final regression gate. Reproduction begins only with an actual counterexample.
+Generation may run syntax and static configuration preflights only. Validation may build the reused harness, collect/replay traces, and run bounded local semantic diagnostics as described in Validation 3. Model-checking campaigns begin only after the initial validation gate; subsequent repairs use the local-feedback loop and final regression gate. Reproduction handles actual counterexamples and rechecks unresolved prior findings.

--- a/skills/incremental-modeling/references/reproduction/01-confirm-counterexample.md
+++ b/skills/incremental-modeling/references/reproduction/01-confirm-counterexample.md
@@ -20,7 +20,7 @@ Before delegating, attach only the evidence the main skill needs:
 
 Confirm and reproduce against the new implementation revision. When the same test and environment are compatible with the old revision, run it as a control to distinguish introduced, newly exposed, and pre-existing behavior. The old-version control strengthens attribution but does not replace reproduction on the new version.
 
-Reattempt every unresolved prior finding on each new run, including unchanged mechanisms and `NO_MODEL_CHANGE` runs. Reuse the reproduction test, not its previous outcome. Record the current attempt and disposition under the same finding ID. Rechecking an already confirmed finding is not new code-review discovery: do not apply the known-code-review pre-filter or drop it merely because it is known. When the update fixes a prior defect, record `FIXED` in the CI verdict with source and fresh test/control evidence; an unsuccessful reproduction alone is insufficient.
+Reattempt every unresolved prior finding on each new run, including unchanged mechanisms and `NO_MODEL_CHANGE` runs. Rerun the existing reproduction test and record the current attempt and disposition under the same finding ID. Skip the known-code-review pre-filter when rechecking an already confirmed finding. When the update fixes a prior defect, record `FIXED` in the CI verdict with source and fresh test/control evidence.
 
 ## Delegate and Preserve Verdict Boundaries
 

--- a/skills/incremental-modeling/references/reproduction/01-confirm-counterexample.md
+++ b/skills/incremental-modeling/references/reproduction/01-confirm-counterexample.md
@@ -4,7 +4,7 @@ This is a thin entry point. Read and follow the installed Specula **bug-confirma
 
 ## Preconditions
 
-- An actual TLC counterexample exists. A Scenario, code suspicion, or model-checking run with no violation is not an MC finding.
+- For a new finding, an actual TLC counterexample exists. A Scenario, code suspicion, or model-checking run with no violation is not an MC finding. Unresolved prior findings enter for a fresh reproduction attempt on the current revision, even if this run finds no new counterexample.
 - The finding names its violated property, saved TLC output/trace, current source revision, reference Actions, and update Scenario.
 - A focused-only violation must also be admitted by full current reference behavior, or be supported by a valid open/discharge argument. Otherwise return it to model-checking repair before reproduction.
 - Trace validation and model-checking evidence identify the current suite used to produce the finding.
@@ -20,6 +20,8 @@ Before delegating, attach only the evidence the main skill needs:
 
 Confirm and reproduce against the new implementation revision. When the same test and environment are compatible with the old revision, run it as a control to distinguish introduced, newly exposed, and pre-existing behavior. The old-version control strengthens attribution but does not replace reproduction on the new version.
 
+Reattempt every unresolved prior finding on each new run, including unchanged mechanisms and `NO_MODEL_CHANGE` runs. Reuse the reproduction test, not its previous outcome. Record the current attempt and disposition under the same finding ID. Rechecking an already confirmed finding is not new code-review discovery: do not apply the known-code-review pre-filter or drop it merely because it is known. When the update fixes a prior defect, record `FIXED` in the CI verdict with source and fresh test/control evidence; an unsuccessful reproduction alone is insufficient.
+
 ## Delegate and Preserve Verdict Boundaries
 
 Use the main **bug-confirmation** workflow to:
@@ -32,4 +34,4 @@ Use the main **bug-confirmation** workflow to:
 
 Never classify a new invariant violation as a model defect merely because it appears after the update. A faithful new model may have exposed a real implementation bug. Conversely, a syntactically valid focused counterexample is not a bug until code reachability and consequence are established.
 
-Accept MC counterexamples only. Do not discover or enqueue standalone code-review findings.
+Accept new MC counterexamples and unresolved prior findings for rechecking. Do not discover or enqueue new standalone code-review findings.

--- a/skills/incremental-modeling/references/reproduction/01-confirm-counterexample.md
+++ b/skills/incremental-modeling/references/reproduction/01-confirm-counterexample.md
@@ -4,7 +4,7 @@ This is a thin entry point. Read and follow the installed Specula **bug-confirma
 
 ## Preconditions
 
-- For a new finding, an actual TLC counterexample exists. A Scenario, code suspicion, or model-checking run with no violation is not an MC finding. Unresolved prior findings enter for a fresh reproduction attempt on the current revision, even if this run finds no new counterexample.
+- For a new finding, an actual TLC counterexample exists. A Scenario, code suspicion, or model-checking run with no violation is not an MC finding. Prior bug and warning findings enter for a fresh reproduction attempt on the current revision, even if this run finds no new counterexample.
 - The finding names its violated property, saved TLC output/trace, current source revision, reference Actions, and update Scenario.
 - A focused-only violation must also be admitted by full current reference behavior, or be supported by a valid open/discharge argument. Otherwise return it to model-checking repair before reproduction.
 - Trace validation and model-checking evidence identify the current suite used to produce the finding.
@@ -20,7 +20,7 @@ Before delegating, attach only the evidence the main skill needs:
 
 Confirm and reproduce against the new implementation revision. When the same test and environment are compatible with the old revision, run it as a control to distinguish introduced, newly exposed, and pre-existing behavior. The old-version control strengthens attribution but does not replace reproduction on the new version.
 
-Reattempt every unresolved prior finding on each new run, including unchanged mechanisms and `NO_MODEL_CHANGE` runs. Rerun the existing reproduction test and record the current attempt and disposition under the same finding ID. Skip the known-code-review pre-filter when rechecking an already confirmed finding. When the update fixes a prior defect, record `FIXED` in the CI verdict with source and fresh test/control evidence.
+Reattempt prior bug and warning findings on each new run, including unchanged mechanisms and `NO_MODEL_CHANGE` runs. Rerun the existing reproduction test and record the current attempt and disposition under the same finding ID. Skip the known-code-review pre-filter when rechecking an already confirmed finding. When the update fixes a prior defect, record `FIXED` in the CI verdict with source and fresh test/control evidence.
 
 ## Delegate and Preserve Verdict Boundaries
 
@@ -34,4 +34,4 @@ Use the main **bug-confirmation** workflow to:
 
 Never classify a new invariant violation as a model defect merely because it appears after the update. A faithful new model may have exposed a real implementation bug. Conversely, a syntactically valid focused counterexample is not a bug until code reachability and consequence are established.
 
-Accept new MC counterexamples and unresolved prior findings for rechecking. Do not discover or enqueue new standalone code-review findings.
+Accept new MC counterexamples and prior bug and warning findings for rechecking. Do not discover or enqueue new standalone code-review findings.

--- a/src/specula/ci_inheritance.py
+++ b/src/specula/ci_inheritance.py
@@ -19,7 +19,8 @@ def result_key(base: str, tree: str, configuration: str) -> str:
 def matches_source(store: CIStore, checked: dict[str, Any], tree: str, configuration: str) -> bool:
     """Match the frozen, pre-instrumentation source, not just its original HEAD."""
     return (
-        checked.get("source_tree") == tree
+        checked.get("verdict") in ("PASS", "WARNING", "FAIL")
+        and checked.get("source_tree") == tree
         and checked.get("check_key") == configuration
         and checked.get("dirty") is False
         and git(store.path(checked["source"]), "rev-parse", f"{checked['snapshot_commit']}^{{tree}}") == tree

--- a/src/specula/ci_init.py
+++ b/src/specula/ci_init.py
@@ -1,8 +1,4 @@
-"""Guidance composition and run-scoped baseline registration for CI initialization.
-
-Registration preserves reusable artifacts; it deliberately makes no automatic
-semantic-quality verdict. The ordinary pipeline remains the execution owner.
-"""
+"""Guidance composition and run-scoped baseline registration for CI initialization."""
 
 from __future__ import annotations
 
@@ -186,7 +182,7 @@ def register_baseline(
         "source": source,
         "pipeline_exit_code": pipeline_exit_code,
         "validation_status": "UNVERIFIED",
-        "validation_note": "Registration is not a verification verdict; inspect the retained validation evidence.",
+        "validation_note": "See the retained validation reports for results.",
         "assets": str(assets.relative_to(run_dir)),
         "guidance": str(inputs_dir.relative_to(run_dir)),
         "run_output": str(work_dir.relative_to(run_dir)),

--- a/src/specula/ci_init.py
+++ b/src/specula/ci_init.py
@@ -129,7 +129,7 @@ def _copy_assets(work_dir: Path, destination: Path) -> tuple[dict[str, str], lis
             omitted.append(relative.as_posix())
 
     for path in sorted(work_dir.iterdir()):
-        if path.name in ASSET_DIRS or path.suffix == ".md":
+        if path.name in ASSET_DIRS or path.suffix == ".md" or path.name == "ci-verdict.json":
             copy(path)
     return files, omitted
 

--- a/src/specula/ci_phase.py
+++ b/src/specula/ci_phase.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from specula import ci_init, stop_gate
+from specula import ci_init, ci_verdict, stop_gate
 from specula.ci_store import CIError, read_json
 from specula.phaselib import AgentFiles, Phase, Workspace, _last_message_path
 from specula.prompts import render
@@ -69,6 +69,8 @@ class IncrementalPhase(Phase):
                         raise CIError(f"missing required result: {required}")
                 if stop_gate._accept_main(self.key, str(work)) != 0:
                     raise CIError("incremental run left blocked or unfinished work")
+                inputs = read_json(ws.run_dir / "ci-input.json")
+                ci_verdict.read(work, ws.run_dir.name, previous=Path(inputs["old_model"]))
             except (OSError, ValueError, CIError) as exc:
                 print(f"ERROR: {exc}; current model will not be updated")
                 failures.append((name, 1))

--- a/src/specula/ci_store.py
+++ b/src/specula/ci_store.py
@@ -225,7 +225,7 @@ class CIStore:
             "guidance": inputs["guidance"],
             "run_id": run_dir.name,
             "files_sha256": files,
-            "verification": "Agent-reported workflow completion; inspect retained evidence, not a proof of safety.",
+            "verification": "Completed verification workflow.",
             "verdict": inputs.get("verdict"),
             "previous": inputs["previous"],
             "check_key": inputs.get("check_key"),

--- a/src/specula/ci_store.py
+++ b/src/specula/ci_store.py
@@ -226,6 +226,7 @@ class CIStore:
             "run_id": run_dir.name,
             "files_sha256": files,
             "verification": "Agent-reported workflow completion; inspect retained evidence, not a proof of safety.",
+            "verdict": inputs.get("verdict"),
             "previous": inputs["previous"],
             "check_key": inputs.get("check_key"),
             "source_tree": inputs.get("source_tree")

--- a/src/specula/ci_verdict.py
+++ b/src/specula/ci_verdict.py
@@ -1,4 +1,4 @@
-"""Derive CI success from current finding dispositions, separately from completion."""
+"""Compute CI verdicts from current finding dispositions."""
 
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ def conclusion(findings: list[dict[str, str]]) -> str:
 
 def exit_code(verdict: object) -> int:
     if not isinstance(verdict, str) or verdict not in VERDICTS:
-        raise CIError("missing or invalid CI verdict; a completed workflow is not a passing check")
+        raise CIError("missing or invalid CI verdict")
     return BUG_EXIT_CODE if verdict == "FAIL" else 0
 
 
@@ -76,7 +76,7 @@ def _read(work: Path, run_id: str | None = None) -> dict[str, Any]:
 
 
 def prior_findings(work: Path) -> dict[str, str]:
-    """The prior inventory schedules fresh confirmation, never supplies a verdict."""
+    """Read prior finding IDs and dispositions for rechecking."""
     if (work / FILENAME).exists() or (work / FILENAME).is_symlink():
         return {finding["id"]: finding["status"] for finding in _read(work)["findings"]}
     if ci_init._regular_file(work, "confirmed-bugs.md"):
@@ -100,7 +100,7 @@ def read(work: Path, run_id: str | None = None, *, previous: Path | None = None)
 
 
 def from_confirmation(work: Path, run_id: str) -> str:
-    """Initialization already has a canonical report; do not ask for another one."""
+    """Build the initialization verdict from the canonical confirmation report."""
     if not ci_init._regular_file(work, "confirmed-bugs.md"):
         raise CIError("missing CI initialization confirmation report")
     statuses = _confirmation_finding_statuses((work / "confirmed-bugs.md").read_text(), impact_only=False)

--- a/src/specula/ci_verdict.py
+++ b/src/specula/ci_verdict.py
@@ -15,7 +15,7 @@ BUG_EXIT_CODE = 2
 VERDICTS = {"PASS", "WARNING", "FAIL"}
 BUG_STATUSES = {"REPRODUCED", "ENV_LIMITED"}
 LIVE_STATUSES = BUG_STATUSES | {"MASKED"}
-TERMINAL_STATUSES = LIVE_STATUSES | {"FALSE POSITIVE", "DROPPED", "FIXED"}
+TERMINAL_STATUSES = LIVE_STATUSES | {"FALSE POSITIVE", "DROPPED", "FIXED", "NEEDS MORE INFO", "DEFERRED"}
 
 
 def conclusion(findings: list[dict[str, str]]) -> str:
@@ -57,6 +57,8 @@ def _read(work: Path, run_id: str | None = None) -> dict[str, Any]:
         ):
             raise CIError("CI finding IDs must be unique and nonempty")
         seen.add(fid)
+        if status == "PENDING REPAIR":
+            raise CIError(f"{fid}: CI workflow did not converge (PENDING REPAIR)")
         if not isinstance(status, str) or status not in TERMINAL_STATUSES:
             raise CIError(f"{fid}: unresolved or invalid CI finding status: {status}")
         if not isinstance(evidence, str) or not evidence:

--- a/src/specula/ci_verdict.py
+++ b/src/specula/ci_verdict.py
@@ -1,0 +1,117 @@
+"""Derive CI success from current finding dispositions, separately from completion."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from specula import ci_init
+from specula.ci_store import CIError, read_json, write_json
+from specula.resource_summary import _confirmation_finding_statuses
+
+FILENAME = "ci-verdict.json"
+BUG_EXIT_CODE = 2
+VERDICTS = {"PASS", "WARNING", "FAIL"}
+BUG_STATUSES = {"REPRODUCED", "ENV_LIMITED"}
+LIVE_STATUSES = BUG_STATUSES | {"MASKED"}
+TERMINAL_STATUSES = LIVE_STATUSES | {"FALSE POSITIVE", "DROPPED", "FIXED"}
+
+
+def conclusion(findings: list[dict[str, str]]) -> str:
+    statuses = {finding["status"] for finding in findings}
+    if statuses & BUG_STATUSES:
+        return "FAIL"
+    return "WARNING" if "MASKED" in statuses else "PASS"
+
+
+def exit_code(verdict: object) -> int:
+    if not isinstance(verdict, str) or verdict not in VERDICTS:
+        raise CIError("missing or invalid CI verdict; a completed workflow is not a passing check")
+    return BUG_EXIT_CODE if verdict == "FAIL" else 0
+
+
+def _read(work: Path, run_id: str | None = None) -> dict[str, Any]:
+    if not ci_init._regular_file(work, FILENAME):
+        raise CIError(f"missing current {FILENAME}")
+    record = read_json(work / FILENAME)
+    if type(record.get("version")) is not int or record["version"] != 1:
+        raise CIError("unsupported CI verdict version")
+    if not isinstance(record.get("run_id"), str) or not record["run_id"]:
+        raise CIError("CI verdict must identify its run")
+    if run_id is not None and record["run_id"] != run_id:
+        raise CIError("CI verdict belongs to another run")
+    findings = record.get("findings")
+    if not isinstance(findings, list):
+        raise CIError("CI verdict must contain a findings list, including when empty")
+    seen: set[str] = set()
+    for finding in findings:
+        if not isinstance(finding, dict):
+            raise CIError("invalid CI finding")
+        fid, status, evidence = (finding.get(key) for key in ("id", "status", "evidence"))
+        if (
+            not isinstance(fid, str)
+            or re.fullmatch(r"[A-Za-z0-9._-]+", fid) is None
+            or fid in {".", ".."}
+            or fid in seen
+        ):
+            raise CIError("CI finding IDs must be unique and nonempty")
+        seen.add(fid)
+        if not isinstance(status, str) or status not in TERMINAL_STATUSES:
+            raise CIError(f"{fid}: unresolved or invalid CI finding status: {status}")
+        if not isinstance(evidence, str) or not evidence:
+            raise CIError(f"{fid}: missing current confirmation evidence")
+        path = Path(evidence)
+        if (
+            path.is_absolute()
+            or ".." in path.parts
+            or evidence == FILENAME
+            or not path.parts
+            or not (path.parts[0] in ci_init.ASSET_DIRS or (len(path.parts) == 1 and path.suffix == ".md"))
+            or not ci_init._regular_file(work, evidence)
+            or not (work / evidence).read_bytes().strip()
+        ):
+            raise CIError(f"{fid}: confirmation evidence must be a retained, nonempty file inside the work directory")
+    return record
+
+
+def prior_findings(work: Path) -> dict[str, str]:
+    """The prior inventory schedules fresh confirmation, never supplies a verdict."""
+    if (work / FILENAME).exists() or (work / FILENAME).is_symlink():
+        return {finding["id"]: finding["status"] for finding in _read(work)["findings"]}
+    if ci_init._regular_file(work, "confirmed-bugs.md"):
+        statuses = _confirmation_finding_statuses((work / "confirmed-bugs.md").read_text(), impact_only=False)
+        if statuses is not None:
+            return statuses
+    return {}
+
+
+def read(work: Path, run_id: str | None = None, *, previous: Path | None = None) -> str:
+    record = _read(work, run_id)
+    if previous is not None:
+        required = {fid for fid, status in prior_findings(previous).items() if status in LIVE_STATUSES}
+        current = {finding["id"]: finding["status"] for finding in record["findings"]}
+        missing = required - current.keys()
+        if missing:
+            raise CIError(f"prior findings need current confirmation: {', '.join(sorted(missing))}")
+        if any(current[fid] == "DROPPED" for fid in required):
+            raise CIError("prior confirmed findings cannot be dropped; record a current confirmation or repair verdict")
+    return conclusion(record["findings"])
+
+
+def from_confirmation(work: Path, run_id: str) -> str:
+    """Initialization already has a canonical report; do not ask for another one."""
+    if not ci_init._regular_file(work, "confirmed-bugs.md"):
+        raise CIError("missing CI initialization confirmation report")
+    statuses = _confirmation_finding_statuses((work / "confirmed-bugs.md").read_text(), impact_only=False)
+    if statuses is None:
+        raise CIError("cannot read CI initialization finding dispositions")
+    record = {
+        "version": 1,
+        "run_id": run_id,
+        "findings": [
+            {"id": fid, "status": status, "evidence": "confirmed-bugs.md"} for fid, status in statuses.items()
+        ],
+    }
+    write_json(work / FILENAME, record)
+    return read(work, run_id)

--- a/src/specula/ci_workflow.py
+++ b/src/specula/ci_workflow.py
@@ -276,9 +276,7 @@ class CIPipeline(Pipeline):
 
     def _summary_validation_limits(self) -> tuple[str, ...]:
         if self.incremental:
-            return (
-                "See ci-report.md for actual verification coverage and remaining limits; completion is not a proof of safety.",
-            )
+            return ()
         return super()._summary_validation_limits()
 
     def main(self) -> int:

--- a/src/specula/ci_workflow.py
+++ b/src/specula/ci_workflow.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from specula import ci_init, resumelib
+from specula import ci_init, ci_verdict, resumelib
 from specula.ci_identity import check_key
 from specula.ci_inheritance import register_candidate
 from specula.ci_store import CIError, CIStore, freeze_source, git, read_json, write_json
@@ -260,7 +260,13 @@ class CIPipeline(Pipeline):
             ci_init._copy_assets(Path(current["model_path"]), work)
             # Prior run summaries remain available in old_model; they are not
             # this run's findings, completion evidence, or resource history.
-            for filename in ("summary.md", ".summary-findings.md", "ci-report.md", BYOM_REPORT_FILENAME):
+            for filename in (
+                "summary.md",
+                ".summary-findings.md",
+                "ci-report.md",
+                ci_verdict.FILENAME,
+                BYOM_REPORT_FILENAME,
+            ):
                 (work / filename).unlink(missing_ok=True)
         write_json(record, inputs)
         self.inputs = inputs
@@ -290,14 +296,17 @@ class CIPipeline(Pipeline):
             self._phase("INCREMENTAL WORKFLOW", "launch_incremental.sh", self._phase_args(names))
         return 0
 
-    def finalize_ci_run(self, exit_code: int) -> str | None:
+    def finalize_ci_run(self, exit_code: int) -> tuple[str | None, int]:
         if self.dry_run:
-            return None
+            return None, exit_code
         resume = f"specula run --ci-dir={shlex.quote(str(self.ci_dir))} --run-id={self.run_id}"
         if exit_code:
             if self.run_dir is not None and resumelib.active_entries(self.run_dir):
-                return f"Current CI model unchanged. To resume the conversation: {resume}"
-            return "Current CI model unchanged. No unfinished conversation is available; fix the error and start a new run."
+                return f"Current CI model unchanged. To resume the conversation: {resume}", exit_code
+            return (
+                "Current CI model unchanged. No unfinished conversation is available; fix the error and start a new run.",
+                exit_code,
+            )
         if self.inputs is None or self.store is None or self.run_dir is None:
             raise CIError("no frozen CI inputs; current model unchanged")
         source = self.store.path(self.inputs["source"])
@@ -305,13 +314,25 @@ class CIPipeline(Pipeline):
             raise CIError("pre-instrumentation source was modified during the run")
         name = self.extract_names()[0]
         work = Path(self.get_work_dir(name))
+        verdict = (
+            ci_verdict.read(work, self.run_id, previous=Path(self.inputs["old_model"]))
+            if self.incremental
+            else ci_verdict.from_confirmation(work, self.run_id)
+        )
         publication = dict(self.inputs)
+        publication["verdict"] = verdict
         if self.incremental and self.guidance_text is not None:
             publication["guidance"] = self.guidance_text
         publication["check_key"] = check_key(self, publication["guidance"])
         current = self.store.publish(self.run_dir, work, publication, advance=False)
         token = current.relative_to(self.store.root).as_posix()
-        result = {"run_id": self.run_id, "complete": True, "candidate": self.candidate, "snapshot": token}
+        result = {
+            "run_id": self.run_id,
+            "complete": True,
+            "verdict": verdict,
+            "candidate": self.candidate,
+            "snapshot": token,
+        }
         write_json(self.run_dir / "ci-result.json", result)
         if self.receipt is not None:
             write_json(self.receipt, result)
@@ -323,4 +344,7 @@ class CIPipeline(Pipeline):
             with contextlib.suppress(OSError, ValueError):
                 self.resource_summary.complete_run([name])
         label = "CI candidate saved; current model unchanged" if self.candidate else "Current CI model updated"
-        return f"{label}: {current}/model\nResults and usage: {work}/summary.md"
+        return (
+            f"CI verdict: {verdict}\n{label}: {current}/model\nResults and usage: {work}/summary.md",
+            ci_verdict.exit_code(verdict),
+        )

--- a/src/specula/github_ci.py
+++ b/src/specula/github_ci.py
@@ -21,7 +21,7 @@ from typing import Any
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from specula import ci_init
+from specula import ci_init, ci_verdict
 from specula.adapters.utils.run_lock import CI_EVENT_LOCK_FD_ENV
 from specula.ci_identity import check_key
 from specula.ci_inheritance import candidate_for, inherit, matches_source, result_key
@@ -256,11 +256,12 @@ class GitHubCI:
                     "commit": commit,
                     "status": "reused current result" if from_current else "reused candidate result",
                     "complete": True,
+                    "verdict": evidence["verdict"],
                     "run_id": evidence.get("evidence_run_id", evidence["run_id"]),
                 }
                 write_json(attempt_path, result)
                 self.rows.append(result)
-                return 0
+                return ci_verdict.exit_code(evidence["verdict"])
         if not candidate and not force:
             reused = inherit(self.store, self.source, commit, configuration)
             if reused is not None:
@@ -268,26 +269,45 @@ class GitHubCI:
                     "commit": commit,
                     "status": "inherited PR result" if reused["reuse_kind"] == "candidate" else "reused current result",
                     "complete": True,
+                    "verdict": reused["verdict"],
                     "run_id": reused["evidence_run_id"],
                 }
                 write_json(attempt_path, result)
                 self.rows.append(result)
-                return 0
+                return ci_verdict.exit_code(reused["verdict"])
         if attempt_path.exists() and not force:
             previous = read_json(attempt_path)
-            self.rows.append({**previous, "status": f"already attempted ({previous['status']})"})
-            return 0 if previous.get("complete") is True else 1
+            if previous.get("complete") is not True:
+                self.rows.append({**previous, "status": f"already attempted ({previous['status']})"})
+                return 1
+            if previous.get("verdict") in ("PASS", "WARNING", "FAIL"):
+                self.rows.append({**previous, "status": f"already attempted ({previous['status']})"})
+                return ci_verdict.exit_code(previous["verdict"])
+            # Legacy completion receipts have no bug verdict; run a fresh check.
         result = {"commit": commit, "status": "incomplete", "complete": False}
         write_json(attempt_path, result)
         code, receipt = self._invoke(candidate=candidate)
         result.update({"run_id": receipt.get("run_id"), "exit_code": code})
-        if code == 0:
-            if receipt.get("complete") is not True or receipt.get("candidate") is not candidate:
+        if code in {0, ci_verdict.BUG_EXIT_CODE} and receipt.get("complete") is True:
+            if receipt.get("candidate") is not candidate:
                 raise CIError("incremental command did not return a completed result receipt")
             snapshot = self.store.snapshot(receipt["snapshot"])
             if snapshot["source_commit"] != commit or snapshot["check_key"] != configuration:
                 raise CIError("completed result does not match this task's source/configuration")
-            result.update({"status": "candidate checked" if candidate else "checked", "complete": True})
+            if (
+                snapshot.get("verdict") != receipt.get("verdict")
+                or ci_verdict.exit_code(snapshot.get("verdict")) != code
+            ):
+                raise CIError("completed result does not match the CI verdict/exit status")
+            result.update(
+                {
+                    "status": "candidate checked" if candidate else "checked",
+                    "complete": True,
+                    "verdict": snapshot["verdict"],
+                }
+            )
+        elif code == 0:
+            raise CIError("incremental command did not return a completed result receipt")
         else:
             result["status"] = "failed"
         write_json(attempt_path, result)
@@ -350,21 +370,24 @@ class GitHubCI:
                             "commit": target,
                             "status": f"included in cumulative update to {current['source_commit']}; no separate check for this event",
                             "complete": False,
+                            "verdict": current.get("verdict"),
                             "run_id": current["evidence_run_id"],
                         }
                     )
-                    return 0
-            # The incremental runner diffs from the last successful snapshot to
+                    return ci_verdict.exit_code(current.get("verdict"))
+            # The incremental runner diffs from the last completed snapshot to
             # this target, including all intervening net changes in one run.
             return self.check(event, target, candidate=False, force=force)
 
     def report(self, error: str | None = None) -> None:
         self.reports.mkdir(parents=True, exist_ok=False)
-        lines = ["# Specula CI", "", "| Source commit | Result | Specula run |", "|---|---|---|"]
+        lines = ["# Specula CI", "", "| Source commit | Result | Verdict | Specula run |", "|---|---|---|---|"]
         for row in self.rows:
             lines.append(
-                f"| {html.escape(str(row['commit']))} | {html.escape(str(row['status']))} | {html.escape(str(row.get('run_id') or '-'))} |"
+                f"| {html.escape(str(row['commit']))} | {html.escape(str(row['status']))} | {html.escape(str(row.get('verdict') or '-'))} | {html.escape(str(row.get('run_id') or '-'))} |"
             )
+            if row.get("verdict") == "WARNING" and os.environ.get("GITHUB_ACTIONS") == "true":
+                print("::warning::Specula found masked defects; see the CI report for their safeguards and evidence.")
             run_id = row.get("run_id")
             if not isinstance(run_id, str) or not _valid_run_id(run_id):
                 continue
@@ -378,6 +401,7 @@ class GitHubCI:
             destination.mkdir(exist_ok=True)
             for relative in (
                 "ci-report.md",
+                ci_verdict.FILENAME,
                 "summary.md",
                 "confirmed-bugs.md",
                 "spec/changelog.md",
@@ -397,6 +421,7 @@ class GitHubCI:
             "Each update checks the cumulative diff to its target, not every intermediate version separately.",
             "Reused/inherited rows launch no additional Agent; their usage summaries belong to the original run.",
             "Reports describe actual coverage; completion is not a proof of safety.",
+            "FAIL means confirmed bugs (REPRODUCED or ENV_LIMITED); WARNING means masked findings only.",
             "",
         ]
         content = "\n".join(lines)

--- a/src/specula/github_ci.py
+++ b/src/specula/github_ci.py
@@ -420,7 +420,6 @@ class GitHubCI:
             "",
             "Each update checks the cumulative diff to its target, not every intermediate version separately.",
             "Reused/inherited rows launch no additional Agent; their usage summaries belong to the original run.",
-            "Reports describe actual coverage; completion is not a proof of safety.",
             "FAIL means confirmed bugs (REPRODUCED or ENV_LIMITED); WARNING means masked findings only.",
             "",
         ]

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -1202,9 +1202,14 @@ class Pipeline:
     def run_storage_root(self) -> Path:
         return SPECULA_ROOT / "runs"
 
-    def finalize_ci_run(self, exit_code: int) -> str | None:
+    def finalize_ci_run(self, exit_code: int) -> tuple[str | None, int]:
         """Publish persistent CI state after output and log finalization."""
-        return None
+        if self.ci_init and not self.dry_run and exit_code == 0:
+            from specula import ci_verdict
+
+            verdict = ci_verdict.from_confirmation(Path(self.get_work_dir(self.extract_names()[0])), self.run_id)
+            return f"CI verdict: {verdict}", ci_verdict.exit_code(verdict)
+        return None, exit_code
 
     def resolve_run_dir(self, *, acquire_lock: bool = False) -> int | None:
         """Establish the per-run root. Returns an exit code for an invalid
@@ -3934,7 +3939,7 @@ def main(argv: list[str]) -> int:
                 if code == 0:
                     code = 1
         try:
-            ci_message = p.finalize_ci_run(code)
+            ci_message, code = p.finalize_ci_run(code)
             if ci_message is not None:
                 print(ci_message, file=terminal_stdout, flush=True)
         except Exception as exc:

--- a/src/specula/prompts/incremental.md
+++ b/src/specula/prompts/incremental.md
@@ -18,10 +18,14 @@ Treat old source and artifacts as read-only evidence. Make all changes in the ne
 
 Follow the skill's Readiness and Final Reporting guidance. First briefly check readiness against the existing evidence; if required work remains, continue it before final reporting. This self-check does not need a separate file.
 
-Only once ready, write `{{work_dir}}/ci-report.md` as a short result summary with evidence links. A few lines suffice for an uneventful update. Reuse the maintained stage records rather than rewriting the one-shot reports; resource summaries and costs are handled by the existing tools.
+Only once ready, write `{{work_dir}}/ci-report.md` as a short result summary with evidence links, and `{{work_dir}}/ci-verdict.json` following the skill's CI Verdict format with run ID `{{run_id}}`. A few lines suffice for an uneventful update. Reuse the maintained stage records rather than rewriting the one-shot reports; resource summaries and costs are handled by the existing tools.
+
+Reattempt confirmation/reproduction for every unresolved prior finding on this revision, including for `NO_MODEL_CHANGE`. Prior conclusions alone do not count as current evidence. Keep their finding IDs and record the current disposition in `ci-verdict.json`; a verified repair is `FIXED`. Inspect the prior finding reports even when the baseline predates this verdict file.
 
 Only when the skill's applicable completion conditions are satisfied and all started work has been observed, end your final response with this exact line:
 
 SPECULA_INCREMENTAL_COMPLETE {{run_id}}
+
+Confirmed bugs do not prevent this workflow-completion marker or publication of a valid model. The controller separately returns CI failure for `REPRODUCED` and `ENV_LIMITED`, and a nonblocking warning for `MASKED`.
 
 If blocked or interrupted, save brief progress and the next step in the existing records or handoff, not a final CI report, and do not emit that line. The current CI model will remain unchanged. On manual resume, continue this same conversation and workspace, including any partial report; do not restart valid completed work.

--- a/src/specula/prompts/incremental.md
+++ b/src/specula/prompts/incremental.md
@@ -20,7 +20,7 @@ Follow the skill's Readiness and Final Reporting guidance. First briefly check r
 
 Only once ready, write `{{work_dir}}/ci-report.md` as a short result summary with evidence links, and `{{work_dir}}/ci-verdict.json` following the skill's CI Verdict format with run ID `{{run_id}}`. A few lines suffice for an uneventful update. Reuse the maintained stage records rather than rewriting the one-shot reports; resource summaries and costs are handled by the existing tools.
 
-Reattempt confirmation/reproduction for every unresolved prior finding on this revision, including for `NO_MODEL_CHANGE`. Keep their finding IDs and record the current disposition in `ci-verdict.json`; a verified repair is `FIXED`. Inspect the prior finding reports even when the baseline predates this verdict file.
+Reattempt confirmation/reproduction for prior bug and warning findings on this revision, including for `NO_MODEL_CHANGE`. Keep their finding IDs and record the current disposition in `ci-verdict.json`; a verified repair is `FIXED`. Inspect the prior finding reports even when the baseline predates this verdict file.
 
 Only when the skill's applicable completion conditions are satisfied and all started work has been observed, end your final response with this exact line:
 

--- a/src/specula/prompts/incremental.md
+++ b/src/specula/prompts/incremental.md
@@ -20,12 +20,12 @@ Follow the skill's Readiness and Final Reporting guidance. First briefly check r
 
 Only once ready, write `{{work_dir}}/ci-report.md` as a short result summary with evidence links, and `{{work_dir}}/ci-verdict.json` following the skill's CI Verdict format with run ID `{{run_id}}`. A few lines suffice for an uneventful update. Reuse the maintained stage records rather than rewriting the one-shot reports; resource summaries and costs are handled by the existing tools.
 
-Reattempt confirmation/reproduction for every unresolved prior finding on this revision, including for `NO_MODEL_CHANGE`. Prior conclusions alone do not count as current evidence. Keep their finding IDs and record the current disposition in `ci-verdict.json`; a verified repair is `FIXED`. Inspect the prior finding reports even when the baseline predates this verdict file.
+Reattempt confirmation/reproduction for every unresolved prior finding on this revision, including for `NO_MODEL_CHANGE`. Keep their finding IDs and record the current disposition in `ci-verdict.json`; a verified repair is `FIXED`. Inspect the prior finding reports even when the baseline predates this verdict file.
 
 Only when the skill's applicable completion conditions are satisfied and all started work has been observed, end your final response with this exact line:
 
 SPECULA_INCREMENTAL_COMPLETE {{run_id}}
 
-Confirmed bugs do not prevent this workflow-completion marker or publication of a valid model. The controller separately returns CI failure for `REPRODUCED` and `ENV_LIMITED`, and a nonblocking warning for `MASKED`.
+The controller returns CI failure for `REPRODUCED` and `ENV_LIMITED`, and a nonblocking warning for `MASKED`.
 
 If blocked or interrupted, save brief progress and the next step in the existing records or handoff, not a final CI report, and do not emit that line. The current CI model will remain unchanged. On manual resume, continue this same conversation and workspace, including any partial report; do not restart valid completed work.

--- a/src/specula/resource_summary.py
+++ b/src/specula/resource_summary.py
@@ -907,7 +907,7 @@ def render_summary(
         "",
         "## Detailed reports",
         "",
-        *_report_links(work_dir),
+        *_report_links(work_dir, complete=state.run_complete),
         "",
         "## Resource usage",
         "",
@@ -1017,7 +1017,7 @@ def findings_fragment_issue(content: str, confirmed_bugs: str | None = None) -> 
     return None
 
 
-def _confirmation_finding_statuses(content: str) -> dict[str, str] | None:
+def _confirmation_finding_statuses(content: str, *, impact_only: bool = True) -> dict[str, str] | None:
     lines = content.splitlines()
     headers = [
         index
@@ -1053,7 +1053,7 @@ def _confirmation_finding_statuses(content: str) -> dict[str, str] | None:
         )
         if status is None:
             return None
-        if status in _IMPACT_FINDING_STATUSES:
+        if not impact_only or status in _IMPACT_FINDING_STATUSES:
             statuses[finding_id] = status
     return statuses
 
@@ -1095,12 +1095,20 @@ def _fragment_finding_statuses(content: str, start: int, end: int) -> dict[str, 
     return statuses if status_fields == len(statuses) else None
 
 
-def _report_links(work_dir: Path | None) -> list[str]:
+def _report_links(work_dir: Path | None, *, complete: bool) -> list[str]:
     reports = (
         ("Confirmation report", "confirmed-bugs.md"),
         ("Severity report", "bug-severity.md"),
     )
     lines: list[str] = []
+    if work_dir is not None and _safe_regular_file(work_dir, work_dir / "ci-verdict.json"):
+        from specula import ci_verdict
+
+        try:
+            verdict = ci_verdict.read(work_dir) if complete else "INCOMPLETE"
+        except (OSError, ValueError, RuntimeError):
+            verdict = "INCOMPLETE"
+        lines.append(f"- CI verdict: **{verdict}** ([finding dispositions](ci-verdict.json))")
     if work_dir is not None and _safe_regular_file(work_dir, work_dir / "ci-report.md"):
         lines.append("- [Incremental CI report](ci-report.md)")
     for label, filename in reports:

--- a/tests/e2e/test_ci_bug_verdict.py
+++ b/tests/e2e/test_ci_bug_verdict.py
@@ -1,0 +1,180 @@
+"""Bug verdicts survive real CLI/event plumbing; adapters supply fixture evidence."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import test_github_ci as fixtures
+import test_incremental_ci as incremental_fixtures
+
+from specula.ci_store import CIStore
+
+
+class InitializationVerdict(unittest.TestCase):
+    def test_initialization_with_confirmed_bugs_publishes_baseline_and_exits_red(self) -> None:
+        fixture = incremental_fixtures.IncrementalCLI()
+        fixture.setUp()
+        self.addCleanup(fixture.doCleanups)
+        # Supply a final confirmation report and its matching summary through
+        # the fixture adapter. This tests finalization, not bug discovery.
+        report = (
+            "# Fixture confirmation\n\n"
+            "| Entry | Finding | Status | Counts as final bug? |\n|---|---|---|---|\n"
+            "| 1 | MC-1 | ENV_LIMITED | no |\n\n"
+            "## Entry 1: Fixture\n\n- **Finding ID**: MC-1\n- **Status**: ENV_LIMITED\n"
+        )
+        summary = (
+            "One fixture finding.\n\n## Findings\n\n"
+            "- **MC-1: Fixture** — Status: ENV_LIMITED. Fixture evidence only.\n\n"
+            "## Validation limits\n\nNo real verification performed.\n"
+        )
+        helper = fixture.adapter.with_suffix(".init-verdict.py")
+        helper.write_text(
+            "import sys\nfrom pathlib import Path\nwork=Path(sys.argv[1])\n"
+            f"(work/'confirmed-bugs.md').write_text({report!r})\n"
+            f"(work/'.summary-findings.md').write_text({summary!r})\n"
+        )
+        script = fixture.adapter.read_text().replace(
+            "esac\n",
+            "esac\n"
+            'if [ "$SPECULA_PHASE" = bug_classification ]; then\n'
+            f'  python3 {shlex.quote(str(helper))} "$SPECULA_WORK_DIR"\n'
+            "fi\n",
+        )
+        fixture.adapter.write_text(script)
+        result = fixture.run_ci("--ci-init", "--agent=fake", f"--artifact={fixture.source}", "footest")
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertEqual(CIStore(fixture.ci).current()["verdict"], "FAIL")
+        self.assertTrue((fixture.ci / "current/model/spec/base.tla").is_file())
+        self.assertTrue(json.loads((fixture.latest() / "ci-result.json").read_text())["complete"])
+
+
+class BugVerdictEvents(unittest.TestCase):
+    def setUp(self) -> None:
+        self.events = fixtures.GitHubEvents()
+        self.events.setUp()
+        self.addCleanup(self.events.doCleanups)
+        self.fixture = self.events.fixture
+        self.ci = self.fixture.ci
+
+    def test_red_push_and_repeated_events_preserve_failure_and_published_model(self) -> None:
+        before = (self.ci / "current").resolve()
+        self.fixture.change_source("bug fixture\n")
+        self.fixture.finding_status("REPRODUCED")
+        result, reports = self.events.push()
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        baseline = (self.ci / "current").resolve()
+        self.assertNotEqual(before, baseline)
+        self.assertEqual(CIStore(self.ci).current()["verdict"], "FAIL")
+        self.assertIn("| FAIL |", (reports / "summary.md").read_text())
+        self.assertTrue(list(reports.glob("*/ci-verdict.json")))
+        for kind in ("schedule", "workflow_dispatch"):
+            result, reports = self.events.event(kind, {})
+            self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+            self.assertIn("| FAIL |", (reports / "summary.md").read_text())
+        result, _ = self.events.push()
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(self.events.calls(), 1)
+        self.assertEqual((self.ci / "current").resolve(), baseline)
+
+        # A new source version reruns confirmation. Its fix can turn CI green.
+        self.fixture.change_source("fixed fixture\n")
+        self.fixture.finding_status("FIXED")
+        result, reports = self.events.push()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(self.events.calls(), 2)
+        self.assertIn("| PASS |", (reports / "summary.md").read_text())
+        self.assertIn("-bug fixture\n+fixed fixture", (self.fixture.latest() / "source.diff").read_text())
+
+    def test_red_candidate_survives_duplicate_queue_and_squash_inheritance(self) -> None:
+        self.events.prepare_pr()
+        self.fixture.finding_status("ENV_LIMITED")
+        baseline = (self.ci / "current").resolve()
+        for _ in range(2):
+            result, reports = self.events.open_pr()
+            self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+            self.assertIn("| FAIL |", (reports / "summary.md").read_text())
+        self.assertEqual(self.events.calls(), 1)
+        self.assertEqual((self.ci / "current").resolve(), baseline)
+        base = self.fixture.git("rev-parse", "trunk")
+        head = self.fixture.git("rev-parse", "feature")
+        group = self.fixture.git("commit-tree", f"{head}^{{tree}}", "-p", base, "-p", head, "-m", "merge group")
+        self.fixture.git("update-ref", "refs/heads/queue", group)
+        result, reports = self.events.event(
+            "merge_group",
+            {"action": "checks_requested", "merge_group": {"base_ref": "refs/heads/trunk", "head_sha": group}},
+        )
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("reused candidate result", (reports / "summary.md").read_text())
+        merged = self.events.squash()
+        result, reports = self.events.push()
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertEqual(self.events.calls(), 1)
+        self.assertEqual(CIStore(self.ci).current()["source_commit"], merged)
+        self.assertEqual(CIStore(self.ci).current()["verdict"], "FAIL")
+        self.assertIn("inherited PR result", (reports / "summary.md").read_text())
+
+    def test_masked_findings_are_visible_nonblocking_warnings(self) -> None:
+        self.fixture.change_source("masked fixture\n")
+        self.fixture.finding_status("MASKED")
+        with mock.patch.dict(os.environ, {"GITHUB_ACTIONS": "true"}):
+            for _ in range(2):
+                result, reports = self.events.push()
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("::warning::", result.stdout)
+                self.assertIn("| WARNING |", (reports / "summary.md").read_text())
+        self.assertEqual(self.events.calls(), 1)
+
+    def test_resuming_an_interrupted_check_can_finish_red_and_be_reused_red(self) -> None:
+        self.fixture.change_source("bug fixture\n")
+        fail = Path(f"{self.fixture.adapter}.fail")
+        fail.touch()
+        result, _ = self.events.push()
+        self.assertNotEqual(result.returncode, 0)
+        run = self.fixture.latest()
+        fail.unlink()
+        self.fixture.finding_status("REPRODUCED")
+        result = self.fixture.run_ci(f"--run-id={run.name}")
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        receipt = json.loads((run / "ci-result.json").read_text())
+        self.assertTrue(receipt["complete"])
+        result, reports = self.events.push()
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertEqual(self.events.calls(), 2)
+        self.assertIn("reused current result", (reports / "summary.md").read_text())
+
+    def test_legacy_completion_without_a_verdict_requires_a_fresh_check(self) -> None:
+        self.fixture.change_source("fixture update\n")
+        result, _ = self.events.push()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        state_path = self.ci / "current/state.json"
+        state = json.loads(state_path.read_text())
+        del state["verdict"]
+        state_path.write_text(json.dumps(state))
+        for path in (self.ci / ".github-ci/attempts").glob("*.json"):
+            attempt = json.loads(path.read_text())
+            del attempt["verdict"]
+            path.write_text(json.dumps(attempt))
+        self.fixture.finding_status("REPRODUCED")
+        result, reports = self.events.push()
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertEqual(self.events.calls(), 2)
+        self.assertIn("| FAIL |", (reports / "summary.md").read_text())
+
+    def test_delayed_event_does_not_turn_a_red_cumulative_check_green(self) -> None:
+        self.fixture.change_source("earlier fixture\n")
+        earlier = self.fixture.git("rev-parse", "HEAD")
+        self.fixture.change_source("later fixture\n")
+        self.fixture.finding_status("REPRODUCED")
+        result, _ = self.events.push()
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        result, reports = self.events.push(earlier)
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("no separate check", (reports / "summary.md").read_text())
+        self.assertIn("| FAIL |", (reports / "summary.md").read_text())
+        self.assertEqual(self.events.calls(), 1)

--- a/tests/e2e/test_incremental_ci.py
+++ b/tests/e2e/test_incremental_ci.py
@@ -48,6 +48,14 @@ class IncrementalCLI(unittest.TestCase):
             '    if [ -f "$resume" ]; then cp "$resume" "$0.resumed"; fi\n'
             '    if [ ! -f "$0.nochange" ]; then printf "updated fixture model\\n" > "$SPECULA_WORK_DIR/spec/base.tla"; fi\n'
             '    printf "# CI fixture report\\nNo real verification performed.\\n" > "$SPECULA_WORK_DIR/ci-report.md"\n'
+            "    python3 -c 'import json,sys; from pathlib import Path; "
+            "work,run,adapter=map(Path,sys.argv[1:]); "
+            'flag=Path(str(adapter)+".findings"); '
+            "findings=json.loads(flag.read_text()) if flag.exists() else []; "
+            '(work/"spec/confirmation-fixture.md").write_text("Current fixture confirmation for " + run.name); '
+            '(work/"ci-verdict.json").write_text(json.dumps({"version":1,"run_id":run.name,"findings":findings}))\' '
+            '"$SPECULA_WORK_DIR" "$SPECULA_RUN_DIR" "$0"\n'
+            '    if [ -f "$0.omit-verdict" ]; then rm "$SPECULA_WORK_DIR/ci-verdict.json"; fi\n'
             '    printf \'{"agent":"codex","session_id":"fixture-native-session","usage":{"total_tokens":150,"cached_input_tokens":50},"total_cost_usd":0.01,"usage_complete":true}\\n\' > "${log%.log}.usage.json"\n'
             '    printf "SPECULA_INCREMENTAL_COMPLETE %s\\n" "$(basename "$SPECULA_RUN_DIR")" > "$log"\n'
             "    exit 0\n"
@@ -75,6 +83,80 @@ class IncrementalCLI(unittest.TestCase):
     def change_source(self, text: str) -> None:
         (self.source / "logic.txt").write_text(text)
         self.commit("update")
+
+    def finding_status(self, status: str) -> None:
+        Path(f"{self.adapter}.findings").write_text(
+            json.dumps([{"id": "MC-1", "status": status, "evidence": "spec/confirmation-fixture.md"}])
+        )
+
+    def test_confirmed_bugs_fail_but_publish_a_completed_model(self) -> None:
+        self.initialize()
+        for status in ("REPRODUCED", "ENV_LIMITED"):
+            with self.subTest(status=status):
+                previous = (self.ci / "current").resolve()
+                self.change_source(f"{status} fixture\n")
+                self.finding_status(status)
+                result = self.run_ci("--incremental", "--agent=fake")
+                self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+                self.assertIn("CI verdict: FAIL", result.stdout)
+                self.assertIn("Current CI model updated", result.stdout)
+                self.assertNotEqual((self.ci / "current").resolve(), previous)
+                state = CIStore(self.ci).current()
+                self.assertEqual(state["source_commit"], self.git("rev-parse", "HEAD"))
+                self.assertEqual(state["verdict"], "FAIL")
+                receipt = json.loads((self.latest() / "ci-result.json").read_text())
+                self.assertTrue(receipt["complete"])
+                self.assertEqual(receipt["verdict"], "FAIL")
+                self.assertIn(
+                    "CI verdict: **FAIL**", (self.latest() / "footest/.specula-output/summary.md").read_text()
+                )
+                usage = json.loads((self.latest() / "footest/.specula-output/.resource-summary-state.json").read_text())
+                self.assertTrue(usage["run_complete"])
+
+    def test_warning_and_verified_fix_can_advance_a_red_baseline(self) -> None:
+        self.initialize()
+        self.change_source("bug fixture\n")
+        self.finding_status("REPRODUCED")
+        self.assertEqual(self.run_ci("--incremental", "--agent=fake").returncode, 2)
+        for status, verdict in (("MASKED", "WARNING"), ("FIXED", "PASS")):
+            with self.subTest(status=status):
+                self.change_source(f"{status} fixture\n")
+                self.finding_status(status)
+                result = self.run_ci("--incremental", "--agent=fake")
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertEqual(CIStore(self.ci).current()["verdict"], verdict)
+                self.assertIn(f"CI verdict: {verdict}", result.stdout)
+                evidence = (self.ci / "current/model/spec/confirmation-fixture.md").read_text()
+                self.assertIn(self.latest().name, evidence)
+        self.assertIn("-MASKED fixture\n+FIXED fixture", (self.latest() / "source.diff").read_text())
+
+    def test_old_findings_require_a_current_disposition_even_without_model_changes(self) -> None:
+        self.initialize()
+        self.change_source("bug fixture\n")
+        self.finding_status("REPRODUCED")
+        self.assertEqual(self.run_ci("--incremental", "--agent=fake").returncode, 2)
+        baseline = (self.ci / "current").resolve()
+        self.change_source("unrelated fixture update\n")
+        Path(f"{self.adapter}.nochange").touch()
+        Path(f"{self.adapter}.findings").unlink()
+        result = self.run_ci("--incremental", "--agent=fake")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("prior findings need current confirmation: MC-1", result.stdout)
+        self.assertEqual((self.ci / "current").resolve(), baseline)
+        self.assertFalse((self.latest() / "ci-result.json").exists())
+        summary = (self.latest() / "footest/.specula-output/summary.md").read_text()
+        self.assertNotIn("CI verdict: **PASS**", summary)
+        self.assertIn("CI verdict: **INCOMPLETE**", summary)
+
+    def test_completion_marker_without_verdict_is_not_a_passing_check(self) -> None:
+        self.initialize()
+        baseline = (self.ci / "current").resolve()
+        self.change_source("update\n")
+        Path(f"{self.adapter}.omit-verdict").touch()
+        result = self.run_ci("--incremental", "--agent=fake")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing current ci-verdict.json", result.stdout)
+        self.assertEqual((self.ci / "current").resolve(), baseline)
 
     def test_compaction_yield_does_not_publish_and_failure_continues(self) -> None:
         self.initialize()

--- a/tests/e2e/test_incremental_ci.py
+++ b/tests/e2e/test_incremental_ci.py
@@ -130,6 +130,25 @@ class IncrementalCLI(unittest.TestCase):
                 self.assertIn(self.latest().name, evidence)
         self.assertIn("-MASKED fixture\n+FIXED fixture", (self.latest() / "source.diff").read_text())
 
+    def test_information_is_saved_but_pending_repair_fails_without_publishing(self) -> None:
+        self.initialize()
+        for status in ("NEEDS MORE INFO", "DEFERRED"):
+            self.change_source(f"{status} fixture\n")
+            self.finding_status(status)
+            result = self.run_ci("--incremental", "--agent=fake")
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            record = json.loads((self.ci / "current/model/ci-verdict.json").read_text())
+            self.assertEqual(record["findings"][0]["status"], status)
+            self.assertEqual(CIStore(self.ci).current()["verdict"], "PASS")
+        baseline = (self.ci / "current").resolve()
+        self.change_source("pending repair fixture\n")
+        self.finding_status("PENDING REPAIR")
+        result = self.run_ci("--incremental", "--agent=fake")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("CI workflow did not converge (PENDING REPAIR)", result.stdout)
+        self.assertEqual((self.ci / "current").resolve(), baseline)
+        self.assertFalse((self.latest() / "ci-result.json").exists())
+
     def test_old_findings_require_a_current_disposition_even_without_model_changes(self) -> None:
         self.initialize()
         self.change_source("bug fixture\n")

--- a/tests/unit/test_ci_store.py
+++ b/tests/unit/test_ci_store.py
@@ -44,6 +44,7 @@ class StoreTests(unittest.TestCase):
             "snapshot_commit": commit,
             "dirty": False,
             "guidance": "scope",
+            "verdict": "PASS",
         }
 
     def test_publication_copies_assets_and_binds_source(self) -> None:

--- a/tests/unit/test_ci_verdict.py
+++ b/tests/unit/test_ci_verdict.py
@@ -35,6 +35,9 @@ def write_record(work: Path, statuses: list[str], **overrides: Any) -> None:
         (["MASKED"], "WARNING", 0),
         (["FALSE POSITIVE", "FIXED", "DROPPED"], "PASS", 0),
         (["MASKED", "REPRODUCED"], "FAIL", 2),
+        (["NEEDS MORE INFO", "DEFERRED"], "PASS", 0),
+        (["NEEDS MORE INFO", "REPRODUCED"], "FAIL", 2),
+        (["DEFERRED", "MASKED"], "WARNING", 0),
     ],
 )
 def test_verdict_is_computed_from_all_dispositions(
@@ -45,10 +48,10 @@ def test_verdict_is_computed_from_all_dispositions(
     assert ci_verdict.exit_code(verdict) == code
 
 
-@pytest.mark.parametrize("status", ["NEEDS MORE INFO", "PENDING REPAIR", "DEFERRED", "INCOMPLETE", "unknown"])
+@pytest.mark.parametrize("status", ["PENDING REPAIR", "INCOMPLETE", "unknown"])
 def test_unresolved_disposition_cannot_pass(tmp_path: Path, status: str) -> None:
     write_record(tmp_path, [status])
-    with pytest.raises(CIError, match="unresolved or invalid"):
+    with pytest.raises(CIError, match="did not converge|unresolved or invalid"):
         ci_verdict.read(tmp_path, "current")
 
 
@@ -97,20 +100,38 @@ def test_prior_bug_cannot_disappear_from_the_next_run(tmp_path: Path) -> None:
         ci_verdict.read(current, "current", previous=prior)
 
 
-@pytest.mark.parametrize("status", ["REPRODUCED", "ENV_LIMITED", "MASKED", "NEEDS MORE INFO"])
-def test_initialization_uses_final_confirmation_dispositions(tmp_path: Path, status: str) -> None:
+def test_prior_information_does_not_require_further_processing(tmp_path: Path) -> None:
+    prior, current = tmp_path / "old", tmp_path / "new"
+    write_record(prior, ["NEEDS MORE INFO", "DEFERRED"])
+    retained = (prior / ci_verdict.FILENAME).read_bytes()
+    write_record(current, [])
+    assert ci_verdict.read(current, "current", previous=prior) == "PASS"
+    assert (prior / ci_verdict.FILENAME).read_bytes() == retained
+
+
+@pytest.mark.parametrize(
+    ("status", "verdict"),
+    [
+        ("REPRODUCED", "FAIL"),
+        ("ENV_LIMITED", "FAIL"),
+        ("MASKED", "WARNING"),
+        ("NEEDS MORE INFO", "PASS"),
+        ("DEFERRED (repair loop exhausted; RR-001 in deferred/)", "PASS"),
+        ("PENDING REPAIR (RR-001)", None),
+    ],
+)
+def test_initialization_uses_final_confirmation_dispositions(tmp_path: Path, status: str, verdict: str | None) -> None:
     (tmp_path / "confirmed-bugs.md").write_text(
         "# Confirmation Report\n\n"
         "| Entry | Finding | Status | Counts as final bug? |\n"
         "|---|---|---|---|\n"
         f"| 1 | MC-1 | {status} | no |\n\n"
     )
-    if status == "NEEDS MORE INFO":
-        with pytest.raises(CIError, match="unresolved"):
+    if verdict is None:
+        with pytest.raises(CIError, match="did not converge"):
             ci_verdict.from_confirmation(tmp_path, "init")
     else:
-        verdict = ci_verdict.from_confirmation(tmp_path, "init")
-        assert verdict == ("WARNING" if status == "MASKED" else "FAIL")
+        assert ci_verdict.from_confirmation(tmp_path, "init") == verdict
 
 
 def test_missing_or_malformed_cached_verdict_is_not_green() -> None:

--- a/tests/unit/test_ci_verdict.py
+++ b/tests/unit/test_ci_verdict.py
@@ -1,0 +1,120 @@
+"""CI gates use explicit current dispositions and retain prior finding coverage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from specula import ci_verdict
+from specula.ci_store import CIError
+
+
+def write_record(work: Path, statuses: list[str], **overrides: Any) -> None:
+    work.mkdir(exist_ok=True)
+    (work / "evidence.md").write_text("Current fixture confirmation evidence; no real verification performed.\n")
+    record = {
+        "version": 1,
+        "run_id": "current",
+        "findings": [
+            {"id": f"MC-{i}", "status": status, "evidence": "evidence.md"} for i, status in enumerate(statuses)
+        ],
+        **overrides,
+    }
+    (work / ci_verdict.FILENAME).write_text(json.dumps(record))
+
+
+@pytest.mark.parametrize(
+    ("statuses", "verdict", "code"),
+    [
+        ([], "PASS", 0),
+        (["REPRODUCED"], "FAIL", 2),
+        (["ENV_LIMITED"], "FAIL", 2),
+        (["MASKED"], "WARNING", 0),
+        (["FALSE POSITIVE", "FIXED", "DROPPED"], "PASS", 0),
+        (["MASKED", "REPRODUCED"], "FAIL", 2),
+    ],
+)
+def test_verdict_is_computed_from_all_dispositions(
+    tmp_path: Path, statuses: list[str], verdict: str, code: int
+) -> None:
+    write_record(tmp_path, statuses)
+    assert ci_verdict.read(tmp_path, "current") == verdict
+    assert ci_verdict.exit_code(verdict) == code
+
+
+@pytest.mark.parametrize("status", ["NEEDS MORE INFO", "PENDING REPAIR", "DEFERRED", "INCOMPLETE", "unknown"])
+def test_unresolved_disposition_cannot_pass(tmp_path: Path, status: str) -> None:
+    write_record(tmp_path, [status])
+    with pytest.raises(CIError, match="unresolved or invalid"):
+        ci_verdict.read(tmp_path, "current")
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"run_id": "old"},
+        {"version": True},
+        {"findings": None},
+        {"findings": [None]},
+        {"findings": [{"id": "MC-0", "status": "REPRODUCED"}]},
+        {"findings": [{"id": "MC-0", "status": [], "evidence": "evidence.md"}]},
+        {"findings": [{"id": "MC-0", "status": "MASKED", "evidence": "evidence.md"}] * 2},
+    ],
+)
+def test_stale_or_malformed_record_cannot_pass(tmp_path: Path, overrides: dict[str, Any]) -> None:
+    write_record(tmp_path, [], **overrides)
+    with pytest.raises(CIError):
+        ci_verdict.read(tmp_path, "current")
+
+
+def test_missing_and_unsafe_evidence_cannot_pass(tmp_path: Path) -> None:
+    with pytest.raises(CIError, match="missing current"):
+        ci_verdict.read(tmp_path, "current")
+    write_record(tmp_path, ["REPRODUCED"])
+    evidence = tmp_path / "evidence.md"
+    evidence.write_text("")
+    with pytest.raises(CIError, match="confirmation evidence"):
+        ci_verdict.read(tmp_path, "current")
+    evidence.unlink()
+    evidence.symlink_to(tmp_path / ci_verdict.FILENAME)
+    with pytest.raises(CIError, match="confirmation evidence"):
+        ci_verdict.read(tmp_path, "current")
+
+
+def test_prior_bug_cannot_disappear_from_the_next_run(tmp_path: Path) -> None:
+    prior, current = tmp_path / "old", tmp_path / "new"
+    write_record(prior, ["REPRODUCED", "ENV_LIMITED", "MASKED"])
+    write_record(current, [])
+    with pytest.raises(CIError, match="prior findings need current confirmation"):
+        ci_verdict.read(current, "current", previous=prior)
+    write_record(current, ["FIXED", "FIXED", "MASKED"])
+    assert ci_verdict.read(current, "current", previous=prior) == "WARNING"
+    write_record(current, ["DROPPED", "FIXED", "MASKED"])
+    with pytest.raises(CIError, match="cannot be dropped"):
+        ci_verdict.read(current, "current", previous=prior)
+
+
+@pytest.mark.parametrize("status", ["REPRODUCED", "ENV_LIMITED", "MASKED", "NEEDS MORE INFO"])
+def test_initialization_uses_final_confirmation_dispositions(tmp_path: Path, status: str) -> None:
+    (tmp_path / "confirmed-bugs.md").write_text(
+        "# Confirmation Report\n\n"
+        "| Entry | Finding | Status | Counts as final bug? |\n"
+        "|---|---|---|---|\n"
+        f"| 1 | MC-1 | {status} | no |\n\n"
+    )
+    if status == "NEEDS MORE INFO":
+        with pytest.raises(CIError, match="unresolved"):
+            ci_verdict.from_confirmation(tmp_path, "init")
+    else:
+        verdict = ci_verdict.from_confirmation(tmp_path, "init")
+        assert verdict == ("WARNING" if status == "MASKED" else "FAIL")
+
+
+def test_missing_or_malformed_cached_verdict_is_not_green() -> None:
+    values: list[object] = [None, "", "complete", [], {}]
+    for value in values:
+        with pytest.raises(CIError, match="missing or invalid CI verdict"):
+            ci_verdict.exit_code(value)


### PR DESCRIPTION
Specula could complete a check, confirm a real implementation bug, and still return success. CI now derives a separate verdict from the final finding dispositions: `REPRODUCED` and `ENV_LIMITED` return exit code 2, while `MASKED` produces a nonblocking warning. `NEEDS MORE INFO` and `DEFERRED` are informational; a remaining `PENDING REPAIR` fails the workflow.

Each new incremental workflow reattempts confirmation/reproduction of prior bug and warning findings, including `NO_MODEL_CHANGE` runs. A run-bound `ci-verdict.json` records current dispositions and evidence references. Initialization derives its verdict from the existing confirmation report. Exact-result reuse, merge inheritance, cached events, and native resume preserve failures and warnings; completion-only legacy results require a fresh check.

Validation covers CLI/state/verdict regressions, Ruff, mypy, shell syntax and symlink checks, invariant-checking helper tests, and trace-debugger basic checks.
