### PR TITLE
Improve run feedback and preserve pipeline history

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -491,3 +491,5 @@ The scheduler owns `--run-id`, `--isolate`, and `--no-isolate` so that each task
 Agent activity is printed during each step and written to its log. Silent periods do not produce inactivity reminders. Set `SPECULA_PROGRESS=off` to disable live reporting. During or after a default isolated run, start with the run-level `index.md` to choose a target and browse its results; for a legacy single-target run, start with `.specula-output/index.md`. Use `pipeline-summary.md` for final deliverable status and `pipeline.log` for troubleshooting.
 
 Starting or resuming a run appends to its existing `pipeline.log`. Each invocation has a unique ID, UTC start and end timestamps, and its final exit code. Previous output is retained without automatic rotation or cleanup.
+
+Use `confirmed-bugs.md` for current confirmation results. Existing per-finding `verdict.md` files are labelled as historical records without changing their original text. Each finding's `error.txt` retains timestamped errors across retries, including after a successful confirmation.

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -488,4 +488,6 @@ The scheduler owns `--run-id`, `--isolate`, and `--no-isolate` so that each task
 
 ## Progress and Logs
 
-Agent activity is printed during each step and written to its log. Set `SPECULA_PROGRESS=off` to disable live reporting. During or after a default isolated run, start with the run-level `index.md` to choose a target and browse its results; for a legacy single-target run, start with `.specula-output/index.md`. Use `pipeline-summary.md` for final deliverable status and `pipeline.log` for troubleshooting.
+Agent activity is printed during each step and written to its log. Silent periods do not produce inactivity reminders. Set `SPECULA_PROGRESS=off` to disable live reporting. During or after a default isolated run, start with the run-level `index.md` to choose a target and browse its results; for a legacy single-target run, start with `.specula-output/index.md`. Use `pipeline-summary.md` for final deliverable status and `pipeline.log` for troubleshooting.
+
+Starting or resuming a run appends to its existing `pipeline.log`. Each invocation has a unique ID, UTC start and end timestamps, and its final exit code. Previous output is retained without automatic rotation or cleanup.

--- a/src/specula/confirmlib.py
+++ b/src/specula/confirmlib.py
@@ -35,6 +35,7 @@ import shutil
 import stat
 import subprocess
 import threading
+import time
 import traceback
 from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
@@ -2107,7 +2108,9 @@ def run_finding_safe(
             cfg.clear_policy_states(("finding", f.id))
         try:
             f.fdir.mkdir(parents=True, exist_ok=True)
-            (f.fdir / "error.txt").write_text(traceback.format_exc())
+            timestamp = time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime())
+            with (f.fdir / "error.txt").open("a", encoding="utf-8") as error_log:
+                error_log.write(f"\n=== Error at {timestamp} ===\n{traceback.format_exc()}")
         except OSError:
             pass
         failure_code = quota.RATE_LIMIT_RC if isinstance(exc, RateLimited) else 1
@@ -3478,6 +3481,26 @@ def _report_body(body: str) -> str:
     return "\n".join(lines).strip()
 
 
+def _label_historical_verdict(finding: Finding) -> None:
+    path = finding.fdir / "verdict.md"
+    if path.is_symlink() or not path.is_file():
+        return
+    notice = b"> Historical record. See [confirmed-bugs.md](../../confirmed-bugs.md) for the current result.\n\n"
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    try:
+        original = path.read_bytes()
+        if original.startswith(notice):
+            return
+        temporary.write_bytes(notice + original)
+        temporary.replace(path)
+    except OSError as exc:
+        with contextlib.suppress(OSError):
+            _log(f"  WARNING: cannot label historical verdict {path}: {exc}")
+    finally:
+        with contextlib.suppress(OSError):
+            temporary.unlink(missing_ok=True)
+
+
 def aggregate(cfg: ConfirmConfig, outcomes: list[Outcome]) -> None:
     """Write the phase's confirmed-bugs.md from the per-finding outcomes. This is
     the canonical Phase-4 deliverable the classification phase (Phase 4b) and the
@@ -3585,6 +3608,8 @@ def aggregate(cfg: ConfirmConfig, outcomes: list[Outcome]) -> None:
         lines.append("---")
         lines.append("")
     report.write_text("\n".join(lines))
+    for outcome in outcomes:
+        _label_historical_verdict(outcome.finding)
     _log(f"\nWrote {report}  ({len(outcomes)} findings, {len(reproduced)} reproduced)")
 
 

--- a/src/specula/phaselib.py
+++ b/src/specula/phaselib.py
@@ -1553,7 +1553,6 @@ class Phase:
             with contextlib.suppress(ValueError):
                 ignored.add(path.relative_to(work_dir))
         snapshot = progress.workspace_snapshot(work_dir, ignored)
-        started_at = time.monotonic()
         prelaunch_log_stamp = progress.file_stamp(files["log"])
         activity_log = activity_sidecar
         prelaunch_activity_stamp = progress.file_stamp(activity_log)
@@ -1594,9 +1593,7 @@ class Phase:
                 log=files["log"],
                 activity_log=activity_log,
                 ignored=ignored,
-                snapshot=snapshot,
                 reported_snapshot=snapshot,
-                last_observed_at=started_at,
                 log_stamp=prelaunch_log_stamp,
                 activity_stamp=prelaunch_activity_stamp,
                 adapter_name=adapter.stem,
@@ -3537,7 +3534,6 @@ Output:
         snapshot = progress.workspace_snapshot(wd, ignored)
         prelaunch_log_stamp = progress.file_stamp(log_file)
         prelaunch_activity_stamp = progress.file_stamp(activity_log)
-        started_at = time.monotonic()
         proc: subprocess.Popen[bytes] | None = None
         running: progress.RunningAgent | None = None
         try:
@@ -3574,9 +3570,7 @@ Output:
                 log=log_file,
                 activity_log=activity_log,
                 ignored=ignored,
-                snapshot=snapshot,
                 reported_snapshot=snapshot,
-                last_observed_at=started_at,
                 log_stamp=prelaunch_log_stamp,
                 activity_stamp=prelaunch_activity_stamp,
                 adapter_name=adapter.stem,

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -3960,10 +3960,8 @@ def main(argv: list[str]) -> int:
                     with log_path.open("a", encoding="utf-8") as log_stream:
                         log_stream.write("\n" + boundary + "\n")
                 except OSError as exc:
-                    print(f"ERROR: cannot append pipeline log: {exc}", file=terminal_stdout, flush=True)
-                    if code == 0:
-                        code = 1
-                    boundary = _invocation_boundary(invocation_id, f"finished (exit {code})")
+                    with contextlib.suppress(OSError, UnicodeError):
+                        print(f"WARNING: cannot append pipeline log: {exc}", file=terminal_stdout, flush=True)
             with contextlib.suppress(OSError, UnicodeError):
                 print(boundary, file=terminal_stdout, flush=True)
             if code == 0 and result_index is not None:

--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -4,7 +4,7 @@
 Runs the full phase sequence (analysis → specgen → harness → validation →
 confirmation [+ repair loop] → classification → summary) by invoking the
 per-phase launchers as subprocesses, exactly like the bash did — the dry-run
-command lines, the `main 2>&1 | tee pipeline.log` plumbing, the repair-request
+command lines, the `main 2>&1 | tee -a pipeline.log` plumbing, the repair-request
 state machine and the quota gate are all faithful ports of the bash, covered by
 tests/unit/test_pipelinelib.py and the end-to-end dry-run chain in tests/e2e.
 
@@ -3834,6 +3834,11 @@ class Pipeline:
         return 0
 
 
+def _invocation_boundary(invocation_id: str, status: str) -> str:
+    timestamp = time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime())
+    return f"=== Pipeline invocation {invocation_id}: {status} at {timestamp} ==="
+
+
 def main(argv: list[str]) -> int:
     # bash echo flushed per line; python block-buffers when stdout is a pipe
     # (everything below runs through the tee), which would hold progress lines
@@ -3869,7 +3874,8 @@ def main(argv: list[str]) -> int:
         out_dir.mkdir(parents=True, exist_ok=True)
         log_path = out_dir / "pipeline.log"
     p.pipeline_log_path = log_path
-    tee = subprocess.Popen(["tee", str(log_path)], stdin=subprocess.PIPE)
+    invocation_id = os.environ[resumelib.INVOCATION_ENV] if p.run_dir else secrets.token_hex(16)
+    tee = subprocess.Popen(["tee", "-a", str(log_path)], stdin=subprocess.PIPE)
     assert tee.stdin is not None  # stdin=PIPE
     tee_in = tee.stdin
     terminal_stdout = os.fdopen(os.dup(1), "w", encoding="utf-8", errors="surrogateescape")
@@ -3878,6 +3884,7 @@ def main(argv: list[str]) -> int:
     os.dup2(tee_in.fileno(), 1)  # fd-level: phase subprocesses inherit the tee
     os.dup2(tee_in.fileno(), 2)
     try:
+        print("\n" + _invocation_boundary(invocation_id, "started"))
         code = p.main()
     except SystemExit as e:
         code = e.code if isinstance(e.code, int) else 1
@@ -3947,6 +3954,18 @@ def main(argv: list[str]) -> int:
             if code == 0:
                 code = 1
         try:
+            boundary = _invocation_boundary(invocation_id, f"finished (exit {code})")
+            if tee_rc == 0:
+                try:
+                    with log_path.open("a", encoding="utf-8") as log_stream:
+                        log_stream.write("\n" + boundary + "\n")
+                except OSError as exc:
+                    print(f"ERROR: cannot append pipeline log: {exc}", file=terminal_stdout, flush=True)
+                    if code == 0:
+                        code = 1
+                    boundary = _invocation_boundary(invocation_id, f"finished (exit {code})")
+            with contextlib.suppress(OSError, UnicodeError):
+                print(boundary, file=terminal_stdout, flush=True)
             if code == 0 and result_index is not None:
                 with contextlib.suppress(OSError, UnicodeError):
                     print(

--- a/src/specula/progress.py
+++ b/src/specula/progress.py
@@ -20,8 +20,6 @@ class ProgressConfig:
     change_report_seconds: float = 5.0
     status_after_seconds: float = 60.0
     status_repeat_seconds: float = 300.0
-    quiet_after_seconds: float = 300.0
-    quiet_repeat_seconds: float = 300.0
 
 
 @dataclass
@@ -32,15 +30,11 @@ class RunningAgent:
     log: Path
     activity_log: Path
     ignored: set[Path]
-    snapshot: dict[Path, tuple[int, int]]
     reported_snapshot: dict[Path, tuple[int, int]]
-    last_observed_at: float
     log_stamp: tuple[int, int] | None
     activity_stamp: tuple[int, int] | None
     adapter_name: str
     last_change_report_at: float = 0.0
-    last_status_report_at: float = 0.0
-    last_quiet_report_at: float = 0.0
     last_output_report_at: float = 0.0
     reported_output: bool = False
     reported_sustained_output: bool = False
@@ -89,17 +83,6 @@ def workspace_snapshot(work_dir: Path, ignored: set[Path]) -> dict[Path, tuple[i
 
 def _ts() -> str:
     return time.strftime("%H:%M:%S")
-
-
-def _elapsed(seconds: float) -> str:
-    total = max(0, int(seconds))
-    hours, remainder = divmod(total, 3600)
-    minutes, secs = divmod(remainder, 60)
-    if hours:
-        return f"{hours}h{minutes:02}m"
-    if minutes:
-        return f"{minutes}m{secs:02}s"
-    return f"{secs}s"
 
 
 def _changes(before: dict[Path, tuple[int, int]], after: dict[Path, tuple[int, int]]) -> list[tuple[str, Path]]:
@@ -175,15 +158,12 @@ def report(running: list[RunningAgent], config: ProgressConfig) -> None:
     for agent in running:
         finished = agent.proc.poll() is not None
         snapshot = workspace_snapshot(agent.work_dir, agent.ignored)
-        observed_changes = _changes(agent.snapshot, snapshot)
-        agent.snapshot = snapshot
 
         activity_stamp = file_stamp(agent.activity_log)
         activity_changed = activity_stamp != agent.activity_stamp
         printed_event = False
         if activity_changed or (finished and agent.activity_buffer):
             agent.activity_stamp = activity_stamp
-            agent.last_observed_at = now
             for event in _read_events(agent, finished):
                 if not event or event == agent.last_event:
                     continue
@@ -195,12 +175,9 @@ def report(running: list[RunningAgent], config: ProgressConfig) -> None:
         log_changed = log_stamp != agent.log_stamp
         if log_changed:
             agent.log_stamp = log_stamp
-            agent.last_observed_at = now
 
         if not finished and (activity_changed or log_changed or printed_event):
             _report_output_state(agent, now, printed_event, config)
-        if observed_changes:
-            agent.last_observed_at = now
 
         reportable_changes = _changes(agent.reported_snapshot, snapshot)
         if reportable_changes and (
@@ -211,17 +188,3 @@ def report(running: list[RunningAgent], config: ProgressConfig) -> None:
             print(f"[{_ts()}] {agent.name}: {_describe_changes(reportable_changes)}")
             agent.reported_snapshot = snapshot
             agent.last_change_report_at = now
-
-        if not finished:
-            quiet_for = now - agent.last_observed_at
-            if quiet_for >= config.quiet_after_seconds:
-                if not agent.last_quiet_report_at or now - agent.last_quiet_report_at >= config.quiet_repeat_seconds:
-                    print(f"[{_ts()}] {agent.name}: quiet for {_elapsed(quiet_for)}; process is still alive")
-                    agent.last_quiet_report_at = now
-            elif quiet_for >= config.status_after_seconds:
-                if not agent.last_status_report_at or now - agent.last_status_report_at >= config.status_repeat_seconds:
-                    print(
-                        f"[{_ts()}] {agent.name}: no observable activity for "
-                        f"{_elapsed(quiet_for)}; process is still alive"
-                    )
-                    agent.last_status_report_at = now

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -538,6 +538,8 @@ class CliE2E(unittest.TestCase):
         )
         self.assertEqual(setup.returncode, 0, setup.stderr)
         run = root / "runs" / run_id
+        pipeline_log = run / "pipeline.log"
+        setup_log = pipeline_log.read_bytes()
         wd = run / "footest" / ".specula-output"
         for rel in (
             "modeling-brief.md",
@@ -566,10 +568,19 @@ class CliE2E(unittest.TestCase):
             cwd=work,
         )
         self.assertEqual(first.returncode, 9, first.stdout + first.stderr)
+        interrupted_log = pipeline_log.read_bytes()
+        self.assertTrue(interrupted_log.startswith(setup_log))
+        self.assertIn(b"finished (exit 9)", interrupted_log)
 
         resumed = self.run_cli(root, ["run", f"--run-id={run_id}"], cwd=work)
 
         self.assertEqual(resumed.returncode, 0, resumed.stdout + resumed.stderr)
+        self.assertTrue(pipeline_log.read_bytes().startswith(interrupted_log))
+        log_text = pipeline_log.read_text()
+        starts = re.findall(r"=== Pipeline invocation ([0-9a-f]{32}): started at", log_text)
+        finishes = re.findall(r"=== Pipeline invocation ([0-9a-f]{32}): finished \(exit (\d+)\)", log_text)
+        self.assertEqual(len(set(starts)), 3, log_text)
+        self.assertEqual(finishes, list(zip(starts, ("0", "9", "0"), strict=True)))
         self.assertEqual(Path(f"{adapter}.validation-count").read_text(), "xx")
         self.assertEqual(
             Path(f"{adapter}.validation-prompt").read_text(),

--- a/tests/e2e/test_incremental_ci.py
+++ b/tests/e2e/test_incremental_ci.py
@@ -113,6 +113,35 @@ class IncrementalCLI(unittest.TestCase):
                 usage = json.loads((self.latest() / "footest/.specula-output/.resource-summary-state.json").read_text())
                 self.assertTrue(usage["run_complete"])
 
+    def test_final_log_failure_preserves_passing_result_and_published_baseline(self) -> None:
+        self.initialize()
+        previous = (self.ci / "current").resolve()
+        self.change_source("updated source\n")
+        script = self.adapter.read_text().replace(
+            "    exit 0\n    ;;\n",
+            '    mv "$SPECULA_RUN_DIR/pipeline.log" "$SPECULA_RUN_DIR/pipeline-running.log"\n'
+            '    mkdir "$SPECULA_RUN_DIR/pipeline.log"\n'
+            "    exit 0\n    ;;\n",
+            1,
+        )
+        self.adapter.write_text(script)
+
+        result = self.run_ci("--incremental", "--agent=fake")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("WARNING: cannot append pipeline log:", result.stdout)
+        self.assertIn("finished (exit 0)", result.stdout)
+        current = (self.ci / "current").resolve()
+        self.assertNotEqual(current, previous)
+        self.assertEqual(CIStore(self.ci).current()["verdict"], "PASS")
+        self.assertEqual(CIStore(self.ci).current()["source_commit"], self.git("rev-parse", "HEAD"))
+        receipt = json.loads((self.latest() / "ci-result.json").read_text())
+        self.assertTrue(receipt["complete"])
+        self.assertEqual(receipt["verdict"], "PASS")
+        self.assertEqual(current, self.ci / receipt["snapshot"])
+        self.assertEqual((current / "model/spec/base.tla").read_text(), "updated fixture model\n")
+        self.assertTrue((self.latest() / "pipeline-running.log").is_file())
+
     def test_warning_and_verified_fix_can_advance_a_red_baseline(self) -> None:
         self.initialize()
         self.change_source("bug fixture\n")

--- a/tests/unit/test_confirmlib.py
+++ b/tests/unit/test_confirmlib.py
@@ -158,6 +158,102 @@ class TestVerdict(ConfirmCase):
         self.assertEqual(C.parse_verdict("VERDICT: DROPPED\nVERDICT: FALSE POSITIVE"), "FALSE POSITIVE")
 
 
+class TestHistoricalConfirmationFiles(ConfirmCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.ws = self.seed("T", [{"id": "MC-1", "source": "model-checking", "title": "t", "summary": "s"}])
+        self.work_dir = self.ws.work_dir("T")
+        self.fdir = self.work_dir / "confirmation" / "MC-1"
+        self.fdir.mkdir(parents=True)
+
+    def test_existing_verdict_is_labelled_once_on_success_and_cache_reuse(self) -> None:
+        verdict = self.fdir / "verdict.md"
+        original = b"# Previous verdict\r\nVERDICT: NEEDS MORE INFO\r\n"
+        verdict.write_bytes(original)
+        with mock.patch.object(
+            C, "run_agent_blocking", _fake_turn_with_repro(self.ws, "T", "MC-1", _response("REPRODUCED"))
+        ):
+            self.assertEqual(C.run_parallel_confirmation(self.cfg(self.ws, "T")), 0)
+
+        labelled = verdict.read_bytes()
+        self.assertTrue(labelled.startswith(b"> Historical record."))
+        self.assertTrue(labelled.endswith(original))
+        self.assertIn(b"[confirmed-bugs.md](../../confirmed-bugs.md)", labelled)
+        cache = (self.fdir / "verdict.json").read_bytes()
+        report = (self.work_dir / "confirmed-bugs.md").read_bytes()
+        self.assertIn(b"| 1 | MC-1 | REPRODUCED |", report)
+
+        verdict.write_bytes(original)
+        with mock.patch.object(C, "run_agent_blocking", _boom):
+            for _attempt in range(2):
+                self.assertEqual(C.run_parallel_confirmation(self.cfg(self.ws, "T")), 0)
+                self.assertEqual(verdict.read_bytes(), labelled)
+                self.assertEqual((self.fdir / "verdict.json").read_bytes(), cache)
+                self.assertEqual((self.work_dir / "confirmed-bugs.md").read_bytes(), report)
+
+    def test_missing_verdict_markdown_is_not_created(self) -> None:
+        with mock.patch.object(C, "run_agent_blocking", _fake_turn(_response("FALSE POSITIVE"))):
+            self.assertEqual(C.run_parallel_confirmation(self.cfg(self.ws, "T")), 0)
+        self.assertFalse((self.fdir / "verdict.md").exists())
+
+    def test_label_write_failure_preserves_original_and_confirmation_result(self) -> None:
+        verdict = self.fdir / "verdict.md"
+        original = b"VERDICT: NEEDS MORE INFO\n"
+        verdict.write_bytes(original)
+        original_replace = Path.replace
+
+        def fail_label_replace(path: Path, target: str | os.PathLike[str]) -> Path:
+            if Path(target) == verdict:
+                raise OSError("cannot replace historical note")
+            return original_replace(path, target)
+
+        with (
+            mock.patch.object(C, "run_agent_blocking", _fake_turn(_response("FALSE POSITIVE"))),
+            mock.patch.object(Path, "replace", fail_label_replace),
+            mock.patch.object(C, "_log") as log,
+        ):
+            self.assertEqual(C.run_parallel_confirmation(self.cfg(self.ws, "T")), 0)
+
+        self.assertEqual(verdict.read_bytes(), original)
+        self.assertIn("cannot replace historical note", str(log.call_args_list))
+        self.assertEqual(list(self.fdir.glob(".verdict.md.*.tmp")), [])
+        self.assertEqual(json.loads((self.fdir / "verdict.json").read_text())["status"], "FALSE POSITIVE")
+
+    def test_errors_append_and_survive_success_and_cache_reuse(self) -> None:
+        error = self.fdir / "error.txt"
+        original = b"older failure without a trailing newline"
+        error.write_bytes(original)
+        for failure_code in (9, 75):
+            before = error.read_bytes()
+            with mock.patch.object(C, "run_agent_blocking", _fake_turn("", rc=failure_code)):
+                self.assertEqual(C.run_parallel_confirmation(self.cfg(self.ws, "T")), 75 if failure_code == 75 else 1)
+            self.assertTrue(error.read_bytes().startswith(before + b"\n"))
+
+        history = error.read_bytes()
+        self.assertIn(b"adapter exited 9", history)
+        self.assertIn(b"RateLimited: MC-1 turn 1 A", history)
+        self.assertEqual(len(re.findall(rb"=== Error at \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC ===", history)), 2)
+        with mock.patch.object(C, "run_agent_blocking", _fake_turn(_response("FALSE POSITIVE"))):
+            self.assertEqual(C.run_parallel_confirmation(self.cfg(self.ws, "T")), 0)
+        with mock.patch.object(C, "run_agent_blocking", _boom):
+            self.assertEqual(C.run_parallel_confirmation(self.cfg(self.ws, "T")), 0)
+        self.assertEqual(error.read_bytes(), history)
+
+    def test_failed_rerun_keeps_previous_json_and_labels_existing_markdown(self) -> None:
+        with mock.patch.object(C, "run_agent_blocking", _fake_turn(_response("FALSE POSITIVE"))):
+            self.assertEqual(C.run_parallel_confirmation(self.cfg(self.ws, "T")), 0)
+        cache = (self.fdir / "verdict.json").read_bytes()
+        verdict = self.fdir / "verdict.md"
+        original = b"VERDICT: FALSE POSITIVE\n"
+        verdict.write_bytes(original)
+        with mock.patch.object(C, "run_agent_blocking", _fake_turn("", rc=9)):
+            self.assertEqual(C.run_parallel_confirmation(self.cfg(self.ws, "T", model="another-model")), 1)
+        self.assertEqual((self.fdir / "verdict.json").read_bytes(), cache)
+        self.assertTrue(verdict.read_bytes().startswith(b"> Historical record."))
+        self.assertTrue(verdict.read_bytes().endswith(original))
+        self.assertIn("| 1 | MC-1 | INCOMPLETE |", (self.work_dir / "confirmed-bugs.md").read_text())
+
+
 class TestConfirmConfigCompatibility(ConfirmCase):
     def test_legacy_positional_arguments_keep_their_meaning(self) -> None:
         ws = Workspace(["T"])

--- a/tests/unit/test_phaselib.py
+++ b/tests/unit/test_phaselib.py
@@ -3107,8 +3107,6 @@ class TestProgressReporting(PhaseCase):
             change_report_seconds=0.0,
             status_after_seconds=0.01,
             status_repeat_seconds=0.01,
-            quiet_after_seconds=0.025,
-            quiet_repeat_seconds=0.01,
         )
         self.patch_attr(phaselib.Phase, "progress_config", self.config)
         self.adapter = adapters / "fake.sh"
@@ -3368,12 +3366,13 @@ class TestProgressReporting(PhaseCase):
         self.assertIn(f"{NAME}: adapter error: BYOK providers require an explicit model.", out)
         self.assertIn(f"FAILED  {NAME}: adapter exited 1", out)
 
-    def test_quiet_liveness_is_sparse_and_can_be_disabled(self) -> None:
+    def test_quiet_agent_only_reports_completion(self) -> None:
         self.write_adapter("sleep 0.06\n")
         rc, out = self.run_fake()
         self.assertEqual(rc, 0, out)
-        self.assertIn(f"{NAME}: no observable activity", out)
-        self.assertIn(f"{NAME}: quiet for", out)
+        self.assertNotIn(f"{NAME}: no observable activity", out)
+        self.assertNotIn(f"{NAME}: quiet for", out)
+        self.assertIn(f"{NAME}: completed (exit 0)", out)
 
         self.set_env("SPECULA_PROGRESS", "off")
         rc, out = self.run_fake()
@@ -3438,9 +3437,7 @@ class TestProgressReporting(PhaseCase):
             log=root / "agent.log",
             activity_log=root / "agent.activity.jsonl",
             ignored=set(),
-            snapshot={},
             reported_snapshot={},
-            last_observed_at=0.0,
             log_stamp=None,
             activity_stamp=None,
             adapter_name="fake",
@@ -3481,9 +3478,7 @@ class TestProgressReporting(PhaseCase):
             log=root / "agent.log",
             activity_log=root / "agent.activity.jsonl",
             ignored=set(),
-            snapshot={},
             reported_snapshot={},
-            last_observed_at=0.0,
             log_stamp=None,
             activity_stamp=None,
             adapter_name="fake",
@@ -3523,9 +3518,7 @@ class TestProgressReporting(PhaseCase):
             log=root / "agent.log",
             activity_log=root / "agent.activity.jsonl",
             ignored=set(),
-            snapshot={},
             reported_snapshot={},
-            last_observed_at=0.0,
             log_stamp=None,
             activity_stamp=None,
             adapter_name="fake",
@@ -3553,9 +3546,7 @@ class TestProgressReporting(PhaseCase):
             log=root / "agent.log",
             activity_log=root / "agent.activity.jsonl",
             ignored=set(),
-            snapshot={},
             reported_snapshot={},
-            last_observed_at=0.0,
             log_stamp=None,
             activity_stamp=None,
             adapter_name="fake",
@@ -3577,9 +3568,7 @@ class TestProgressReporting(PhaseCase):
             log=root / "agent.log",
             activity_log=activity,
             ignored=set(),
-            snapshot={},
             reported_snapshot={},
-            last_observed_at=time.monotonic(),
             log_stamp=None,
             activity_stamp=progress_module.file_stamp(activity),
             adapter_name="codex",

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -17,6 +17,7 @@ import hashlib
 import io
 import json
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -3587,6 +3588,84 @@ class TestMainTeeTeardown(TmpCwd):
         log_text = (self.tmp / ".specula-output" / "pipeline.log").read_text()
         self.assertIn("pre-crash progress", log_text)
         self.assertIn("ValueError: boom", log_text)
+
+    def test_legacy_restarts_append_history_and_distinct_invocation_boundaries(self) -> None:
+        out = self.tmp / ".specula-output"
+        out.mkdir()
+        log_path = out / "pipeline.log"
+        original = b"older interrupted output without a newline"
+        log_path.write_bytes(original)
+        first = self._run_entry(
+            "def boom(self):\n    print('first attempt')\n    raise ValueError('boom')\npl.Pipeline.main = boom"
+        )
+        self.assertEqual(first.returncode, 1, first.stdout + first.stderr)
+        first_log = log_path.read_bytes()
+        self.assertTrue(first_log.startswith(original + b"\n"))
+
+        second = self._run_entry(
+            "def succeed(self):\n    print('second attempt')\n    return 0\npl.Pipeline.main = succeed"
+        )
+
+        self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+        self.assertTrue(log_path.read_bytes().startswith(first_log))
+        log_text = log_path.read_text()
+        starts = re.findall(r"=== Pipeline invocation ([0-9a-f]{32}): started at .* UTC ===", log_text)
+        finishes = re.findall(
+            r"=== Pipeline invocation ([0-9a-f]{32}): finished \(exit (\d+)\) at .* UTC ===", log_text
+        )
+        self.assertEqual(len(starts), 2, log_text)
+        self.assertEqual(len(set(starts)), 2)
+        self.assertEqual(finishes, [(starts[0], "1"), (starts[1], "0")])
+        self.assertLess(log_text.index("first attempt"), log_text.index("second attempt"))
+        self.assertEqual(log_text.count("ValueError: boom"), 1)
+        self.assertNotIn("first attempt", second.stdout)
+
+    def test_isolated_restart_preserves_interrupted_log(self) -> None:
+        setup = f"pl.SPECULA_ROOT = pl.Path({str(self.tmp)!r})\n"
+        first = self._run_entry(
+            setup
+            + "def interrupt(self):\n    print('before interruption')\n    raise KeyboardInterrupt\npl.Pipeline.main = interrupt",
+            ["--run-id=restart-run", "t|g|l|r"],
+        )
+        self.assertEqual(first.returncode, 130, first.stdout + first.stderr)
+        log_path = self.tmp / "runs" / "restart-run" / "pipeline.log"
+        first_log = log_path.read_bytes()
+        self.assertIn(b"finished (exit 130)", first_log)
+
+        second = self._run_entry(
+            setup + "pl.Pipeline.main = lambda self: 0",
+            ["--run-id=restart-run", "--fresh-context", "t|g|l|r"],
+        )
+
+        self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+        self.assertTrue(log_path.read_bytes().startswith(first_log))
+        self.assertIn("finished (exit 0)", log_path.read_text())
+
+    def test_log_boundary_records_final_ci_exit_code(self) -> None:
+        result = self._run_entry(
+            "pl.Pipeline.main = lambda self: 0\n"
+            "pl.Pipeline.finalize_ci_run = lambda self, code: ('CI verdict: FAIL', 2)"
+        )
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        log_text = (self.tmp / ".specula-output" / "pipeline.log").read_text()
+        self.assertIn("finished (exit 2)", log_text)
+        self.assertNotIn("finished (exit 0)", log_text)
+
+    def test_log_boundary_write_failure_fails_pipeline(self) -> None:
+        result = self._run_entry(
+            "original_open = pl.Path.open\n"
+            "def fail_boundary(path, mode='r', *args, **kwargs):\n"
+            "    if path.name == 'pipeline.log' and mode == 'a':\n"
+            "        raise OSError('boundary write failed')\n"
+            "    return original_open(path, mode, *args, **kwargs)\n"
+            "pl.Path.open = fail_boundary\n"
+            "pl.Pipeline.main = lambda self: 0"
+        )
+
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("boundary write failed", result.stdout)
+        self.assertNotIn("View all results:", result.stdout)
 
     def test_final_source_capture_runs_after_pipeline_failure(self) -> None:
         marker = self.tmp / "captured"

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -3652,20 +3652,27 @@ class TestMainTeeTeardown(TmpCwd):
         self.assertIn("finished (exit 2)", log_text)
         self.assertNotIn("finished (exit 0)", log_text)
 
-    def test_log_boundary_write_failure_fails_pipeline(self) -> None:
-        result = self._run_entry(
-            "original_open = pl.Path.open\n"
-            "def fail_boundary(path, mode='r', *args, **kwargs):\n"
-            "    if path.name == 'pipeline.log' and mode == 'a':\n"
-            "        raise OSError('boundary write failed')\n"
-            "    return original_open(path, mode, *args, **kwargs)\n"
-            "pl.Path.open = fail_boundary\n"
-            "pl.Pipeline.main = lambda self: 0"
-        )
+    def test_log_boundary_write_failure_preserves_final_exit_code(self) -> None:
+        for exit_code in (0, 2, 9):
+            with self.subTest(exit_code=exit_code):
+                result = self._run_entry(
+                    "original_open = pl.Path.open\n"
+                    "def fail_boundary(path, mode='r', *args, **kwargs):\n"
+                    "    if path.name == 'pipeline.log' and mode == 'a':\n"
+                    "        raise OSError('boundary write failed')\n"
+                    "    return original_open(path, mode, *args, **kwargs)\n"
+                    "pl.Path.open = fail_boundary\n"
+                    "pl.Pipeline.main = lambda self: 0\n"
+                    f"pl.Pipeline.finalize_ci_run = lambda self, code: (None, {exit_code})"
+                )
 
-        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-        self.assertIn("boundary write failed", result.stdout)
-        self.assertNotIn("View all results:", result.stdout)
+                self.assertEqual(result.returncode, exit_code, result.stdout + result.stderr)
+                self.assertIn("WARNING: cannot append pipeline log: boundary write failed", result.stdout)
+                self.assertIn(f"finished (exit {exit_code})", result.stdout)
+                if exit_code == 0:
+                    self.assertIn("View all results:", result.stdout)
+                else:
+                    self.assertNotIn("View all results:", result.stdout)
 
     def test_final_source_capture_runs_after_pipeline_failure(self) -> None:
         marker = self.tmp / "captured"

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -7,10 +7,10 @@ import io
 import json
 import subprocess
 import tempfile
-import time
 import unittest
 from collections.abc import Iterator
 from pathlib import Path
+from unittest import mock
 
 from specula import progress
 from specula.adapters.utils.event_stream import parse_events, stream_events
@@ -263,9 +263,7 @@ class TestProgressParsing(unittest.TestCase):
                 log=root / "agent.log",
                 activity_log=activity,
                 ignored={activity.relative_to(root)},
-                snapshot={},
                 reported_snapshot={},
-                last_observed_at=time.monotonic(),
                 log_stamp=None,
                 activity_stamp=None,
                 adapter_name="codex",
@@ -350,6 +348,45 @@ class TestProgressParsing(unittest.TestCase):
             self.assertIn("activity log", stderr.getvalue())
             self.assertEqual(log.read_text(), "first\nfinal\n")
 
+    def test_quiet_agent_stays_silent_and_reports_later_activity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            activity = root / "agent.activity.jsonl"
+            proc = mock.Mock(spec=subprocess.Popen)
+            proc.poll.return_value = None
+            agent = progress.RunningAgent(
+                name="target",
+                proc=proc,
+                work_dir=root,
+                log=root / "agent.log",
+                activity_log=activity,
+                ignored={activity.relative_to(root)},
+                reported_snapshot={},
+                log_stamp=None,
+                activity_stamp=None,
+                adapter_name="copilot-cli",
+            )
+            output = io.StringIO()
+            for tick in (61.0, 301.0, 601.0, 1201.0):
+                with (
+                    mock.patch("specula.progress.time.monotonic", return_value=tick),
+                    contextlib.redirect_stdout(output),
+                ):
+                    progress.report([agent], progress.ProgressConfig())
+                self.assertEqual(output.getvalue(), "")
+
+            events = [
+                {"type": "tool.execution_start", "data": {"toolName": "bash", "arguments": {"command": "make test"}}},
+                {"type": "session.error", "data": {"message": "provider unavailable"}},
+            ]
+            activity.write_text("\n".join(json.dumps(event) for event in events) + "\n")
+            (root / "report.md").write_text("new evidence\n")
+            with contextlib.redirect_stdout(output):
+                progress.report([agent], progress.ProgressConfig())
+            self.assertIn("target: running make test", output.getvalue())
+            self.assertIn("target: adapter error: provider unavailable", output.getvalue())
+            self.assertIn("target: created report.md", output.getvalue())
+
     def test_finished_agent_never_claims_process_is_still_alive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -362,9 +399,7 @@ class TestProgressParsing(unittest.TestCase):
                 log=root / "agent.log",
                 activity_log=root / "agent.activity.jsonl",
                 ignored=set(),
-                snapshot={},
                 reported_snapshot={},
-                last_observed_at=time.monotonic() - 600,
                 log_stamp=None,
                 activity_stamp=None,
                 adapter_name="codex",
@@ -388,9 +423,7 @@ class TestProgressParsing(unittest.TestCase):
                 log=log,
                 activity_log=root / "agent.activity.jsonl",
                 ignored={Path("agent.log")},
-                snapshot={},
                 reported_snapshot={},
-                last_observed_at=time.monotonic(),
                 log_stamp=None,
                 activity_stamp=None,
                 adapter_name="fake",


### PR DESCRIPTION
## Feedback from @munimthahmid 
- [x] Feedback 6: remove inactivity reminders while preserving real activity, errors, and completion reporting.
- [x] Feedback 7: append to `pipeline.log` across restarts and resumes, with invocation IDs, UTC boundaries, and final exit codes.
- [x] Feedback 5: label existing verdict Markdown as historical and append timestamped errors without deleting earlier records.
