### PR TITLE
Fix review routing on resumed runs

### DIFF
--- a/src/specula/pipelinelib.py
+++ b/src/specula/pipelinelib.py
@@ -1593,7 +1593,9 @@ class Pipeline:
             if phase is None:
                 assert self._restored_default is not None
                 return self._restored_default
-            route = f"review:{fallback}" if phase == "review" and fallback is not None else phase
+            route = phase
+            if phase == "review" and fallback is not None:
+                route = next(key for key, spec in self._route_specs().items() if spec == (phase, fallback))
             return self._restored_routes[route]
         if self.agent_routing is None:
             return AgentSelection(agent=self.agent, model=self.model, effort=self.effort)

--- a/tests/e2e/test_cli_pipeline.py
+++ b/tests/e2e/test_cli_pipeline.py
@@ -479,6 +479,12 @@ class CliE2E(unittest.TestCase):
         self.assertEqual(supplied.read_text(), "---- MODULE Model ----\n====\n")
 
     def test_run_id_resumes_interrupted_validation_without_phase_skip_flags(self) -> None:
+        self._resume_interrupted_validation(enable_reviews=False)
+
+    def test_run_id_resumes_interrupted_validation_with_saved_review_route(self) -> None:
+        self._resume_interrupted_validation(enable_reviews=True)
+
+    def _resume_interrupted_validation(self, *, enable_reviews: bool) -> None:
         root = self.specroot()
         work = self.workdir()
         artifact = work / "artifact"
@@ -523,13 +529,40 @@ class CliE2E(unittest.TestCase):
         adapter.chmod(0o755)
         target = "footest|owner/repo|Go|reference"
         run_id = "resume-validation"
+        config = work / "agents.json"
+        reviewer = adapter.with_name("fake-reviewer.sh")
+        routing_args = ["--agent=fake"]
+        if enable_reviews:
+            config.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "default_profile": "worker",
+                        "profiles": {
+                            "worker": {"agent": "fake", "model": "worker-model", "effort": "medium"},
+                            "reviewer": {"agent": "fake-reviewer", "model": "review-model", "effort": "high"},
+                        },
+                        "phases": {"review": "reviewer"},
+                    }
+                )
+            )
+            reviewer.write_text(
+                "#!/bin/sh\nset -eu\n"
+                'printf "%s\\n" "$@" > "$0.args"\n'
+                'for arg do case "$arg" in --log=*) log=${arg#*=} ;; esac; done\n'
+                'test "${log##*/}" = "review-validation.log"\n'
+                'printf "fixture review\\n" > "$SPECULA_WORK_DIR/spec/review-validation.md"\n'
+                'printf "review completed\\n" > "$log"\n'
+            )
+            reviewer.chmod(0o755)
+            routing_args = [f"--agent-config={config}", "--enable-reviews"]
 
         setup = self.run_cli(
             root,
             [
                 "run",
                 f"--run-id={run_id}",
-                "--agent=fake",
+                *routing_args,
                 f"--artifact={artifact}",
                 *ALL_PHASE_SKIPS,
                 target,
@@ -558,6 +591,7 @@ class CliE2E(unittest.TestCase):
                 "run",
                 f"--run-id={run_id}",
                 "--fresh-context",
+                *(routing_args if enable_reviews else []),
                 "--skip-analysis",
                 "--skip-specgen",
                 "--skip-harness",
@@ -571,10 +605,18 @@ class CliE2E(unittest.TestCase):
         interrupted_log = pipeline_log.read_bytes()
         self.assertTrue(interrupted_log.startswith(setup_log))
         self.assertIn(b"finished (exit 9)", interrupted_log)
+        if enable_reviews:
+            self.assertFalse(Path(f"{reviewer}.args").exists())
+            config.unlink()
 
         resumed = self.run_cli(root, ["run", f"--run-id={run_id}"], cwd=work)
 
         self.assertEqual(resumed.returncode, 0, resumed.stdout + resumed.stderr)
+        if enable_reviews:
+            self.assertTrue((wd / "spec/review-validation.md").is_file())
+            review_args = Path(f"{reviewer}.args").read_text().splitlines()
+            self.assertIn("--model=review-model", review_args)
+            self.assertIn("--effort=high", review_args)
         self.assertTrue(pipeline_log.read_bytes().startswith(interrupted_log))
         log_text = pipeline_log.read_text()
         starts = re.findall(r"=== Pipeline invocation ([0-9a-f]{32}): started at", log_text)

--- a/tests/unit/test_pipelinelib.py
+++ b/tests/unit/test_pipelinelib.py
@@ -1729,6 +1729,50 @@ class TestAgentRouting(TmpCwd):
         self.assertEqual(explicit_calls[0][0], "analysis")
         self.assertEqual(self._agent_arg(explicit_calls[0]), "--agent=copilot-cli")
 
+    def test_restored_review_commands_keep_saved_routes_and_tuning(self) -> None:
+        for explicit_review in (False, True):
+            with self.subTest(explicit_review=explicit_review):
+                phases = {"analyze": "codex", "validate": "copilot"}
+                if explicit_review:
+                    phases["review"] = "codex"
+                config = write_agent_config(self.tmp / "agents.json", phases)
+                original = pl.Pipeline()
+                self.assertIsNone(original.parse_args([f"--agent-config={config}", "--enable-reviews", "t"]))
+                original.run_id = f"run-{explicit_review}"
+                original.run_dir = self.tmp / original.run_id
+                original.run_dir.mkdir()
+                original._write_run_meta()
+                saved = json.loads((original.run_dir / "run.json").read_text())["resume_configuration"]
+                config.unlink()
+
+                restored = pl.Pipeline()
+                self.assertIsNone(restored.parse_args([f"--run-id={original.run_id}"]))
+                restored._restore_resume_configuration(saved)
+                restored.wait_for_quota = mock.Mock()  # type: ignore[method-assign]
+                launch = mock.Mock()
+                restored._phase = launch  # type: ignore[method-assign]
+                expected = (
+                    [("codex", "gpt-5.5", "high")] * 3
+                    if explicit_review
+                    else [
+                        ("codex", "gpt-5.5", "high"),
+                        ("claude-code", "claude-sonnet", "max"),
+                        ("copilot-cli", "gpt-5-mini", "low"),
+                    ]
+                )
+                for phase, (agent, model, effort) in zip(("analysis", "specgen", "validation"), expected, strict=True):
+                    with self.subTest(phase=phase):
+                        restored.run_review(phase, ["t"])
+                        args = launch.call_args.args[2]
+                        self.assertEqual(args[0], phase)
+                        self.assertIn(f"--agent={agent}", args)
+                        self.assertIn(f"--model={model}", args)
+                        self.assertIn(f"--effort={effort}", args)
+
+                phase_args = restored._phase_args(["t"], phase="validate")
+                self.assertIn("--agent=copilot-cli", phase_args)
+                self.assertIn("--model=gpt-5-mini", phase_args)
+
     def test_proactive_quota_waits_only_for_claude_routes(self) -> None:
         config = write_agent_config(
             self.tmp / "agents.json",


### PR DESCRIPTION
Resuming a run with phase-specific agent configuration can crash before analysis or validation review with `KeyError: 'review:analyze'` or `KeyError: 'review:validate'`. Resolve restored review selections through the existing canonical route mapping, preserving saved model and effort settings and compatibility with existing run metadata.

Regression tests cover all three review phases with explicit and fallback routing, plus an interrupted validation resumed through the real CLI into review and final reporting using fake adapters. The original configuration file is removed before resume to verify that saved routing is sufficient. The tests reproduce the failure on the unpatched code.

Validation: focused regression tests, Ruff, mypy, invariant-tool tests, trace-debugger basic checks, and shell syntax checks pass. The full Python suite and PR CI are pending.
